### PR TITLE
Cluster Wide Mode for etcd Operator 

### DIFF
--- a/community-operators/etcd/etcdoperator.v0.9.2.clusterserviceversion.yaml
+++ b/community-operators/etcd/etcdoperator.v0.9.2.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: placeholder
   annotations:
     tectonic-visibility: ocs
-    alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+    alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example", "annotations": [{"etcd.database.coreos.com/scope": "clusterwide"}]},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster-restore","annotations": [{"etcd.database.coreos.com/scope": "clusterwide"}]}},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup","annotations": [{"etcd.database.coreos.com/scope": "clusterwide"}]}},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
 spec:
   displayName: etcd
   description: |
@@ -73,7 +73,7 @@ spec:
   - type: OwnNamespace
     supported: true
   - type: SingleNamespace
-    supported: true
+    supported: false
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
@@ -133,6 +133,7 @@ spec:
                 command:
                 - etcd-operator
                 - --create-crd=false
+                - --cluster-wide
                 image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
                 env:
                 - name: MY_POD_NAMESPACE

--- a/community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -70,9 +70,9 @@ spec:
   - type: SingleNamespace
     supported: true
   - type: MultiNamespace
-    supported: false
-  - type: AllNamespaces
     supported: true
+  - type: AllNamespaces
+    supported: false
     
   install:
     strategy: deployment


### PR DESCRIPTION
### Description

Updates the etcd Operator to run using the `--cluster-wide` flag, which configures it to watch for `EtcdCluster` objects [with the correct annotation](https://github.com/coreos/etcd-operator/blob/c8f63d508266990a4d20718d94363c30e75e6282/example/example-etcd-cluster.yaml#L8) in all namespaces. This allows it to be correctly installed using the ["global" `OperatorGroup` provided by the Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/deploy/chart/templates/0000_50_16-operatorgroup-default.yaml#L1).