### PR TITLE
[community] Add Jaeger bundle file and directories

### DIFF
--- a/community-operators/bundles/jaeger/bundle.0.0.1.yaml
+++ b/community-operators/bundles/jaeger/bundle.0.0.1.yaml
@@ -1,0 +1,162 @@
+---
+# Source: operator-artifacts/templates/jaeger.yaml
+
+
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: jaegers.io.jaegertracing
+      spec:
+        group: io.jaegertracing
+        names:
+          kind: Jaeger
+          listKind: JaegerList
+          plural: jaegers
+          singular: jaeger
+        scope: Namespaced
+        version: v1alpha1
+      
+  clusterServiceVersions: |-
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: jaeger-operator.v1.8.2
+        namespace: placeholder
+        annotations:
+          categories: "tracing, monitoring, troubleshooting, distributed"
+          certified: "false"
+          containerImage: docker.io/jaegertracing/jaeger-operator:1.8.2
+          createdAt:  2019-01-09T12:00:00Z
+          support: Jaeger
+      spec:
+        displayName: jaeger-operator
+        description: |-
+          Provides monitoring and troubleshooting microservices-based distributed systems
+        keywords: ['tracing', 'monitoring', 'troubleshooting', 'distributed']
+        version: 1.8.2
+        maintainers:
+        - name: Jaeger Google Group
+          email: jaeger-tracing@googlegroups.com
+        provider:
+          name: Jaeger
+        labels:
+          name: jaeger-operator
+        selector:
+          matchLabels:
+            name: jaeger-operator
+        links:
+        - name: Jaeger Operator Source Code
+          url: https://github.com/jaegertracing/jaeger-operator
+        installModes:
+        - type: OwnNamespace
+          supported: true
+        - type: SingleNamespace
+          supported: true
+        - type: MultiNamespace
+          supported: false
+        - type: AllNamespaces
+          supported: true
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: jaeger-operator
+              rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                - serviceaccounts
+                verbs:
+                - '*'
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - io.jaegertracing
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              - apiGroups:
+                - extensions
+                resources:
+                - ingresses
+                verbs:
+                - "*"
+              - apiGroups:
+                - batch
+                resources:
+                - jobs
+                - cronjobs
+                verbs:
+                - "*"
+            deployments:
+            - name: jaeger-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: jaeger-operator
+                template:
+                  metadata:
+                    labels:
+                      name: jaeger-operator
+                  spec:
+                    serviceAccountName: jaeger-operator
+                    containers:
+                      - name: jaeger-operator
+                        image: jaegertracing/jaeger-operator:1.8.2
+                        ports:
+                        - containerPort: 60000
+                          name: metrics
+                        args: ["start"]
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.annotations['olm.targetNamespaces']
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "jaeger-operator"
+        customresourcedefinitions:
+          owned:
+          - name: jaegers.io.jaegertracing
+            version: v1alpha1
+            kind: Jaeger
+            displayName: Jaeger
+            description: A configuration file for a Jaeger custom resource.
+      
+  packages: |-
+    - packageName: jaeger
+      channels:
+      - name: alpha
+        currentCSV: jaeger-operator.v1.8.2
+      
+


### PR DESCRIPTION
- Create a bundles directory within the community-operators directory.
  The bundles directories hold the blobs pushed to quay.
- Create Jaeger bundle