### PR TITLE
couchbase: use correct replaces syntax

### DIFF
--- a/certified-operators/couchbase/couchbase-enterprise.package.yaml
+++ b/certified-operators/couchbase/couchbase-enterprise.package.yaml
@@ -2,4 +2,4 @@
 packageName: couchbase-enterprise
 channels:
 - name: preview
-  currentCSV: couchbase-operator.v1.0.0
+  currentCSV: couchbase-operator.v1.1.0

--- a/certified-operators/couchbase/couchbase.1.1.0.clusterserviceversion.yaml
+++ b/certified-operators/couchbase/couchbase.1.1.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     alm-examples: >-
       [{"apiVersion":"couchbase.com/v1","kind":"CouchbaseCluster","metadata":{"name":"cb-example","namespace":"default"},"spec":{"authSecret":"cb-example-auth","baseImage":"registry.connect.redhat.com/couchbase/server","buckets":[{"conflictResolution":"seqno","enableFlush":true,"evictionPolicy":"fullEviction","ioPriority":"high","memoryQuota":128,"name":"default","replicas":1,"type":"couchbase"}],"cluster":{"analyticsServiceMemoryQuota":1024,"autoFailoverMaxCount":3,"autoFailoverOnDataDiskIssues":true,"autoFailoverOnDataDiskIssuesTimePeriod":120,"autoFailoverServerGroup":false,"autoFailoverTimeout":120,"clusterName":"cb-example","dataServiceMemoryQuota":256,"eventingServiceMemoryQuota":256,"indexServiceMemoryQuota":256,"indexStorageSetting":"memory_optimized","searchServiceMemoryQuota":256},"servers":[{"name":"all_services","services":["data","index","query","search","eventing","analytics"],"size":3}],"version":"5.5.1-1"}}]
-  name: couchbase-operator.v1.0.0
+  name: couchbase-operator.v1.1.0
   namespace: placeholder
 spec:
   customresourcedefinitions:
@@ -138,7 +138,8 @@ spec:
   provider:
     name: Couchbase
   maturity: stable
-  version: 1.0.0
+  version: 1.1.0
+  replaces: couchbase-operator.v1.0.0
   icon:
     - base64data: >-
         iVBORw0KGgoAAAANSUhEUgAAAK4AAACvCAYAAABkUOVLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAABLSSURBVHic7d17cFz1dQfw77l39ZZlgbHNpH7IxliPlVaStX7gMEVOmeCQQBoIpjNtKYmhbtJ0KFACbdOZlDZMYSAuk0AYDKVDMgVMgU5CsGlpbFLHD7wrrx4rycaWReIkY2wj62FJ1t77O/1DMjEeW3ufe3dX5zPjGY907+93bH/90+7de88PEEIIIYQQQggROAq6gHywr6ZmjlZQMJtSKCOgEABMhMp1GCMAwMAEF+CMSqUGV/f2ngq22vwgwU1jR2trqOLk0NWsVD2Il4JRxUAVgReD6Aow5gDQbAypQDgF5pMM+oCAfmY6SoSj0M3Ovs6a9zfgVdOvP0++kOCehwGKNzRUs6mtJcJagJrAHAZQnMEyxkGUBDhBjF+wrvZEOzt7Mzh/TpjxwX2vvn6hzqH1SvF6Ir4OoDlB13QRJwl4l5m3GwXYvqaj41jQBQVtRgY3VtPQAF3bAOCLYDQEXY9tTB0g/i8FbF3V3Z4MupwgzJjgxsIti4hTX2HgdoBqg67HQ0kQXlFk/vuqrq5fBV1MpuR1cHe0toYqjg/cBKK7GXwD7L2Jyi0EE8xvg7Utw/Mr31y3c6cRdEl+ysvg7qqunlWsFX0VhPsAWhR0PQH4LYOeLdLNJyOdnQNBF+OHvAru3vr6+SGlfxPAXQAqgq4ncIRBBj9bqOPxxo6OD4Mux0t5Edx9NTVzNK34rwh8H4BZQdeThc4AeN7QzEfWdHUdD7oYL+R0cHcvuKakYNbYfUT8ICSwVgwB/C/Do0Ob1/X3jwddjBs5G9x4OHITg54EY0nQteSgXzHzt6I9HT8kgIMuxomcC248vGIZs/ksgHVB15LrCPyO0nnTys7OvqBrsStngrujtTU06/hHfwmi7wAoC7qevEEYY6bHqET/TjQeTwVdjlU5EdxYQ0MNG/RDIooGXUu+ImC/ofAnq3vbDwVdixVZf0F+f23kDphaTELrLwZW6joSsdrIPUHXYkXWrrgHmpoqzQl+AcAfBl3LTMOM181U8VfWHN43FHQtl5KVwY01NNTApNfz7J6CXPM+M9+ysqejK+hCLibrXirEaxtvh6nFJLSBu5qI9sTqmm4LupCLyargxmoj9zDhPyBXDbJFOcCv7K9r+nbQhVwoK14q7GhtDVV8OPB9BjYFXYu4OAZeoJLQpmy5ZBZ4cGMtLaUYM14HcEPQtYh0+K2JobIvrz22ZyzoSgINbnskUpYy6McAPhNkHcI6Bv3cnCi6KegrDoEFt6Oh4bIJU9sGYHVQNQjH9uqF9LnmROJ0UAUE8uasPRIpmzC1H0NCm6vWmBO8fVd1dWB35GU8uLsXXFOSStGbAK7N9NzCU6uL9eJt7ZFIIFeAMhrcWEtLQWHF6BsgtGZyXuGbT6cMbN3R2hrK9MQZDS6NGd+DXD3IM3TjrBMDz2R61owFNxZu/Ae5TpunGBtj4caHMjllRq4qxGsbb2fCS5maTwSCmfi2lcmO1zIxme9BitU0NEDT9kA+xp0JRhSwJhPddXx9qbCrunoWNG0rJLQzRbkGvB5b2jLb74l8DW6xXvwigBo/5xBZZzmKzef8nsS34MbqGv8CchP4DMVf3l8b2ejnDL68xp16EvcAgHI/xhc54Qyb3LLyYMdBPwb3fMXd0doaUsp4CRLama6MdHpxK27T/Rjc8+DOOjFwvzzYKKasWho+5MvDl56+VNhXHVmi69QJuYogfmcUmhmJdnUd8XJQT1dcXafnIaEVn1QKU3/a60E9C268rnEDpC2SuBjCZ+O1jV/ydkgP7KiqKp5VOrsHQJUX44m81Dc8Ohj2qkukJytueUnl/ZDQiuktnVU227M3aq5X3H01NXN0ragP0gFcpEMYnICxdG0y+ZHboVyvuJpe+CAktMIKxuwi6Pd5MZSrFbdtWfNcVaj6IB82COtGCkJ8lds9KVytuKpQPQgJrbCnPJUi16uu4xV377LVFaGi8V+C4fstbCLvDGE8tCjaFx90OoDjFbeg4OwmCa1wqIJLjK+6GcDRihtraSnAmHEEwEI3k4sZ7YPheZctc7oDpqMVl84aN0FCK9xZXH7ioxudnuwouErhbqcTCnEOKXKcI9svFWLhlkVg4yiyrLfulBEAKYCHATIAFAJYEHBNmWYAOAZAAagAoQyMkoBrujiCaehctaaj45jdUx10IDHuRCZDSxgD4+fE6IZGR5jxITMN6DpOK6QGTMM4rZeVDV2qb2t7JDLPMOl+ZjyA/H48/iyAByaGSp+7sA0oA9TZ0FA5SlRGE1Sq6TSXFOaC+EoCz1dMczXClYp5MRE1AijISMUMvcDAHQAesXuq/RW3LtKdoTb3bQQ8yiWhN6Px+KjbwWLhpi1gvsuLwrIS4aFosv1Rt8PEWlpKeTR1MxHdC2CVB5VNj9AZTbZH7J9mw1SPhA67k9h0hhlfi/a0/8jL7Trb6pujSqn9Xo2XbUIGFjQdav+1V+MxQPG6xk0AngBQ6tW4F0OaXtfS1dZj5xx7P/J1bYOt4+07Tpq5dmVPu+d7zA6ODGTl7jEeGW881P4bLwckgKPd7c+AcAMIjj8osEQZtnNlL7js6+PmZ5VGt7R0dfmyok/dBzrhx9hZ4KRfm0lHk+27oOiP4eNm1QyyfZO55eC+V1+/EEC93QmsIuLHV3Uldvs1/pSc3CncAl//XNGexE8Z2OLjFJG26uZP2TnBcnB1Dq23X49FhEGtQHvct/GFa2aI/wmTVy78QKaubOXLcnCVYt+CS8C2IPcTEOlNXmvl//VrfAK8Dy4DRITfd1aSpQn+27exhZfe9nHs69jGVS5LwW2rX1ED4ArHJaVhKq3Pr7GFh1jztDfCBeYlapuWWT3YUnCVMq9xXk96IR0n/BxfeENpcPXUgoXxP231WEvBJcJa5+Wkpyjl14t+4aEQka9XL1gpyzmz9uaM0ey4GiEsIqImq8emDe7UVkB1rioSwgIm1Fvt7pg2uLNPDC4HUOy6KiHSYZQsrjl0lZVD0wZXMYfdVySENaGQtU9n07/GJbb0P0AIL7DipVaOSxtcYukJJjKHmaqsHJc2uCzN7EQGEfESK8dZuBzGi9wWI4R1tNjKUVau485zWYkQdsy1ctC0wWVAA1GlN/UIYcnlVm62mTa4e8LhSjB82e5HiEsIJZqa0rb2mja4RSi63Lt6hLDGMM20uZu2r4LJZlE2dv1wikA/A1RmegZkELOWV3fX6SqU9pPaaYOrMReB8qeHRkt3wnGvKpE5Brgw3THTLqg02cJIiIzSWBWlPWa6b7JGDlo0CeESUdqXc9OvuIod9S4Vwg220P8i3XXcfG2gIbIYgyS4IvfopKV9lGva4GpayJPtK4Www8oziNMG9yzOut4BUAi76EzhqXTHTBvca5LJ0yCY3pUkRFqplr74ULqD0l3HVWAMeFeTEGl9ZKXzpJX7cfPq40SR9U5aOchCcOmXbisRwjr+wMpRVu6hOeqyEiEsYyZLebPwlC/63RYjhFVE1hZKCw9Lsp8d+oT4BGJY6tyZ/vF0jfN50w+RbTS909Jh6Q7o66x5H4SxdMe5oZuhfLpfXTg3uiLZ5s2KuwGvmgB1u6/p0kyoWX6OL7xhgst9nqKLJrdyTcvqSnfARTFpkUaWHkkWwdIU+9qqgIGE5VosDci8x3k5FsYHLPdFFcFRxL52pgfzL6weam3FNa0P6IjCZ3wdX7jGgEZMX/BzjhA0ywukpeBGD3YcgsWP4hwhXL+vOmKpZ5QIRiwcuR2A5c1FHDje3JN43+rB1vaAAJiAd53XlL4OXcf3fRxfuBBb3nIFMbnemT0NW/myfBmKmbfbr8UOunF/OPKYnb2uhP9iLS2lHDJeBrDQz3kIsJUvy8E1CrAdPu8ZS0wPxMONr03tGywCFgu3LOLx1DsE/IHPUzFzyFZwba1usXBjBxgN9mpyZBSElxj0QjSZ2GP12p7wRmJ54+8ZBdgIxjcBlGViymh3u62dnez1TWC8AWQkuKVgbCTwxnhd4+kYYxcIbcx8hDTq0wytb8XBA7/JQB15a0dVVXFlSeVCU+MFrHghaVQFxhIQNRjgpow2OyS8Yf8UG96rawxrQLbcuzAOoA+Eo1B8EkQnQTjBjBMgPsmknaSUOqVo4uSq3t6BmbJqb8VtelW4e65manM1jeYp0uYDfCUYiwEsYuYFRLQQwPyga/2YrmqjnZ29dk6x/UYoVtfYBSAXd+IZBTAC0DAIp6F4GMAIaRhRjCEQj5Kis9BwBsAEgUYApBTUMLFmMOMMLnjen3Ue1Q3T1q6YrGsVrDQdAIj4MmCq1RVN/kjmyY9VCwAQFCrPfV9NfZ/A5QAVMEPXiCsYVIHJH+flACoAVCKX3uAydUR7Eo12T7PfYonwChgP2z4veKWTv3geGB//0/K5yxhMk7+ZevvJU7+hqS9O9v775HtTUgBrNu8PYoBIXfili7/tpd99ny74IhHAOZTPSyL1spPTbN+VZej8gjz5KzxihAx60cmJtoO7pqPjGJjfdjKZEOcj0FtNh9p/7eRcZ/fBsrbF0XlCnI/Uc05PdRTc4fmVbwIsT/8KN/qH5l6+zenJjoK7budOA0RPOp1UCIA3r9u503EbW8ePzIwb41tAGHR6vpjRBkrI/Dc3AzgO7rUHDw4z+Fk3k4uZiUE/CCeTI27GcPWQIqUKHgMw7GYMMeOM6BP0r24HcRXc6KH4SQBPuS1CzCCMzSsOH3Ddj871Y+F6IT0K4LTbccQMQBgsDKnNXgzlOrjNicRpgB/zohiR55j/OdLZ6UnbWk8acZSQ+QQAy88LiZmIjsyeGP2eV6N5EtxwMjlBGh7yYiyRn4jUvVcfPmzrTrppx/NqIACI10X+h0HXezmmyH0E2ub1drSe9uzSlHY3gDNejily3qjSzW94PainwW3uTfQT0z96OabIbcT09ys7Oy01srPD8y6JQ/MrNxOw3+txRU7ae6Tnas/ekJ3Pl1voY/X1V0HpBwBIF8aZ64ypsGJ1b/shPwb3pS9ttKvrCBHd78fYIjcQ0Tf8Ci3g80N1+2sbXyPCLX7OIbIPE15ZmWz/Iz/n8LUT+Fk1ficAX5tCiyxDOGieLf5z/6fx2f7qSDXp9B4mH50W+W1EI231iuQB3xcr3/deWHmw4yBAd8HnvmMicIoYd2QitEAGggsA0e7EqwT+VibmEsEgpodaetptt1JyPF+mJgKAWLjpaTB/LZNzigwgei6aTNydySkzu01TsX4PwG9ldE7hKwZ+Mjy3MuOLUcZ7+OxecE1JYcXoTwGsy/TcwnM/Gx4d/Py6/v7xTE+c8Y3x1h7bM4aS0BcA/F+m5xae2ltCxheDCC0QQHABIBqPj+qFdDOAvUHML9whxm6Mh9a7fVLXjcC2Im1OJE4XhPh6Ar8TVA3CPiJ+d0yNr4/2xQPtqRHoHrqNHR1nzg6V3Sxv2HIDAz8ZOjO0/tqDBwNvSRD45s9rj+0Z6+uuvhnETwddi5gG4XkqCd0a1GvaC2VVZ+BYbeQeEH0XWfAfSnyMGfTwyu7Et4Mu5HxZFVwA2B+O3EpML0Du5c0GQ8S4M5OfiFmVdcEFgH01jct1Da8jN/eayA+Eg4px66ru9mTQpVxMVv5IXt3bfsiYKF4L0H8GXctMxIRXxo3xldkaWiBLV9zz7a+N3EFET2FyVxnhr2Ei+puWZCLru3BmfXAB4EBt09Um8Y8ArAq6ljy2l0j/05Zk2+GgC7EiJ4ILAAxobeGmu5j5Ccjq66VREB7uSy5/fANezZndlHImuOfsq44s0TV6BoTPBl1LriPQNk3h6829if6ga7Er54J7TjwcuYlZ2wzwVUHXkoMOA/R30e7Eq0EX4lTOBhcA3l+2rGiwqOyvAfwtGLODricHnCamR4q11JPhZHIi/eHZK6eDe86u6upZxaHir0MCfCkjYDxVGFKPetWfNmh5Edxz2pY1z1UF6n4QNmFyM+aZboBBP1Bq/Lure3tPBV2Ml/IquOckw+HyMaVvBNG9ABYHXU8A+kF4BmOhZ4K+/dAveRncc3a0tobKPzz9eWK+Cxo+B4YedE2+IZjMeEsj3nIkWf1WLl3aciKvg3u+vZHIAj2l/RlpfDsYDUHX4xmmDpB6OWTQi043dM5FMya454vXr6iFMjYw6EsAIsitvwcG0A7CG9DU1mhnZ2/QBQUhl/7BfNFW3fwpU1frCVgP4DoA84Ku6SKOA3iXgO3Moe3Rnvhvgy4oaDM+uBfaV9O4PKTTWlZqLQPNRFQHoDSDJYwSkFTAASLarSvsbu5JyI5GF5DgprEVt+mLaw5dpencQIwlICwBowqgKgBzpn6FbAxpADg1+Yv7mekoEfeTRn2aSZ1NPYkjBCiv/xz5RoLrgQNNTZWGaV6ucUERjFQpAJgIleswJh/fDhWMKkqdDen6R5MbGgohhBBCCCGEEEIIIYQQQgghhBAz1v8D+o/bXqYjxQQAAAAASUVORK5CYII=
@@ -147,7 +148,7 @@ spec:
     - name: Couchbase
       url: 'https://www.couchbase.com'
     - name: Documentation
-      url: 'https://docs.couchbase.com/operator/1.0/overview.html'
+      url: 'https://docs.couchbase.com/operator/1.1/overview.html'
     - name: Downloads
       url: 'https://www.couchbase.com/downloads'
   installModes:
@@ -185,7 +186,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.name
-                    image: 'registry.connect.redhat.com/couchbase/operator:1.0.0-1'
+                    image: 'registry.connect.redhat.com/couchbase/operator:1.1.0-1'
                     name: couchbase-operator
                     ports:
                       - containerPort: 8080
@@ -308,7 +309,7 @@ spec:
 
     * `authSecret` - provide the name of a secret that contains two keys for the
     `username` and `password` of the super user
-    ([documentation](https://docs.couchbase.com/operator/1.0/couchbase-cluster-config.html))
+    ([documentation](https://docs.couchbase.com/operator/1.1/couchbase-cluster-config.html))
 
 
     ## About Couchbase Server


### PR DESCRIPTION
Uses the correct replaces syntax for the new CSV, and reverts the 1.0.0 CSV from the changes made in  #12 