### PR TITLE
[community] Clean up templateservicebroker csv

### DIFF
--- a/community-operators/template-service-broker/templateservicebrokeroperator.v0.1.0.clusterserviceversion.yaml
+++ b/community-operators/template-service-broker/templateservicebrokeroperator.v0.1.0.clusterserviceversion.yaml
@@ -1,5 +1,3 @@
----
-
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:


### PR DESCRIPTION
- Remove leading dashes from beginning of templateservicebroker csv

There was an issue where the operator bundle would fail parsing due to extra dashes at the start of the CSV. I've removed these leading dashes to avoid problems with creating bundles in the future.