### PR TITLE
Add short descriptions and maturity levels

### DIFF
--- a/certified-operators/couchbase-enterprise/couchbase.1.0.0.clusterserviceversion.yaml
+++ b/certified-operators/couchbase-enterprise/couchbase.1.0.0.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    description: The Couchbase Autonomous Operator allows users to easily deploy, manage, and maintain Couchbase deployments on OpenShift.
     alm-examples: >-
       [{"apiVersion":"couchbase.com/v1","kind":"CouchbaseCluster","metadata":{"name":"cb-example","namespace":"default"},"spec":{"authSecret":"cb-example-auth","baseImage":"registry.connect.redhat.com/couchbase/server","buckets":[{"conflictResolution":"seqno","enableFlush":true,"evictionPolicy":"fullEviction","ioPriority":"high","memoryQuota":128,"name":"default","replicas":1,"type":"couchbase"}],"cluster":{"analyticsServiceMemoryQuota":1024,"autoFailoverMaxCount":3,"autoFailoverOnDataDiskIssues":true,"autoFailoverOnDataDiskIssuesTimePeriod":120,"autoFailoverServerGroup":false,"autoFailoverTimeout":120,"clusterName":"cb-example","dataServiceMemoryQuota":256,"eventingServiceMemoryQuota":256,"indexServiceMemoryQuota":256,"indexStorageSetting":"memory_optimized","searchServiceMemoryQuota":256},"servers":[{"name":"all_services","services":["data","index","query","search","eventing","analytics"],"size":3}],"version":"5.5.1-1"}}]
   name: couchbase-operator.v1.0.0
@@ -137,7 +138,7 @@ spec:
   displayName: Couchbase Operator
   provider:
     name: Couchbase
-  maturity: stable
+  maturity: Seamless Upgrades
   version: 1.0.0
   icon:
     - base64data: >-

--- a/certified-operators/couchbase-enterprise/couchbase.1.1.0.clusterserviceversion.yaml
+++ b/certified-operators/couchbase-enterprise/couchbase.1.1.0.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     categories: "Database"
+    description: The Couchbase Autonomous Operator allows users to easily deploy, manage, and maintain Couchbase deployments on OpenShift.
     alm-examples: >-
       [{"apiVersion":"couchbase.com/v1","kind":"CouchbaseCluster","metadata":{"name":"cb-example","namespace":"default"},"spec":{"authSecret":"cb-example-auth","baseImage":"registry.connect.redhat.com/couchbase/server","buckets":[{"conflictResolution":"seqno","enableFlush":true,"evictionPolicy":"fullEviction","ioPriority":"high","memoryQuota":128,"name":"default","replicas":1,"type":"couchbase"}],"cluster":{"analyticsServiceMemoryQuota":1024,"autoFailoverMaxCount":3,"autoFailoverOnDataDiskIssues":true,"autoFailoverOnDataDiskIssuesTimePeriod":120,"autoFailoverServerGroup":false,"autoFailoverTimeout":120,"clusterName":"cb-example","dataServiceMemoryQuota":256,"eventingServiceMemoryQuota":256,"indexServiceMemoryQuota":256,"indexStorageSetting":"memory_optimized","searchServiceMemoryQuota":256},"servers":[{"name":"all_services","services":["data","index","query","search","eventing","analytics"],"size":3}],"version":"5.5.1-1"}}]
   name: couchbase-operator.v1.1.0
@@ -138,7 +139,7 @@ spec:
   displayName: Couchbase Operator
   provider:
     name: Couchbase
-  maturity: stable
+  maturity: Seamless Upgrades
   version: 1.1.0
   replaces: couchbase-operator.v1.0.0
   icon:

--- a/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.3.2.clusterserviceversion.yaml
+++ b/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.3.2.clusterserviceversion.yaml
@@ -7,13 +7,14 @@ metadata:
   namespace: placeholder
   annotations:
     categories: "Database"
+    description: The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB into Kubernetes clusters, using our management, monitoring and backup platforms, Ops Manager and Cloud Manager.
     alm-examples: >-
       [{"apiVersion":"mongodb.com/v1","kind":"MongoDbStandalone","metadata":{"name":"my-standalone","namespace":"mongodb"},"spec":{"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}},{"apiVersion":"mongodb.com/v1","kind":"MongoDbReplicaSet","metadata":{"name":"my-replica-set","namespace":"mongodb"},"spec":{"members":3,"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}},{"apiVersion":"mongodb.com/v1","kind":"MongoDbShardedCluster","metadata":{"name":"my-sharded-cluster","namespace":"mongodb"},"spec":{"shardCount": 2, "mongodsPerShardCount": 3, "mongosCount": 2, "configServerCount": 3,"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}}]
 spec:
   displayName: MongoDB
   provider:
     name: 'MongoDB, Inc'
-  maturity: stable
+  maturity: Full Lifecycle
   version: 0.3.2
   keywords: ["mongodb", "database", "nosql"]
   maintainers:

--- a/community-operators/automationbroker/automationbrokeroperator.v0.2.0.clusterserviceversion.yaml
+++ b/community-operators/automationbroker/automationbrokeroperator.v0.2.0.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     alm-examples: '[{"apiVersion":"osb.openshift.io/v1alpha1","kind":"AutomationBroker","metadata":{"name":"ansible-service-broker","namespace":"openshift-ansible-service-broker"},"spec":{"createBrokerNamespace":"false","waitForBroker":"false"}}]'
     categories: 'OpenShift Optional, Integration & Delivery'
+    description: Automation Broker is an implementation of the Open Service Broker API managing applications defined in Ansible Playbook Bundles
 spec:
   displayName: Automation Broker Operator
   description: |
@@ -19,7 +20,7 @@ spec:
     Check out the [Keynote Demo from Red Hat Summit 2017](https://youtu.be/8MCbJmZQM9c?list=PLEGSLwUsxfEh4TE2GDU4oygCB-tmShkSn&t=4732)
   keywords: ['ansible', 'automation', 'broker', 'open service broker']
   version: 0.2.0
-  maturity: alpha
+  maturity: Seamless Upgrades
   maintainers:
   - name: Red Hat, Inc.
     email: ansible-service-broker@redhat.com

--- a/community-operators/cluster-logging/clusterlogging.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/cluster-logging/clusterlogging.v0.0.1.clusterserviceversion.yaml
@@ -67,6 +67,8 @@ spec:
 
   keywords: ['elasticsearch', 'kibana', 'fluentd', 'logging', 'aggregated', 'efk']
 
+  maturity: Seamless Upgrades
+
   maintainers:
   - name: Red Hat
     email: aos-logging@redhat.com

--- a/community-operators/descheduler/descheduler.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/descheduler/descheduler.v0.0.1.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certifiedLevel: Primed
     containerImage: registry.svc.ci.openshift.org/openshift/origin-v4.0:descheduler-operator
     createdAt: 2019/11/15
-    description: An operator to run the OpenShift descheduler
+    description: An operator to run the OpenShift descheduler, a scheduler to move running Pods according to policies
     healthIndex: B
     repository: https://github.com/openshift/descheduler-operator
     support: Red Hat
@@ -45,6 +45,7 @@ spec:
       Any api could be changed any time with out any notice. That said, your feedback is
       very important and appreciated to make this project more stable and useful.
    
+  maturity: Seamless Upgrades
   customresourcedefinitions:
     owned:
     - description: Represents an instance of a Descheduler application

--- a/community-operators/etcd/etcdoperator.clusterserviceversion.yaml
+++ b/community-operators/etcd/etcdoperator.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: placeholder
   annotations:
     tectonic-visibility: ocs
+    description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
   displayName: etcd
   description: |
@@ -30,7 +31,7 @@ spec:
     Coming soon, the ability to schedule backups to happen on or off cluster.
   keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
   version: 0.6.1
-  maturity: alpha
+  maturity: Full Lifecycle
   maintainers:
   - name: CoreOS, Inc
     email: support@coreos.com

--- a/community-operators/etcd/etcdoperator.v0.9.0.clusterserviceversion.yaml
+++ b/community-operators/etcd/etcdoperator.v0.9.0.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     tectonic-visibility: ocs
     alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+    description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
   displayName: etcd
   description: |
@@ -43,7 +44,7 @@ spec:
     Coming soon, the ability to schedule backups to happen on or off cluster.
   keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
   version: 0.9.0
-  maturity: alpha
+  maturity: Full Lifecycle
   replaces: etcdoperator.v0.6.1
   maintainers:
   - name: CoreOS, Inc

--- a/community-operators/etcd/etcdoperator.v0.9.2.clusterserviceversion.yaml
+++ b/community-operators/etcd/etcdoperator.v0.9.2.clusterserviceversion.yaml
@@ -69,6 +69,7 @@ metadata:
           }
         }
       ]
+    description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
   displayName: etcd
   description: |
@@ -104,7 +105,7 @@ spec:
     Coming soon, the ability to schedule backups to happen on or off cluster.
   keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
   version: 0.9.2
-  maturity: alpha
+  maturity: Full Lifecycle
   replaces: etcdoperator.v0.9.0
   maintainers:
   - name: CoreOS, Inc

--- a/community-operators/federationv2/federationv2.v0.0.2.clusterserviceversion.yaml
+++ b/community-operators/federationv2/federationv2.v0.0.2.clusterserviceversion.yaml
@@ -7,13 +7,14 @@ metadata:
   namespace: placeholder
   annotations:
     categories: "OpenShift Optional, Integration & Delivery"
+    description: Kubernetes Federation V2 namespace-scoped installation
 spec:
   displayName: FederationV2
   description: |
     Kubernetes Federation V2 namespace-scoped installation
   keywords: ['kubernetes', 'federation', 'hybrid', 'hybrid cloud', 'multi-cluster', 'cluster']
   version: 0.0.2
-  maturity: alpha
+  maturity: Basic Install
   provider:
     name: Red Hat, Inc
   labels:

--- a/community-operators/jaeger/jaeger.v1.8.2.clusterserviceversion.yaml
+++ b/community-operators/jaeger/jaeger.v1.8.2.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: placeholder
   annotations:
     categories: "Logging & Tracing"
+    description: Provides monitoring and troubleshooting microservices-based distributed systems
     certified: "false"
     containerImage: docker.io/jaegertracing/jaeger-operator:1.8.2
     createdAt:  2019-01-09T12:00:00Z
@@ -65,6 +66,7 @@ spec:
     Provides monitoring and troubleshooting microservices-based distributed systems
   keywords: ['tracing', 'monitoring', 'troubleshooting']
   version: 1.8.2
+  maturity: Seamless Upgrades
   maintainers:
   - name: Jaeger Google Group
     email: jaeger-tracing@googlegroups.com

--- a/community-operators/kiecloud-operator/kiecloud-operator.v0.1.0.clusterserviceversion.yaml
+++ b/community-operators/kiecloud-operator/kiecloud-operator.v0.1.0.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ spec:
   description: KieCloud can deploy RHPAM environments in the form of KieApp objects.
   keywords: ['kieapp', 'rhpam', 'kie', 'cloud', 'pam', 'kiecloud']
   version: 0.1.0
-  maturity: beta
+  maturity: Basic Install
   maintainers:
     - name: Red Hat, Inc.
       email: bsig-cloud@redhat.com

--- a/community-operators/metering/metering-operator.v0.13.0.clusterserviceversion.yaml
+++ b/community-operators/metering/metering-operator.v0.13.0.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     tectonic-visibility: openshift-feature
     categories: "OpenShift Optional, Monitoring"
+    description: Metering can generate reports based on historical usage data from a cluster, providing accountability for how resources have been used.
   namespace: placeholder
   labels:
     alm-catalog: openshift-feature
@@ -16,7 +17,7 @@ spec:
   description: Metering can generate reports based on historical usage data from a cluster, providing accountability for how resources have been used.
   keywords: ['metering', 'metrics', 'reporting', 'prometheus', 'chargeback']
   version: 0.13.0
-  maturity: alpha
+  maturity: Seamless Upgrades
   maintainers:
     - email: sd-operator-metering@redhat.com
       name: Red Hat

--- a/community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
@@ -164,7 +164,7 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 50Mi
-  maturity: alpha
+  maturity: Full Lifecycle
   version: 0.14.0
   customresourcedefinitions:
     owned:

--- a/community-operators/prometheus/prometheusoperator.0.15.0.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.15.0.clusterserviceversion.yaml
@@ -179,7 +179,7 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 50Mi
-  maturity: alpha
+  maturity: Full Lifecycle
   version: 0.15.0
   customresourcedefinitions:
     owned:

--- a/community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     categories: "OpenShift Optional, Monitoring"
     alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.3.2","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
+    description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 spec:
   replaces: prometheusoperator.0.15.0
   displayName: Prometheus Operator
@@ -196,7 +197,7 @@ spec:
                   readOnlyRootFilesystem: true
               nodeSelector:
                 beta.kubernetes.io/os: linux
-  maturity: beta
+  maturity: Full Lifecycle
   version: 0.22.2
   customresourcedefinitions:
     owned:

--- a/community-operators/templateservicebroker/templateservicebrokeroperator.v0.2.0.clusterserviceversion.yaml
+++ b/community-operators/templateservicebroker/templateservicebrokeroperator.v0.2.0.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     categories: "OpenShift Optional, Integration & Delivery"
     alm-examples: '[{"apiVersion":"osb.openshift.io/v1alpha1","kind":"TemplateServiceBroker","metadata":{"name":"template-service-broker","namespace":"openshift-template-service-broker"},"spec":{"size":3,"version":"3.2.13"}}]'
+    description: The Template Service Broker implements the Open Service Broker API.
 spec:
   displayName: Template Service Broker Operator
   description: |
@@ -42,7 +43,7 @@ spec:
       is the only asynchronous operation.
   keywords: ['template', 'broker', 'open service broker']
   version: 0.2.0
-  maturity: alpha
+  maturity: Basic Install
   maintainers:
   - name: Red Hat, Inc.
     email: ansible-service-broker@redhat.com

--- a/redhat-operators/amq-streams/amq-streams.v1.0.0.clusterserviceversion.yaml
+++ b/redhat-operators/amq-streams/amq-streams.v1.0.0.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ spec:
 
   keywords: ['amq', 'streams', 'messaging', 'kafka', 'streaming']
   version: 1.0.0
-  maturity: stable
+  maturity: Full Lifecycle
   maintainers:
   - name: Red Hat, Inc.
     email: customerservice@redhat.com


### PR DESCRIPTION
- add short descriptions in `metadata.annotations.descriptions`
- add maturity levels from a list of [Basic Install < Seamless Upgrades < Full Lifecycle < Deep Insight < Auto-Pilot] according to https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-maturity-model.png in `spec.maturity`