### PR TITLE
prometheus: Add v0.27.0 ClusterServiceVersion

### DIFF
--- a/community-operators/prometheus/alertmanager.crd.yaml
+++ b/community-operators/prometheus/alertmanager.crd.yaml
@@ -1,6 +1,8 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -11,10 +13,26 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
         spec:
-          description: 'Specification of the desired behavior of the Alertmanager
-            cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'AlertmanagerSpec is a specification of the desired behavior
+            of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
+            additionalPeers:
+              description: AdditionalPeers allows injecting a set of additional Alertmanagers
+                to peer with to form a highly available cluster.
+              items:
+                type: string
+              type: array
             affinity:
               description: Affinity is a group of affinity scheduling rules.
               properties:
@@ -576,6 +594,13 @@ spec:
             baseImage:
               description: Base image that is used to deploy pods, without tag.
               type: string
+            configMaps:
+              description: ConfigMaps is a list of ConfigMaps in the same namespace
+                as the Alertmanager object, which shall be mounted into the Alertmanager
+                Pods. The ConfigMaps are mounted into /etc/alertmanager/configmaps/<configmap-name>.
+              items:
+                type: string
+              type: array
             containers:
               description: Containers allows injecting additional containers. This
                 is meant to allow adding an authentication proxy to an Alertmanager
@@ -1040,8 +1065,8 @@ spec:
                             to by services.
                           type: string
                         protocol:
-                          description: Protocol for port. Must be UDP or TCP. Defaults
-                            to "TCP".
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
@@ -1194,6 +1219,13 @@ spec:
                           privileged containers are essentially equivalent to root
                           on the host. Defaults to false.
                         type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
                       readOnlyRootFilesystem:
                         description: Whether this container has a read-only root filesystem.
                           Default is false.
@@ -1284,8 +1316,7 @@ spec:
                     type: boolean
                   volumeDevices:
                     description: volumeDevices is the list of block devices to be
-                      used by the container. This is an alpha feature and may change
-                      in the future.
+                      used by the container. This is a beta feature.
                     items:
                       description: volumeDevice describes a mapping of a raw block
                         device within a container.
@@ -1316,8 +1347,8 @@ spec:
                         mountPropagation:
                           description: mountPropagation determines how mounts are
                             propagated from the host to container and the other way
-                            around. When not set, MountPropagationHostToContainer
-                            is used. This field is beta in 1.10.
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
                           type: string
                         name:
                           description: This must match the Name of a Volume.
@@ -1346,6 +1377,12 @@ spec:
               description: The external URL the Alertmanager instances will be available
                 under. This is necessary to generate correct URLs. This is necessary
                 if Alertmanager is not served from root of a DNS name.
+              type: string
+            image:
+              description: Image if specified has precedence over baseImage, tag and
+                sha combinations. Specifying the version is still necessary to ensure
+                the Prometheus Operator knows what version of Alertmanager is being
+                configured.
               type: string
             imagePullSecrets:
               description: An optional list of references to secrets in the same namespace
@@ -1552,11 +1589,12 @@ spec:
                                 the server has more data available. The value is opaque
                                 and may be used to issue another request to the endpoint
                                 that served this list to retrieve the next set of
-                                available objects. Continuing a list may not be possible
-                                if the server configuration has changed or more than
-                                a few minutes have passed. The resourceVersion field
-                                returned when using this continue value will be identical
-                                to the value in the first response.
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
                               type: string
                             resourceVersion:
                               description: 'String that identifies the server''s internal
@@ -1609,8 +1647,9 @@ spec:
                     set to true. There cannot be more than one managing controller.
                   items:
                     description: OwnerReference contains enough information to let
-                      you identify an owning object. Currently, an owning object must
-                      be in the same namespace, so there is no namespace field.
+                      you identify an owning object. An owning object must be in the
+                      same namespace as the dependent, or be cluster-scoped, so there
+                      is no namespace field.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -1657,6 +1696,9 @@ spec:
 
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                   type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
             replicas:
               description: Size is the expected size of the alertmanager cluster.
                 The controller will eventually make the size of the running cluster
@@ -1676,6 +1718,11 @@ spec:
                     to Limits if that is explicitly specified, otherwise to an implementation-defined
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
+            retention:
+              description: Time duration Alertmanager shall retain data for. Default
+                is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)`
+                (milliseconds seconds minutes hours).
+              type: string
             routePrefix:
               description: The route prefix Alertmanager registers HTTP handlers for.
                 This is useful, if using ExternalURL and a proxy is rewriting HTTP
@@ -1778,15 +1825,18 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the Prometheus Pods.
               type: string
+            sha:
+              description: SHA of Alertmanager container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
             storage:
               description: StorageSpec defines the configured storage for a group
-                Prometheus servers.
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
               properties:
-                class:
-                  description: 'Name of the StorageClass to use when requesting storage
-                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
-                    DEPRECATED'
-                  type: string
                 emptyDir:
                   description: Represents an empty directory for a pod. Empty directory
                     volumes support ownership management and SELinux relabeling.
@@ -1797,63 +1847,6 @@ spec:
                         Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       type: string
                     sizeLimit: {}
-                resources:
-                  description: ResourceRequirements describes the compute resource
-                    requirements.
-                  properties:
-                    limits:
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                selector:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                      type: array
-                    matchLabels:
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                                     of matchExpressions, whose key field is "key", the operator
-                                     is "In", and the values array contains only "value". The requirements
-                                     are ANDed.
-                      type: object
                 volumeClaimTemplate:
                   description: PersistentVolumeClaim is a user's request for and claim
                     to a persistent volume
@@ -2049,8 +2042,8 @@ spec:
                                   type: string
                                 metadata:
                                   description: ListMeta describes metadata that synthetic
-                                                 resources must have, including lists and various
-                                                 status objects. A resource may have only one of
+                                    resources must have, including lists and various
+                                    status objects. A resource may have only one of
                                     {ObjectMeta, ListMeta}.
                                   properties:
                                     continue:
@@ -2060,12 +2053,14 @@ spec:
                                         available. The value is opaque and may be
                                         used to issue another request to the endpoint
                                         that served this list to retrieve the next
-                                        set of available objects. Continuing a list
-                                        may not be possible if the server configuration
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
                                         has changed or more than a few minutes have
                                         passed. The resourceVersion field returned
                                         when using this continue value will be identical
-                                        to the value in the first response.
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
                                       type: string
                                     resourceVersion:
                                       description: 'String that identifies the server''s
@@ -2122,20 +2117,20 @@ spec:
                             There cannot be more than one managing controller.
                           items:
                             description: OwnerReference contains enough information
-                              to let you identify an owning object. Currently, an
-                              owning object must be in the same namespace, so there
-                              is no namespace field.
+                              to let you identify an owning object. An owning object
+                              must be in the same namespace as the dependent, or be
+                              cluster-scoped, so there is no namespace field.
                             properties:
                               apiVersion:
                                 description: API version of the referent.
                                 type: string
                               blockOwnerDeletion:
                                 description: If true, AND if the owner has the "foregroundDeletion"
-                                               finalizer, then the owner cannot be deleted from
-                                               the key-value store until this reference is removed.
-                                               Defaults to false. To set this field, a user needs
-                                               "delete" permission of the owner, otherwise 422
-                                               (Unprocessable Entity) will be returned.
+                                  finalizer, then the owner cannot be deleted from
+                                  the key-value store until this reference is removed.
+                                  Defaults to false. To set this field, a user needs
+                                  "delete" permission of the owner, otherwise 422
+                                  (Unprocessable Entity) will be returned.
                                 type: boolean
                               controller:
                                 description: If true, this reference points to the
@@ -2183,6 +2178,26 @@ spec:
                           items:
                             type: string
                           type: array
+                        dataSource:
+                          description: TypedLocalObjectReference contains enough information
+                            to let you locate the typed referenced object inside the
+                            same namespace.
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
                         resources:
                           description: ResourceRequirements describes the compute
                             resource requirements.
@@ -2249,8 +2264,7 @@ spec:
                         volumeMode:
                           description: volumeMode defines what type of volume is required
                             by the claim. Value of Filesystem is implied when not
-                            included in claim spec. This is an alpha feature and may
-                            change in the future.
+                            included in claim spec. This is a beta feature.
                           type: string
                         volumeName:
                           description: VolumeName is the binding reference to the
@@ -2316,7 +2330,7 @@ spec:
                           type: string
             tag:
               description: Tag of Alertmanager container image to be deployed. Defaults
-                to the value of `version`.
+                to the value of `version`. Version is ignored if Tag is set.
               type: string
             tolerations:
               description: If specified, the pod's tolerations.
@@ -2361,9 +2375,9 @@ spec:
               description: Version the cluster should be on.
               type: string
         status:
-          description: 'Most recent observed status of the Alertmanager cluster. Read-only.
-            Not included when requesting from the apiserver, only from the Prometheus
-            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'AlertmanagerStatus is the most recent observed status of the
+            Alertmanager cluster. Read-only. Not included when requesting from the
+            apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             availableReplicas:
               description: Total number of available pods (ready for at least minReadySeconds)

--- a/community-operators/prometheus/prometheus.crd.yaml
+++ b/community-operators/prometheus/prometheus.crd.yaml
@@ -1,6 +1,8 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -11,11 +13,36 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
         spec:
-          description: 'Specification of the desired behavior of the Prometheus cluster.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'PrometheusSpec is a specification of the desired behavior
+            of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             additionalAlertManagerConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or it's key must be defined
+                  type: boolean
+              required:
+              - key
+            additionalAlertRelabelConfigs:
               description: SecretKeySelector selects a key of a Secret.
               properties:
                 key:
@@ -660,9 +687,86 @@ spec:
                   type: array
               required:
               - alertmanagers
+            apiserverConfig:
+              description: 'APIServerConfig defines a host and auth methods to access
+                apiserver. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config'
+              properties:
+                basicAuth:
+                  description: 'BasicAuth allow an endpoint to authenticate over basic
+                    authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                  properties:
+                    password:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                    username:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                bearerToken:
+                  description: Bearer token for accessing apiserver.
+                  type: string
+                bearerTokenFile:
+                  description: File to read bearer token for accessing apiserver.
+                  type: string
+                host:
+                  description: Host of apiserver. A valid string consisting of a hostname
+                    or IP followed by an optional port number
+                  type: string
+                tlsConfig:
+                  description: TLSConfig specifies TLS configuration parameters.
+                  properties:
+                    caFile:
+                      description: The CA cert to use for the targets.
+                      type: string
+                    certFile:
+                      description: The client cert file for the targets.
+                      type: string
+                    insecureSkipVerify:
+                      description: Disable target certificate validation.
+                      type: boolean
+                    keyFile:
+                      description: The client key file for the targets.
+                      type: string
+                    serverName:
+                      description: Used to verify the hostname for the targets.
+                      type: string
+              required:
+              - host
             baseImage:
               description: Base image to use for a Prometheus deployment.
               type: string
+            configMaps:
+              description: ConfigMaps is a list of ConfigMaps in the same namespace
+                as the Prometheus object, which shall be mounted into the Prometheus
+                Pods. The ConfigMaps are mounted into /etc/prometheus/configmaps/<configmap-name>.
+              items:
+                type: string
+              type: array
             containers:
               description: Containers allows injecting additional containers. This
                 is meant to allow adding an authentication proxy to a Prometheus pod.
@@ -796,6 +900,7 @@ spec:
                         configMapRef:
                           description: |-
                             ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
                             The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
                           properties:
                             name:
@@ -811,6 +916,7 @@ spec:
                         secretRef:
                           description: |-
                             SecretEnvSource selects a Secret to populate the environment variables with.
+
                             The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
                           properties:
                             name:
@@ -1124,8 +1230,8 @@ spec:
                             to by services.
                           type: string
                         protocol:
-                          description: Protocol for port. Must be UDP or TCP. Defaults
-                            to "TCP".
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
@@ -1278,6 +1384,13 @@ spec:
                           privileged containers are essentially equivalent to root
                           on the host. Defaults to false.
                         type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
                       readOnlyRootFilesystem:
                         description: Whether this container has a read-only root filesystem.
                           Default is false.
@@ -1368,8 +1481,7 @@ spec:
                     type: boolean
                   volumeDevices:
                     description: volumeDevices is the list of block devices to be
-                      used by the container. This is an alpha feature and may change
-                      in the future.
+                      used by the container. This is a beta feature.
                     items:
                       description: volumeDevice describes a mapping of a raw block
                         device within a container.
@@ -1400,8 +1512,8 @@ spec:
                         mountPropagation:
                           description: mountPropagation determines how mounts are
                             propagated from the host to container and the other way
-                            around. When not set, MountPropagationHostToContainer
-                            is used. This field is beta in 1.10.
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
                           type: string
                         name:
                           description: This must match the Name of a Volume.
@@ -1426,6 +1538,14 @@ spec:
                 required:
                 - name
               type: array
+            enableAdminAPI:
+              description: 'Enable access to prometheus web admin API. Defaults to
+                the value of `false`. WARNING: Enabling the admin APIs enables mutating
+                endpoints, to delete data, shutdown Prometheus, and more. Enabling
+                this should be done with care and the user is advised to add additional
+                authentication authorization via a proxy to ensure only clients authorized
+                to perform these actions can do so. For more information see https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis'
+              type: boolean
             evaluationInterval:
               description: Interval between consecutive evaluations.
               type: string
@@ -1437,6 +1557,12 @@ spec:
               description: The external URL the Prometheus instances will be available
                 under. This is necessary to generate correct URLs. This is necessary
                 if Prometheus is not served from root of a DNS name.
+              type: string
+            image:
+              description: Image if specified has precedence over baseImage, tag and
+                sha combinations. Specifying the version is still necessary to ensure
+                the Prometheus Operator knows what version of Prometheus is being
+                configured.
               type: string
             imagePullSecrets:
               description: An optional list of references to secrets in the same namespace
@@ -1454,6 +1580,9 @@ spec:
               description: ListenLocal makes the Prometheus server listen on loopback,
                 so that it does not bind against the Pod IP.
               type: boolean
+            logFormat:
+              description: Log format for Prometheus to be configured with.
+              type: string
             logLevel:
               description: Log level for Prometheus to be configured with.
               type: string
@@ -1510,7 +1639,9 @@ spec:
                 generateName:
                   description: |-
                     GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
                     If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
                     Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
                   type: string
                 generation:
@@ -1574,6 +1705,7 @@ spec:
                                   field:
                                     description: |-
                                       The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
                                       Examples:
                                         "name" - the field "name" on the current resource
                                         "items[0].name" - the field "name" on the first array entry in "items"
@@ -1639,11 +1771,12 @@ spec:
                                 the server has more data available. The value is opaque
                                 and may be used to issue another request to the endpoint
                                 that served this list to retrieve the next set of
-                                available objects. Continuing a list may not be possible
-                                if the server configuration has changed or more than
-                                a few minutes have passed. The resourceVersion field
-                                returned when using this continue value will be identical
-                                to the value in the first response.
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
                               type: string
                             resourceVersion:
                               description: 'String that identifies the server''s internal
@@ -1685,6 +1818,7 @@ spec:
                 namespace:
                   description: |-
                     Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
                     Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                   type: string
                 ownerReferences:
@@ -1695,8 +1829,9 @@ spec:
                     set to true. There cannot be more than one managing controller.
                   items:
                     description: OwnerReference contains enough information to let
-                      you identify an owning object. Currently, an owning object must
-                      be in the same namespace, so there is no namespace field.
+                      you identify an owning object. An owning object must be in the
+                      same namespace as the dependent, or be cluster-scoped, so there
+                      is no namespace field.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -1730,6 +1865,7 @@ spec:
                 resourceVersion:
                   description: |-
                     An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
                     Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
                   type: string
                 selfLink:
@@ -1739,7 +1875,26 @@ spec:
                 uid:
                   description: |-
                     UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
+            query:
+              description: QuerySpec defines the query command line flags when starting
+                Prometheus.
+              properties:
+                lookbackDelta:
+                  description: The delta difference allowed for retrieving metrics
+                    during expression evaluations.
+                  type: string
+                maxConcurrency:
+                  description: Number of concurrent queries that can be run at once.
+                  format: int32
+                  type: integer
+                timeout:
+                  description: Maximum time a query may take before being aborted.
                   type: string
             remoteRead:
               description: If specified, the remote_read spec. This is an experimental
@@ -1916,6 +2071,11 @@ spec:
                         description: MinBackoff is the initial retry delay. Gets doubled
                           for every retry.
                         type: string
+                      minShards:
+                        description: MinShards is the minimum number of shards, i.e.
+                          amount of concurrency.
+                        format: int32
+                        type: integer
                   remoteTimeout:
                     description: Timeout for requests to the remote write endpoint.
                     type: string
@@ -2005,7 +2165,9 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
             retention:
-              description: Time duration Prometheus shall retain data for.
+              description: Time duration Prometheus shall retain data for. Default
+                is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)`
+                (milliseconds seconds minutes hours days weeks years).
               type: string
             routePrefix:
               description: The route prefix Prometheus registers HTTP handlers for.
@@ -2052,9 +2214,9 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
             ruleSelector:
               description: A label selector is a label query over a set of resources.
@@ -2094,10 +2256,29 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
+            rules:
+              description: /--rules.*/ command-line arguments
+              properties:
+                alert:
+                  description: /--rules.alert.*/ command-line arguments
+                  properties:
+                    forGracePeriod:
+                      description: Minimum duration between alert and restored 'for'
+                        state. This is maintained only for alerts with configured
+                        'for' time greater than grace period.
+                      type: string
+                    forOutageTolerance:
+                      description: Max time to tolerate prometheus outage for restoring
+                        'for' state of alert.
+                      type: string
+                    resendDelay:
+                      description: Minimum amount of time to wait before resending
+                        an alert to Alertmanager.
+                      type: string
             scrapeInterval:
               description: Interval between consecutive scrapes.
               type: string
@@ -2105,10 +2286,6 @@ spec:
               description: Secrets is a list of Secrets in the same namespace as the
                 Prometheus object, which shall be mounted into the Prometheus Pods.
                 The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
-                Secrets changes after initial creation of a Prometheus object are
-                not reflected in the running Pods. To change the secrets mounted into
-                the Prometheus Pods, the object must be deleted and recreated with
-                the new list of secrets.
               items:
                 type: string
               type: array
@@ -2121,7 +2298,9 @@ spec:
                 fsGroup:
                   description: |-
                     A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
                     1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
                     If unset, the Kubelet will not modify the ownership and permissions of any volume.
                   format: int64
                   type: integer
@@ -2236,9 +2415,9 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
             serviceMonitorSelector:
               description: A label selector is a label query over a set of resources.
@@ -2278,19 +2457,22 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
+            sha:
+              description: SHA of Prometheus container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
             storage:
               description: StorageSpec defines the configured storage for a group
-                Prometheus servers.
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
               properties:
-                class:
-                  description: 'Name of the StorageClass to use when requesting storage
-                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
-                    DEPRECATED'
-                  type: string
                 emptyDir:
                   description: Represents an empty directory for a pod. Empty directory
                     volumes support ownership management and SELinux relabeling.
@@ -2301,63 +2483,6 @@ spec:
                         Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       type: string
                     sizeLimit: {}
-                resources:
-                  description: ResourceRequirements describes the compute resource
-                    requirements.
-                  properties:
-                    limits:
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                selector:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                      type: array
-                    matchLabels:
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                                     of matchExpressions, whose key field is "key", the operator
-                                     is "In", and the values array contains only "value". The requirements
-                                     are ANDed.
-                      type: object
                 volumeClaimTemplate:
                   description: PersistentVolumeClaim is a user's request for and claim
                     to a persistent volume
@@ -2425,7 +2550,9 @@ spec:
                         generateName:
                           description: |-
                             GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
                             If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
                             Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
                           type: string
                         generation:
@@ -2493,6 +2620,7 @@ spec:
                                           field:
                                             description: |-
                                               The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
                                               Examples:
                                                 "name" - the field "name" on the current resource
                                                 "items[0].name" - the field "name" on the first array entry in "items"
@@ -2550,8 +2678,8 @@ spec:
                                   type: string
                                 metadata:
                                   description: ListMeta describes metadata that synthetic
-                                                 resources must have, including lists and various
-                                                 status objects. A resource may have only one of
+                                    resources must have, including lists and various
+                                    status objects. A resource may have only one of
                                     {ObjectMeta, ListMeta}.
                                   properties:
                                     continue:
@@ -2561,12 +2689,14 @@ spec:
                                         available. The value is opaque and may be
                                         used to issue another request to the endpoint
                                         that served this list to retrieve the next
-                                        set of available objects. Continuing a list
-                                        may not be possible if the server configuration
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
                                         has changed or more than a few minutes have
                                         passed. The resourceVersion field returned
                                         when using this continue value will be identical
-                                        to the value in the first response.
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
                                       type: string
                                     resourceVersion:
                                       description: 'String that identifies the server''s
@@ -2611,6 +2741,7 @@ spec:
                         namespace:
                           description: |-
                             Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
                             Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                           type: string
                         ownerReferences:
@@ -2622,20 +2753,20 @@ spec:
                             There cannot be more than one managing controller.
                           items:
                             description: OwnerReference contains enough information
-                              to let you identify an owning object. Currently, an
-                              owning object must be in the same namespace, so there
-                              is no namespace field.
+                              to let you identify an owning object. An owning object
+                              must be in the same namespace as the dependent, or be
+                              cluster-scoped, so there is no namespace field.
                             properties:
                               apiVersion:
                                 description: API version of the referent.
                                 type: string
                               blockOwnerDeletion:
                                 description: If true, AND if the owner has the "foregroundDeletion"
-                                               finalizer, then the owner cannot be deleted from
-                                               the key-value store until this reference is removed.
-                                               Defaults to false. To set this field, a user needs
-                                               "delete" permission of the owner, otherwise 422
-                                               (Unprocessable Entity) will be returned.
+                                  finalizer, then the owner cannot be deleted from
+                                  the key-value store until this reference is removed.
+                                  Defaults to false. To set this field, a user needs
+                                  "delete" permission of the owner, otherwise 422
+                                  (Unprocessable Entity) will be returned.
                                 type: boolean
                               controller:
                                 description: If true, this reference points to the
@@ -2659,6 +2790,7 @@ spec:
                         resourceVersion:
                           description: |-
                             An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
                             Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
                           type: string
                         selfLink:
@@ -2668,6 +2800,7 @@ spec:
                         uid:
                           description: |-
                             UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
                             Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                           type: string
                     spec:
@@ -2681,6 +2814,26 @@ spec:
                           items:
                             type: string
                           type: array
+                        dataSource:
+                          description: TypedLocalObjectReference contains enough information
+                            to let you locate the typed referenced object inside the
+                            same namespace.
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
                         resources:
                           description: ResourceRequirements describes the compute
                             resource requirements.
@@ -2747,8 +2900,7 @@ spec:
                         volumeMode:
                           description: volumeMode defines what type of volume is required
                             by the claim. Value of Filesystem is implied when not
-                            included in claim spec. This is an alpha feature and may
-                            change in the future.
+                            included in claim spec. This is a beta feature.
                           type: string
                         volumeName:
                           description: VolumeName is the binding reference to the
@@ -2814,7 +2966,7 @@ spec:
                           type: string
             tag:
               description: Tag of Prometheus container image to be deployed. Defaults
-                to the value of `version`.
+                to the value of `version`. Version is ignored if Tag is set.
               type: string
             thanos:
               description: ThanosSpec defines parameters for a Prometheus server within
@@ -2824,19 +2976,73 @@ spec:
                   description: Thanos base image if other than default.
                   type: string
                 gcs:
-                  description: ThanosGCSSpec defines parameters for use of Google
-                    Cloud Storage (GCS) with Thanos.
+                  description: 'Deprecated: ThanosGCSSpec should be configured with
+                    an ObjectStorageConfig secret starting with Thanos v0.2.0. ThanosGCSSpec
+                    will be removed.'
                   properties:
                     bucket:
                       description: Google Cloud Storage bucket name for stored blocks.
                         If empty it won't store any block inside Google Cloud Storage.
                       type: string
+                    credentials:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                image:
+                  description: Image if specified has precedence over baseImage, tag
+                    and sha combinations. Specifying the version is still necessary
+                    to ensure the Prometheus Operator knows what version of Thanos
+                    is being configured.
+                  type: string
+                objectStorageConfig:
+                  description: SecretKeySelector selects a key of a Secret.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    optional:
+                      description: Specify whether the Secret or it's key must be
+                        defined
+                      type: boolean
+                  required:
+                  - key
                 peers:
                   description: Peers is a DNS name for Thanos to discover peers through.
                   type: string
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
                 s3:
-                  description: ThanosSpec defines parameters for of AWS Simple Storage
-                    Service (S3) with Thanos. (S3 compatible services apply as well)
+                  description: 'Deprecated: ThanosS3Spec should be configured with
+                    an ObjectStorageConfig secret starting with Thanos v0.2.0. ThanosS3Spec
+                    will be removed.'
                   properties:
                     accessKey:
                       description: SecretKeySelector selects a key of a Secret.
@@ -2857,6 +3063,9 @@ spec:
                     bucket:
                       description: S3-Compatible API bucket name for stored blocks.
                       type: string
+                    encryptsse:
+                      description: Whether to use Server Side Encryption
+                      type: boolean
                     endpoint:
                       description: S3-Compatible API endpoint for stored blocks.
                       type: string
@@ -2884,9 +3093,16 @@ spec:
                       description: Whether to use S3 Signature Version 2; otherwise
                         Signature Version 4 will be used.
                       type: boolean
+                sha:
+                  description: SHA of Thanos container image to be deployed. Defaults
+                    to the value of `version`. Similar to a tag, but the SHA explicitly
+                    deploys an immutable container image. Version and Tag are ignored
+                    if SHA is set.
+                  type: string
                 tag:
                   description: Tag of Thanos sidecar container image to be deployed.
-                    Defaults to the value of `version`.
+                    Defaults to the value of `version`. Version is ignored if Tag
+                    is set.
                   type: string
                 version:
                   description: Version describes the version of Thanos to use.
@@ -2934,9 +3150,9 @@ spec:
               description: Version of Prometheus to be deployed.
               type: string
         status:
-          description: 'Most recent observed status of the Prometheus cluster. Read-only.
-            Not included when requesting from the apiserver, only from the Prometheus
-            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'PrometheusStatus is the most recent observed status of the
+            Prometheus cluster. Read-only. Not included when requesting from the apiserver,
+            only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             availableReplicas:
               description: Total number of available pods (ready for at least minReadySeconds)

--- a/community-operators/prometheus/prometheus.package.yaml
+++ b/community-operators/prometheus/prometheus.package.yaml
@@ -1,5 +1,5 @@
-#! package-manifest: deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.22.2.clusterserviceversion.yaml
+#! package-manifest: deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.27.0.clusterserviceversion.yaml
 packageName: prometheus
 channels:
-- name: preview
-  currentCSV: prometheusoperator.0.22.2
+- name: beta
+  currentCSV: prometheusoperator.0.27.0

--- a/community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
@@ -6,7 +6,15 @@ metadata:
   name: prometheusoperator.0.14.0
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
+    capabilities: Seamless Upgrades
+    categories: Monitoring
+    description: Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.
+    containerImage: quay.io/coreos/prometheus-operator:v0.14.0
+    createdAt: 2019-01-08T16:12:00Z
+    repository: https://github.com/coreos/prometheus-operator
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.7.1","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{},"ruleSelector":{},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
+    certified: "false"
+    support: Frederic Branczyk
 spec:
   displayName: Prometheus
   description: |

--- a/community-operators/prometheus/prometheusoperator.0.15.0.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.15.0.clusterserviceversion.yaml
@@ -6,9 +6,15 @@ metadata:
   name: prometheusoperator.0.15.0
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
-    tectonic-visibility: ocs
-    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+    capabilities: Seamless Upgrades
+    categories: Monitoring
+    description: Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.
+    containerImage: quay.io/coreos/prometheus-operator:v0.15.0
+    createdAt: 2019-01-08T16:12:00Z
+    repository: https://github.com/coreos/prometheus-operator
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.7.1","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{},"ruleSelector":{},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
+    certified: "false"
+    support: Frederic Branczyk
 spec:
   replaces: prometheusoperator.0.14.0
   displayName: Prometheus

--- a/community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -6,10 +6,15 @@ metadata:
   name: prometheusoperator.0.22.2
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
-    categories: "OpenShift Optional, Monitoring"
-    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.3.2","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
-    description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
+    capabilities: Seamless Upgrades
+    categories: Monitoring
+    description: Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.
+    containerImage: quay.io/coreos/prometheus-operator:v0.22.2
+    createdAt: 2019-01-08T16:12:00Z
+    repository: https://github.com/coreos/prometheus-operator
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.7.1","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{},"ruleSelector":{},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"PrometheusRule","metadata":{"creationTimestamp":null,"labels":{"prometheus":"example","role":"alert-rules"},"name":"prometheus-example-rules"},"spec":{"groups":[{"name":"./example.rules","rules":[{"alert":"ExampleAlert","expr":"vector(1)"}]}]}}]'
+    certified: "false"
+    support: Frederic Branczyk
 spec:
   replaces: prometheusoperator.0.15.0
   displayName: Prometheus Operator

--- a/community-operators/prometheus/prometheusoperator.0.27.0.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.27.0.clusterserviceversion.yaml
@@ -3,65 +3,65 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: prometheusoperator.0.15.0
+  name: prometheusoperator.0.27.0
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
-    tectonic-visibility: ocs
-    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+    capabilities: Seamless Upgrades
+    categories: Monitoring
+    description: Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.
+    containerImage: quay.io/coreos/prometheus-operator:v0.27.0
+    createdAt: 2019-01-08T16:12:00Z
+    repository: https://github.com/coreos/prometheus-operator
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.7.1","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{},"ruleSelector":{},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"PrometheusRule","metadata":{"creationTimestamp":null,"labels":{"prometheus":"example","role":"alert-rules"},"name":"prometheus-example-rules"},"spec":{"groups":[{"name":"./example.rules","rules":[{"alert":"ExampleAlert","expr":"vector(1)"}]}]}}]'
+    certified: "false"
+    support: Frederic Branczyk
 spec:
-  replaces: prometheusoperator.0.14.0
-  displayName: Prometheus
+  replaces: prometheusoperator.0.22.2
+  displayName: Prometheus Operator
   description: |
-    An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+    The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 
-    _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+    Once installed, the Prometheus Operator provides the following features:
 
-    ### Monitoring applications
+    * **Create/Destroy**: Easily launch a Prometheus instance for your Kubernetes namespace, a specific application or team easily using the Operator.
 
-    Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+    * **Simple Configuration**: Configure the fundamentals of Prometheus like versions, persistence, retention policies, and replicas from a native Kubernetes resource.
 
-    [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+    * **Target Services via Labels**: Automatically generate monitoring target configurations based on familiar Kubernetes label queries; no need to learn a Prometheus specific configuration language.
 
-    ### Supported Features
-
+    ### Other Supported Features
 
     **High availability**
 
-
     Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
-
 
     **Updates via automated operations**
 
-
     New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
-
 
     **Handles the dynamic nature of containers**
 
-
     Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
 
-  keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+  keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting', 'observability']
 
   maintainers:
-  - name: CoreOS, Inc
-    email: support@coreos.com
+  - name: Red Hat
+    email: openshift-operators@redhat.com
 
   provider:
-    name: CoreOS, Inc
+    name: Red Hat
 
   links:
   - name: Prometheus
     url: https://www.prometheus.io/
   - name: Documentation
-    url: https://coreos.com/operators/prometheus/docs/latest/
-  - name: Prometheus Operator Source Code
+    url: https://github.com/coreos/prometheus-operator/tree/master/Documentation
+  - name: Prometheus Operator
     url: https://github.com/coreos/prometheus-operator
 
   labels:
-    alm-status-descriptors: prometheusoperator.0.15.0
+    alm-status-descriptors: prometheusoperator.0.27.0
     alm-owner-prometheus: prometheusoperator
 
   selector:
@@ -78,10 +78,10 @@ spec:
   - type: SingleNamespace
     supported: true
   - type: MultiNamespace
-    supported: false
-  - type: AllNamespaces
     supported: true
-    
+  - type: AllNamespaces
+    supported: false
+
   install:
     strategy: deployment
     spec:
@@ -99,48 +99,69 @@ spec:
           resources:
           - configmaps
           verbs: ["get"]
-      - serviceAccountName: prometheus-operator-0-14-0
+      - serviceAccountName: prometheus-operator-0-27-0
         rules:
         - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
-          verbs: ["get", "list"]
+          verbs:
+          - '*'
         - apiGroups:
           - monitoring.coreos.com
           resources:
           - alertmanagers
           - prometheuses
+          - prometheuses/finalizers
+          - alertmanagers/finalizers
           - servicemonitors
+          - prometheusrules
           verbs:
-          - "*"
+          - '*'
         - apiGroups:
           - apps
           resources:
           - statefulsets
-          verbs: ["*"]
-        - apiGroups: [""]
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
           resources:
           - configmaps
           - secrets
-          verbs: ["*"]
-        - apiGroups: [""]
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
           resources:
           - pods
-          verbs: ["list", "delete"]
-        - apiGroups: [""]
+          verbs:
+          - list
+          - delete
+        - apiGroups:
+          - ""
           resources:
           - services
           - endpoints
-          verbs: ["get", "create", "update"]
-        - apiGroups: [""]
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ""
           resources:
           - nodes
-          verbs: ["list", "watch"]
-        - apiGroups: [""]
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - ""
           resources:
           - namespaces
-          verbs: ['list']
+          verbs:
+          - get
+          - list
+          - watch
       deployments:
       - name: prometheus-operator
         spec:
@@ -153,23 +174,21 @@ spec:
               labels:
                 k8s-app: prometheus-operator
             spec:
-              serviceAccount: prometheus-operator-0-14-0
+              serviceAccount: prometheus-operator-0-27-0
               containers:
               - name: prometheus-operator
-                image: quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d
-                command:
-                  - sh
-                  - -c
-                  - >
-                    /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
-                    --labels alm-status-descriptors=prometheusoperator.0.15.0,alm-owner-prometheus=prometheusoperator
-                    --kubelet-service=kube-system/kubelet
-                    --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                image: quay.io/coreos/prometheus-operator@sha256:933cd5bf380cf7db330808ff54f75f26fda0b1501021d499a1766b7d16224188
+                args:
+                - -namespaces=$(NAMESPACES)
+                - -manage-crds=false
+                - -logtostderr=true
+                - --config-reloader-image=quay.io/coreos/configmap-reload@sha256:e2fd60ff0ae4500a75b80ebaa30e0e7deba9ad107833e8ca53f0047c42c5a057
+                - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader@sha256:61b7969fd1336fd4bbac0622f9e4281f2a2b4ae02ad55748b6fdc65e2be69b73
                 env:
-                  - name: K8S_NAMESPACE
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.namespace
+                - name: NAMESPACES
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 ports:
                 - containerPort: 8080
                   name: http
@@ -180,8 +199,13 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 50Mi
-  maturity: alpha
-  version: 0.15.0
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+              nodeSelector:
+                beta.kubernetes.io/os: linux
+  maturity: beta
+  version: 0.27.0
   customresourcedefinitions:
     owned:
     - name: prometheuses.monitoring.coreos.com
@@ -190,79 +214,76 @@ spec:
       displayName: Prometheus
       description: A running Prometheus instance
       resources:
-        - kind: StatefulSet
-          version: v1beta2
-        - kind: Pod
-          version: v1
+      - kind: StatefulSet
+        version: v1beta2
+      - kind: Pod
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: Service
+        version: v1
       specDescriptors:
       - description: Desired number of Pods for the cluster
         displayName: Size
         path: replicas
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
       - description: A selector for the ConfigMaps from which to load rule files
         displayName: Rule Config Map Selector
         path: ruleSelector
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
       - description: ServiceMonitors to be selected for target discovery
         displayName: Service Monitor Selector
         path: serviceMonitorSelector
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
       - description: The ServiceAccount to use to run the Prometheus pods
         displayName: Service Account
         path: serviceAccountName
         x-descriptors:
-          - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+        - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
       - description: Limits describes the minimum/maximum amount of compute resources required/allowed
         displayName: Resource Requirements
         path: resources
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
-      statusDescriptors:
-        - description: The current number of Pods for the cluster
-          displayName: Cluster Size
-          path: replicas
-        - path: prometheusSelector
-          displayName: Prometheus Service Selector
-          description: Label selector to find the service that routes to this prometheus
-          x-descriptors:
-          - 'urn:alm:descriptor:label:selector'
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+    - name: prometheusrules.monitoring.coreos.com
+      version: v1
+      kind: PrometheusRule
+      displayName: Prometheus Rule
+      description: A Prometheus Rule configures groups of sequentially evaluated recording and alerting rules.
     - name: servicemonitors.monitoring.coreos.com
       version: v1
       kind: ServiceMonitor
       displayName: Service Monitor
       description: Configures prometheus to monitor a particular k8s service
       resources:
-        - kind: Pod
-          version: v1
+      - kind: Pod
+        version: v1
       specDescriptors:
-      - description: Selector to select which namespaces the Endpoints objects are discovered from
-        displayName: Monitoring Namespaces
-        path: namespaceSelector
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
       - description: The label to use to retrieve the job name from
         displayName: Job Label
         path: jobLabel
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
       - description: A list of endpoints allowed as part of this ServiceMonitor
         displayName: Endpoints
         path: endpoints
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+        - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
     - name: alertmanagers.monitoring.coreos.com
       version: v1
       kind: Alertmanager
-      displayName: Alert Manager
-      description: Configures an Alert Manager for the namespace
+      displayName: Alertmanager
+      description: Configures an Alertmanager for the namespace
       resources:
-        - kind: StatefulSet
-          version: v1beta2
-        - kind: Pod
-          version: v1
+      - kind: StatefulSet
+        version: v1beta2
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
       specDescriptors:
       - description: Desired number of Pods for the cluster
         displayName: Size
@@ -273,4 +294,4 @@ spec:
         displayName: Resource Requirements
         path: resources
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'

--- a/community-operators/prometheus/prometheusrule.crd.yaml
+++ b/community-operators/prometheus/prometheusrule.crd.yaml
@@ -1,6 +1,8 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -11,6 +13,295 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: ObjectMeta is metadata that all persisted resources must have,
+            which includes all objects users must create.
+          properties:
+            annotations:
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+            clusterName:
+              description: The name of the cluster which the object belongs to. This
+                is used to distinguish resources with same name and namespace in different
+                clusters. This field is not set anywhere right now and apiserver is
+                going to ignore it if set in create or update request.
+              type: string
+            creationTimestamp:
+              description: Time is a wrapper around time.Time which supports correct
+                marshaling to YAML and JSON.  Wrappers are provided for many of the
+                factory methods that the time package offers.
+              format: date-time
+              type: string
+            deletionGracePeriodSeconds:
+              description: Number of seconds allowed for this object to gracefully
+                terminate before it will be removed from the system. Only set when
+                deletionTimestamp is also set. May only be shortened. Read-only.
+              format: int64
+              type: integer
+            deletionTimestamp:
+              description: Time is a wrapper around time.Time which supports correct
+                marshaling to YAML and JSON.  Wrappers are provided for many of the
+                factory methods that the time package offers.
+              format: date-time
+              type: string
+            finalizers:
+              description: Must be empty before the object is deleted from the registry.
+                Each entry is an identifier for the responsible component that will
+                remove the entry from the list. If the deletionTimestamp of the object
+                is non-nil, entries in this list can only be removed.
+              items:
+                type: string
+              type: array
+            generateName:
+              description: |-
+                GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+              type: string
+            generation:
+              description: A sequence number representing a specific generation of
+                the desired state. Populated by the system. Read-only.
+              format: int64
+              type: integer
+            initializers:
+              description: Initializers tracks the progress of initialization.
+              properties:
+                pending:
+                  description: Pending is a list of initializers that must execute
+                    in order before this object is visible. When the last pending
+                    initializer is removed, and no failing result is set, the initializers
+                    struct will be set to nil and the object is considered as initialized
+                    and visible to all clients.
+                  items:
+                    description: Initializer is information about an initializer that
+                      has not yet completed.
+                    properties:
+                      name:
+                        description: name of the process that is responsible for initializing
+                          this object.
+                        type: string
+                    required:
+                    - name
+                  type: array
+                result:
+                  description: Status is a return value for calls that don't return
+                    other objects.
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    code:
+                      description: Suggested HTTP return code for this status, 0 if
+                        not set.
+                      format: int32
+                      type: integer
+                    details:
+                      description: StatusDetails is a set of additional properties
+                        that MAY be set by the server to provide additional information
+                        about a response. The Reason field of a Status object defines
+                        what attributes will be set. Clients must ignore fields that
+                        do not match the defined type of each attribute, and should
+                        assume that any attribute may be empty, invalid, or under
+                        defined.
+                      properties:
+                        causes:
+                          description: The Causes array includes more details associated
+                            with the StatusReason failure. Not all StatusReasons may
+                            provide detailed causes.
+                          items:
+                            description: StatusCause provides more information about
+                              an api.Status failure, including cases when multiple
+                              errors are encountered.
+                            properties:
+                              field:
+                                description: |-
+                                  The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                  Examples:
+                                    "name" - the field "name" on the current resource
+                                    "items[0].name" - the field "name" on the first array entry in "items"
+                                type: string
+                              message:
+                                description: A human-readable description of the cause
+                                  of the error.  This field may be presented as-is
+                                  to a reader.
+                                type: string
+                              reason:
+                                description: A machine-readable description of the
+                                  cause of the error. If this value is empty there
+                                  is no information available.
+                                type: string
+                          type: array
+                        group:
+                          description: The group attribute of the resource associated
+                            with the status StatusReason.
+                          type: string
+                        kind:
+                          description: 'The kind attribute of the resource associated
+                            with the status StatusReason. On some operations may differ
+                            from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: The name attribute of the resource associated
+                            with the status StatusReason (when there is a single name
+                            which can be described).
+                          type: string
+                        retryAfterSeconds:
+                          description: If specified, the time in seconds before the
+                            operation should be retried. Some errors may indicate
+                            the client must take an alternate action - for those errors
+                            this field may indicate how long to wait before taking
+                            the alternate action.
+                          format: int32
+                          type: integer
+                        uid:
+                          description: 'UID of the resource. (when there is a single
+                            resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    message:
+                      description: A human-readable description of the status of this
+                        operation.
+                      type: string
+                    metadata:
+                      description: ListMeta describes metadata that synthetic resources
+                        must have, including lists and various status objects. A resource
+                        may have only one of {ObjectMeta, ListMeta}.
+                      properties:
+                        continue:
+                          description: continue may be set if the user set a limit
+                            on the number of items returned, and indicates that the
+                            server has more data available. The value is opaque and
+                            may be used to issue another request to the endpoint that
+                            served this list to retrieve the next set of available
+                            objects. Continuing a consistent list may not be possible
+                            if the server configuration has changed or more than a
+                            few minutes have passed. The resourceVersion field returned
+                            when using this continue value will be identical to the
+                            value in the first response, unless you have received
+                            this token from an error message.
+                          type: string
+                        resourceVersion:
+                          description: 'String that identifies the server''s internal
+                            version of this object that can be used by clients to
+                            determine when objects have changed. Value must be treated
+                            as opaque by clients and passed unmodified back to the
+                            server. Populated by the system. Read-only. More info:
+                            https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        selfLink:
+                          description: selfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                    reason:
+                      description: A machine-readable description of why this operation
+                        is in the "Failure" status. If this value is empty there is
+                        no information available. A Reason clarifies an HTTP status
+                        code but does not override it.
+                      type: string
+                    status:
+                      description: 'Status of the operation. One of: "Success" or
+                        "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                      type: string
+              required:
+              - pending
+            labels:
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: |-
+                Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+              type: string
+            ownerReferences:
+              description: List of objects depended by this object. If ALL objects
+                in the list have been deleted, this object will be garbage collected.
+                If this object is managed by a controller, then an entry in this list
+                will point to this controller, with the controller field set to true.
+                There cannot be more than one managing controller.
+              items:
+                description: OwnerReference contains enough information to let you
+                  identify an owning object. An owning object must be in the same
+                  namespace as the dependent, or be cluster-scoped, so there is no
+                  namespace field.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  blockOwnerDeletion:
+                    description: If true, AND if the owner has the "foregroundDeletion"
+                      finalizer, then the owner cannot be deleted from the key-value
+                      store until this reference is removed. Defaults to false. To
+                      set this field, a user needs "delete" permission of the owner,
+                      otherwise 422 (Unprocessable Entity) will be returned.
+                    type: boolean
+                  controller:
+                    description: If true, this reference points to the managing controller.
+                    type: boolean
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                - uid
+              type: array
+            resourceVersion:
+              description: |-
+                An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+              type: string
+            selfLink:
+              description: SelfLink is a URL representing this object. Populated by
+                the system. Read-only.
+              type: string
+            uid:
+              description: |-
+                UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+              type: string
         spec:
           description: PrometheusRuleSpec contains specification parameters for a
             Rule.
@@ -34,7 +325,9 @@ spec:
                         annotations:
                           type: object
                         expr:
-                          type: string
+                          anyOf:
+                          - type: string
+                          - type: integer
                         for:
                           type: string
                         labels:

--- a/community-operators/prometheus/servicemonitor.crd.yaml
+++ b/community-operators/prometheus/servicemonitor.crd.yaml
@@ -1,6 +1,8 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -11,6 +13,16 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
         spec:
           description: ServiceMonitorSpec contains specification parameters for a
             ServiceMonitor.
@@ -125,6 +137,51 @@ spec:
                     description: ProxyURL eg http://proxyserver:2195 Directs scrapes
                       to proxy through this endpoint.
                     type: string
+                  relabelings:
+                    description: 'RelabelConfigs to apply to samples before ingestion.
+                      More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
                   scheme:
                     description: HTTP scheme to use for scraping.
                     type: string
@@ -158,7 +215,7 @@ spec:
               description: The label to use to retrieve the job name from.
               type: string
             namespaceSelector:
-              description: A selector for selecting namespaces either selecting all
+              description: NamespaceSelector is a selector for selecting either all
                 namespaces or a list of namespaces.
               properties:
                 any:
@@ -170,6 +227,17 @@ spec:
                   items:
                     type: string
                   type: array
+            podTargetLabels:
+              description: PodTargetLabels transfers labels on the Kubernetes Pod
+                onto the target.
+              items:
+                type: string
+              type: array
+            sampleLimit:
+              description: SampleLimit defines per-scrape limit on number of scraped
+                samples that will be accepted.
+              format: int64
+              type: integer
             selector:
               description: A label selector is a label query over a set of resources.
                 The result of matchLabels and matchExpressions are ANDed. An empty
@@ -208,9 +276,9 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
             targetLabels:
               description: TargetLabels transfers labels on the Kubernetes Service

--- a/upstream-community-operators/prometheus/alertmanager.crd.yaml
+++ b/upstream-community-operators/prometheus/alertmanager.crd.yaml
@@ -1,6 +1,8 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -11,10 +13,26 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
         spec:
-          description: 'Specification of the desired behavior of the Alertmanager
-            cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'AlertmanagerSpec is a specification of the desired behavior
+            of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
+            additionalPeers:
+              description: AdditionalPeers allows injecting a set of additional Alertmanagers
+                to peer with to form a highly available cluster.
+              items:
+                type: string
+              type: array
             affinity:
               description: Affinity is a group of affinity scheduling rules.
               properties:
@@ -576,6 +594,13 @@ spec:
             baseImage:
               description: Base image that is used to deploy pods, without tag.
               type: string
+            configMaps:
+              description: ConfigMaps is a list of ConfigMaps in the same namespace
+                as the Alertmanager object, which shall be mounted into the Alertmanager
+                Pods. The ConfigMaps are mounted into /etc/alertmanager/configmaps/<configmap-name>.
+              items:
+                type: string
+              type: array
             containers:
               description: Containers allows injecting additional containers. This
                 is meant to allow adding an authentication proxy to an Alertmanager
@@ -1040,8 +1065,8 @@ spec:
                             to by services.
                           type: string
                         protocol:
-                          description: Protocol for port. Must be UDP or TCP. Defaults
-                            to "TCP".
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
@@ -1194,6 +1219,13 @@ spec:
                           privileged containers are essentially equivalent to root
                           on the host. Defaults to false.
                         type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
                       readOnlyRootFilesystem:
                         description: Whether this container has a read-only root filesystem.
                           Default is false.
@@ -1284,8 +1316,7 @@ spec:
                     type: boolean
                   volumeDevices:
                     description: volumeDevices is the list of block devices to be
-                      used by the container. This is an alpha feature and may change
-                      in the future.
+                      used by the container. This is a beta feature.
                     items:
                       description: volumeDevice describes a mapping of a raw block
                         device within a container.
@@ -1316,8 +1347,8 @@ spec:
                         mountPropagation:
                           description: mountPropagation determines how mounts are
                             propagated from the host to container and the other way
-                            around. When not set, MountPropagationHostToContainer
-                            is used. This field is beta in 1.10.
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
                           type: string
                         name:
                           description: This must match the Name of a Volume.
@@ -1346,6 +1377,12 @@ spec:
               description: The external URL the Alertmanager instances will be available
                 under. This is necessary to generate correct URLs. This is necessary
                 if Alertmanager is not served from root of a DNS name.
+              type: string
+            image:
+              description: Image if specified has precedence over baseImage, tag and
+                sha combinations. Specifying the version is still necessary to ensure
+                the Prometheus Operator knows what version of Alertmanager is being
+                configured.
               type: string
             imagePullSecrets:
               description: An optional list of references to secrets in the same namespace
@@ -1552,11 +1589,12 @@ spec:
                                 the server has more data available. The value is opaque
                                 and may be used to issue another request to the endpoint
                                 that served this list to retrieve the next set of
-                                available objects. Continuing a list may not be possible
-                                if the server configuration has changed or more than
-                                a few minutes have passed. The resourceVersion field
-                                returned when using this continue value will be identical
-                                to the value in the first response.
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
                               type: string
                             resourceVersion:
                               description: 'String that identifies the server''s internal
@@ -1609,8 +1647,9 @@ spec:
                     set to true. There cannot be more than one managing controller.
                   items:
                     description: OwnerReference contains enough information to let
-                      you identify an owning object. Currently, an owning object must
-                      be in the same namespace, so there is no namespace field.
+                      you identify an owning object. An owning object must be in the
+                      same namespace as the dependent, or be cluster-scoped, so there
+                      is no namespace field.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -1657,6 +1696,9 @@ spec:
 
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                   type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
             replicas:
               description: Size is the expected size of the alertmanager cluster.
                 The controller will eventually make the size of the running cluster
@@ -1676,6 +1718,11 @@ spec:
                     to Limits if that is explicitly specified, otherwise to an implementation-defined
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
+            retention:
+              description: Time duration Alertmanager shall retain data for. Default
+                is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)`
+                (milliseconds seconds minutes hours).
+              type: string
             routePrefix:
               description: The route prefix Alertmanager registers HTTP handlers for.
                 This is useful, if using ExternalURL and a proxy is rewriting HTTP
@@ -1778,15 +1825,18 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the Prometheus Pods.
               type: string
+            sha:
+              description: SHA of Alertmanager container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
             storage:
               description: StorageSpec defines the configured storage for a group
-                Prometheus servers.
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
               properties:
-                class:
-                  description: 'Name of the StorageClass to use when requesting storage
-                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
-                    DEPRECATED'
-                  type: string
                 emptyDir:
                   description: Represents an empty directory for a pod. Empty directory
                     volumes support ownership management and SELinux relabeling.
@@ -1797,63 +1847,6 @@ spec:
                         Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       type: string
                     sizeLimit: {}
-                resources:
-                  description: ResourceRequirements describes the compute resource
-                    requirements.
-                  properties:
-                    limits:
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                selector:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                      type: array
-                    matchLabels:
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                                     of matchExpressions, whose key field is "key", the operator
-                                     is "In", and the values array contains only "value". The requirements
-                                     are ANDed.
-                      type: object
                 volumeClaimTemplate:
                   description: PersistentVolumeClaim is a user's request for and claim
                     to a persistent volume
@@ -2049,8 +2042,8 @@ spec:
                                   type: string
                                 metadata:
                                   description: ListMeta describes metadata that synthetic
-                                                 resources must have, including lists and various
-                                                 status objects. A resource may have only one of
+                                    resources must have, including lists and various
+                                    status objects. A resource may have only one of
                                     {ObjectMeta, ListMeta}.
                                   properties:
                                     continue:
@@ -2060,12 +2053,14 @@ spec:
                                         available. The value is opaque and may be
                                         used to issue another request to the endpoint
                                         that served this list to retrieve the next
-                                        set of available objects. Continuing a list
-                                        may not be possible if the server configuration
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
                                         has changed or more than a few minutes have
                                         passed. The resourceVersion field returned
                                         when using this continue value will be identical
-                                        to the value in the first response.
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
                                       type: string
                                     resourceVersion:
                                       description: 'String that identifies the server''s
@@ -2122,20 +2117,20 @@ spec:
                             There cannot be more than one managing controller.
                           items:
                             description: OwnerReference contains enough information
-                              to let you identify an owning object. Currently, an
-                              owning object must be in the same namespace, so there
-                              is no namespace field.
+                              to let you identify an owning object. An owning object
+                              must be in the same namespace as the dependent, or be
+                              cluster-scoped, so there is no namespace field.
                             properties:
                               apiVersion:
                                 description: API version of the referent.
                                 type: string
                               blockOwnerDeletion:
                                 description: If true, AND if the owner has the "foregroundDeletion"
-                                               finalizer, then the owner cannot be deleted from
-                                               the key-value store until this reference is removed.
-                                               Defaults to false. To set this field, a user needs
-                                               "delete" permission of the owner, otherwise 422
-                                               (Unprocessable Entity) will be returned.
+                                  finalizer, then the owner cannot be deleted from
+                                  the key-value store until this reference is removed.
+                                  Defaults to false. To set this field, a user needs
+                                  "delete" permission of the owner, otherwise 422
+                                  (Unprocessable Entity) will be returned.
                                 type: boolean
                               controller:
                                 description: If true, this reference points to the
@@ -2183,6 +2178,26 @@ spec:
                           items:
                             type: string
                           type: array
+                        dataSource:
+                          description: TypedLocalObjectReference contains enough information
+                            to let you locate the typed referenced object inside the
+                            same namespace.
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
                         resources:
                           description: ResourceRequirements describes the compute
                             resource requirements.
@@ -2249,8 +2264,7 @@ spec:
                         volumeMode:
                           description: volumeMode defines what type of volume is required
                             by the claim. Value of Filesystem is implied when not
-                            included in claim spec. This is an alpha feature and may
-                            change in the future.
+                            included in claim spec. This is a beta feature.
                           type: string
                         volumeName:
                           description: VolumeName is the binding reference to the
@@ -2316,7 +2330,7 @@ spec:
                           type: string
             tag:
               description: Tag of Alertmanager container image to be deployed. Defaults
-                to the value of `version`.
+                to the value of `version`. Version is ignored if Tag is set.
               type: string
             tolerations:
               description: If specified, the pod's tolerations.
@@ -2361,9 +2375,9 @@ spec:
               description: Version the cluster should be on.
               type: string
         status:
-          description: 'Most recent observed status of the Alertmanager cluster. Read-only.
-            Not included when requesting from the apiserver, only from the Prometheus
-            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'AlertmanagerStatus is the most recent observed status of the
+            Alertmanager cluster. Read-only. Not included when requesting from the
+            apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             availableReplicas:
               description: Total number of available pods (ready for at least minReadySeconds)

--- a/upstream-community-operators/prometheus/prometheus.crd.yaml
+++ b/upstream-community-operators/prometheus/prometheus.crd.yaml
@@ -1,6 +1,8 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -11,11 +13,36 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
         spec:
-          description: 'Specification of the desired behavior of the Prometheus cluster.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'PrometheusSpec is a specification of the desired behavior
+            of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             additionalAlertManagerConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or it's key must be defined
+                  type: boolean
+              required:
+              - key
+            additionalAlertRelabelConfigs:
               description: SecretKeySelector selects a key of a Secret.
               properties:
                 key:
@@ -660,9 +687,86 @@ spec:
                   type: array
               required:
               - alertmanagers
+            apiserverConfig:
+              description: 'APIServerConfig defines a host and auth methods to access
+                apiserver. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config'
+              properties:
+                basicAuth:
+                  description: 'BasicAuth allow an endpoint to authenticate over basic
+                    authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                  properties:
+                    password:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                    username:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                bearerToken:
+                  description: Bearer token for accessing apiserver.
+                  type: string
+                bearerTokenFile:
+                  description: File to read bearer token for accessing apiserver.
+                  type: string
+                host:
+                  description: Host of apiserver. A valid string consisting of a hostname
+                    or IP followed by an optional port number
+                  type: string
+                tlsConfig:
+                  description: TLSConfig specifies TLS configuration parameters.
+                  properties:
+                    caFile:
+                      description: The CA cert to use for the targets.
+                      type: string
+                    certFile:
+                      description: The client cert file for the targets.
+                      type: string
+                    insecureSkipVerify:
+                      description: Disable target certificate validation.
+                      type: boolean
+                    keyFile:
+                      description: The client key file for the targets.
+                      type: string
+                    serverName:
+                      description: Used to verify the hostname for the targets.
+                      type: string
+              required:
+              - host
             baseImage:
               description: Base image to use for a Prometheus deployment.
               type: string
+            configMaps:
+              description: ConfigMaps is a list of ConfigMaps in the same namespace
+                as the Prometheus object, which shall be mounted into the Prometheus
+                Pods. The ConfigMaps are mounted into /etc/prometheus/configmaps/<configmap-name>.
+              items:
+                type: string
+              type: array
             containers:
               description: Containers allows injecting additional containers. This
                 is meant to allow adding an authentication proxy to a Prometheus pod.
@@ -796,6 +900,7 @@ spec:
                         configMapRef:
                           description: |-
                             ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
                             The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
                           properties:
                             name:
@@ -811,6 +916,7 @@ spec:
                         secretRef:
                           description: |-
                             SecretEnvSource selects a Secret to populate the environment variables with.
+
                             The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
                           properties:
                             name:
@@ -1124,8 +1230,8 @@ spec:
                             to by services.
                           type: string
                         protocol:
-                          description: Protocol for port. Must be UDP or TCP. Defaults
-                            to "TCP".
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
@@ -1278,6 +1384,13 @@ spec:
                           privileged containers are essentially equivalent to root
                           on the host. Defaults to false.
                         type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
                       readOnlyRootFilesystem:
                         description: Whether this container has a read-only root filesystem.
                           Default is false.
@@ -1368,8 +1481,7 @@ spec:
                     type: boolean
                   volumeDevices:
                     description: volumeDevices is the list of block devices to be
-                      used by the container. This is an alpha feature and may change
-                      in the future.
+                      used by the container. This is a beta feature.
                     items:
                       description: volumeDevice describes a mapping of a raw block
                         device within a container.
@@ -1400,8 +1512,8 @@ spec:
                         mountPropagation:
                           description: mountPropagation determines how mounts are
                             propagated from the host to container and the other way
-                            around. When not set, MountPropagationHostToContainer
-                            is used. This field is beta in 1.10.
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
                           type: string
                         name:
                           description: This must match the Name of a Volume.
@@ -1426,6 +1538,14 @@ spec:
                 required:
                 - name
               type: array
+            enableAdminAPI:
+              description: 'Enable access to prometheus web admin API. Defaults to
+                the value of `false`. WARNING: Enabling the admin APIs enables mutating
+                endpoints, to delete data, shutdown Prometheus, and more. Enabling
+                this should be done with care and the user is advised to add additional
+                authentication authorization via a proxy to ensure only clients authorized
+                to perform these actions can do so. For more information see https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis'
+              type: boolean
             evaluationInterval:
               description: Interval between consecutive evaluations.
               type: string
@@ -1437,6 +1557,12 @@ spec:
               description: The external URL the Prometheus instances will be available
                 under. This is necessary to generate correct URLs. This is necessary
                 if Prometheus is not served from root of a DNS name.
+              type: string
+            image:
+              description: Image if specified has precedence over baseImage, tag and
+                sha combinations. Specifying the version is still necessary to ensure
+                the Prometheus Operator knows what version of Prometheus is being
+                configured.
               type: string
             imagePullSecrets:
               description: An optional list of references to secrets in the same namespace
@@ -1454,6 +1580,9 @@ spec:
               description: ListenLocal makes the Prometheus server listen on loopback,
                 so that it does not bind against the Pod IP.
               type: boolean
+            logFormat:
+              description: Log format for Prometheus to be configured with.
+              type: string
             logLevel:
               description: Log level for Prometheus to be configured with.
               type: string
@@ -1510,7 +1639,9 @@ spec:
                 generateName:
                   description: |-
                     GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
                     If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
                     Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
                   type: string
                 generation:
@@ -1574,6 +1705,7 @@ spec:
                                   field:
                                     description: |-
                                       The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
                                       Examples:
                                         "name" - the field "name" on the current resource
                                         "items[0].name" - the field "name" on the first array entry in "items"
@@ -1639,11 +1771,12 @@ spec:
                                 the server has more data available. The value is opaque
                                 and may be used to issue another request to the endpoint
                                 that served this list to retrieve the next set of
-                                available objects. Continuing a list may not be possible
-                                if the server configuration has changed or more than
-                                a few minutes have passed. The resourceVersion field
-                                returned when using this continue value will be identical
-                                to the value in the first response.
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
                               type: string
                             resourceVersion:
                               description: 'String that identifies the server''s internal
@@ -1685,6 +1818,7 @@ spec:
                 namespace:
                   description: |-
                     Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
                     Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                   type: string
                 ownerReferences:
@@ -1695,8 +1829,9 @@ spec:
                     set to true. There cannot be more than one managing controller.
                   items:
                     description: OwnerReference contains enough information to let
-                      you identify an owning object. Currently, an owning object must
-                      be in the same namespace, so there is no namespace field.
+                      you identify an owning object. An owning object must be in the
+                      same namespace as the dependent, or be cluster-scoped, so there
+                      is no namespace field.
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -1730,6 +1865,7 @@ spec:
                 resourceVersion:
                   description: |-
                     An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
                     Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
                   type: string
                 selfLink:
@@ -1739,7 +1875,26 @@ spec:
                 uid:
                   description: |-
                     UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
+            query:
+              description: QuerySpec defines the query command line flags when starting
+                Prometheus.
+              properties:
+                lookbackDelta:
+                  description: The delta difference allowed for retrieving metrics
+                    during expression evaluations.
+                  type: string
+                maxConcurrency:
+                  description: Number of concurrent queries that can be run at once.
+                  format: int32
+                  type: integer
+                timeout:
+                  description: Maximum time a query may take before being aborted.
                   type: string
             remoteRead:
               description: If specified, the remote_read spec. This is an experimental
@@ -1916,6 +2071,11 @@ spec:
                         description: MinBackoff is the initial retry delay. Gets doubled
                           for every retry.
                         type: string
+                      minShards:
+                        description: MinShards is the minimum number of shards, i.e.
+                          amount of concurrency.
+                        format: int32
+                        type: integer
                   remoteTimeout:
                     description: Timeout for requests to the remote write endpoint.
                     type: string
@@ -2005,7 +2165,9 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
             retention:
-              description: Time duration Prometheus shall retain data for.
+              description: Time duration Prometheus shall retain data for. Default
+                is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)`
+                (milliseconds seconds minutes hours days weeks years).
               type: string
             routePrefix:
               description: The route prefix Prometheus registers HTTP handlers for.
@@ -2052,9 +2214,9 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
             ruleSelector:
               description: A label selector is a label query over a set of resources.
@@ -2094,10 +2256,29 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
+            rules:
+              description: /--rules.*/ command-line arguments
+              properties:
+                alert:
+                  description: /--rules.alert.*/ command-line arguments
+                  properties:
+                    forGracePeriod:
+                      description: Minimum duration between alert and restored 'for'
+                        state. This is maintained only for alerts with configured
+                        'for' time greater than grace period.
+                      type: string
+                    forOutageTolerance:
+                      description: Max time to tolerate prometheus outage for restoring
+                        'for' state of alert.
+                      type: string
+                    resendDelay:
+                      description: Minimum amount of time to wait before resending
+                        an alert to Alertmanager.
+                      type: string
             scrapeInterval:
               description: Interval between consecutive scrapes.
               type: string
@@ -2105,10 +2286,6 @@ spec:
               description: Secrets is a list of Secrets in the same namespace as the
                 Prometheus object, which shall be mounted into the Prometheus Pods.
                 The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
-                Secrets changes after initial creation of a Prometheus object are
-                not reflected in the running Pods. To change the secrets mounted into
-                the Prometheus Pods, the object must be deleted and recreated with
-                the new list of secrets.
               items:
                 type: string
               type: array
@@ -2121,7 +2298,9 @@ spec:
                 fsGroup:
                   description: |-
                     A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
                     1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
                     If unset, the Kubelet will not modify the ownership and permissions of any volume.
                   format: int64
                   type: integer
@@ -2236,9 +2415,9 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
             serviceMonitorSelector:
               description: A label selector is a label query over a set of resources.
@@ -2278,19 +2457,22 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
+            sha:
+              description: SHA of Prometheus container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
             storage:
               description: StorageSpec defines the configured storage for a group
-                Prometheus servers.
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
               properties:
-                class:
-                  description: 'Name of the StorageClass to use when requesting storage
-                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
-                    DEPRECATED'
-                  type: string
                 emptyDir:
                   description: Represents an empty directory for a pod. Empty directory
                     volumes support ownership management and SELinux relabeling.
@@ -2301,63 +2483,6 @@ spec:
                         Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       type: string
                     sizeLimit: {}
-                resources:
-                  description: ResourceRequirements describes the compute resource
-                    requirements.
-                  properties:
-                    limits:
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                selector:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                      type: array
-                    matchLabels:
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                                     of matchExpressions, whose key field is "key", the operator
-                                     is "In", and the values array contains only "value". The requirements
-                                     are ANDed.
-                      type: object
                 volumeClaimTemplate:
                   description: PersistentVolumeClaim is a user's request for and claim
                     to a persistent volume
@@ -2425,7 +2550,9 @@ spec:
                         generateName:
                           description: |-
                             GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
                             If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
                             Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
                           type: string
                         generation:
@@ -2493,6 +2620,7 @@ spec:
                                           field:
                                             description: |-
                                               The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
                                               Examples:
                                                 "name" - the field "name" on the current resource
                                                 "items[0].name" - the field "name" on the first array entry in "items"
@@ -2550,8 +2678,8 @@ spec:
                                   type: string
                                 metadata:
                                   description: ListMeta describes metadata that synthetic
-                                                 resources must have, including lists and various
-                                                 status objects. A resource may have only one of
+                                    resources must have, including lists and various
+                                    status objects. A resource may have only one of
                                     {ObjectMeta, ListMeta}.
                                   properties:
                                     continue:
@@ -2561,12 +2689,14 @@ spec:
                                         available. The value is opaque and may be
                                         used to issue another request to the endpoint
                                         that served this list to retrieve the next
-                                        set of available objects. Continuing a list
-                                        may not be possible if the server configuration
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
                                         has changed or more than a few minutes have
                                         passed. The resourceVersion field returned
                                         when using this continue value will be identical
-                                        to the value in the first response.
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
                                       type: string
                                     resourceVersion:
                                       description: 'String that identifies the server''s
@@ -2611,6 +2741,7 @@ spec:
                         namespace:
                           description: |-
                             Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
                             Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                           type: string
                         ownerReferences:
@@ -2622,20 +2753,20 @@ spec:
                             There cannot be more than one managing controller.
                           items:
                             description: OwnerReference contains enough information
-                              to let you identify an owning object. Currently, an
-                              owning object must be in the same namespace, so there
-                              is no namespace field.
+                              to let you identify an owning object. An owning object
+                              must be in the same namespace as the dependent, or be
+                              cluster-scoped, so there is no namespace field.
                             properties:
                               apiVersion:
                                 description: API version of the referent.
                                 type: string
                               blockOwnerDeletion:
                                 description: If true, AND if the owner has the "foregroundDeletion"
-                                               finalizer, then the owner cannot be deleted from
-                                               the key-value store until this reference is removed.
-                                               Defaults to false. To set this field, a user needs
-                                               "delete" permission of the owner, otherwise 422
-                                               (Unprocessable Entity) will be returned.
+                                  finalizer, then the owner cannot be deleted from
+                                  the key-value store until this reference is removed.
+                                  Defaults to false. To set this field, a user needs
+                                  "delete" permission of the owner, otherwise 422
+                                  (Unprocessable Entity) will be returned.
                                 type: boolean
                               controller:
                                 description: If true, this reference points to the
@@ -2659,6 +2790,7 @@ spec:
                         resourceVersion:
                           description: |-
                             An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
                             Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
                           type: string
                         selfLink:
@@ -2668,6 +2800,7 @@ spec:
                         uid:
                           description: |-
                             UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
                             Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                           type: string
                     spec:
@@ -2681,6 +2814,26 @@ spec:
                           items:
                             type: string
                           type: array
+                        dataSource:
+                          description: TypedLocalObjectReference contains enough information
+                            to let you locate the typed referenced object inside the
+                            same namespace.
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
                         resources:
                           description: ResourceRequirements describes the compute
                             resource requirements.
@@ -2747,8 +2900,7 @@ spec:
                         volumeMode:
                           description: volumeMode defines what type of volume is required
                             by the claim. Value of Filesystem is implied when not
-                            included in claim spec. This is an alpha feature and may
-                            change in the future.
+                            included in claim spec. This is a beta feature.
                           type: string
                         volumeName:
                           description: VolumeName is the binding reference to the
@@ -2814,7 +2966,7 @@ spec:
                           type: string
             tag:
               description: Tag of Prometheus container image to be deployed. Defaults
-                to the value of `version`.
+                to the value of `version`. Version is ignored if Tag is set.
               type: string
             thanos:
               description: ThanosSpec defines parameters for a Prometheus server within
@@ -2824,19 +2976,73 @@ spec:
                   description: Thanos base image if other than default.
                   type: string
                 gcs:
-                  description: ThanosGCSSpec defines parameters for use of Google
-                    Cloud Storage (GCS) with Thanos.
+                  description: 'Deprecated: ThanosGCSSpec should be configured with
+                    an ObjectStorageConfig secret starting with Thanos v0.2.0. ThanosGCSSpec
+                    will be removed.'
                   properties:
                     bucket:
                       description: Google Cloud Storage bucket name for stored blocks.
                         If empty it won't store any block inside Google Cloud Storage.
                       type: string
+                    credentials:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                image:
+                  description: Image if specified has precedence over baseImage, tag
+                    and sha combinations. Specifying the version is still necessary
+                    to ensure the Prometheus Operator knows what version of Thanos
+                    is being configured.
+                  type: string
+                objectStorageConfig:
+                  description: SecretKeySelector selects a key of a Secret.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    optional:
+                      description: Specify whether the Secret or it's key must be
+                        defined
+                      type: boolean
+                  required:
+                  - key
                 peers:
                   description: Peers is a DNS name for Thanos to discover peers through.
                   type: string
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
                 s3:
-                  description: ThanosSpec defines parameters for of AWS Simple Storage
-                    Service (S3) with Thanos. (S3 compatible services apply as well)
+                  description: 'Deprecated: ThanosS3Spec should be configured with
+                    an ObjectStorageConfig secret starting with Thanos v0.2.0. ThanosS3Spec
+                    will be removed.'
                   properties:
                     accessKey:
                       description: SecretKeySelector selects a key of a Secret.
@@ -2857,6 +3063,9 @@ spec:
                     bucket:
                       description: S3-Compatible API bucket name for stored blocks.
                       type: string
+                    encryptsse:
+                      description: Whether to use Server Side Encryption
+                      type: boolean
                     endpoint:
                       description: S3-Compatible API endpoint for stored blocks.
                       type: string
@@ -2884,9 +3093,16 @@ spec:
                       description: Whether to use S3 Signature Version 2; otherwise
                         Signature Version 4 will be used.
                       type: boolean
+                sha:
+                  description: SHA of Thanos container image to be deployed. Defaults
+                    to the value of `version`. Similar to a tag, but the SHA explicitly
+                    deploys an immutable container image. Version and Tag are ignored
+                    if SHA is set.
+                  type: string
                 tag:
                   description: Tag of Thanos sidecar container image to be deployed.
-                    Defaults to the value of `version`.
+                    Defaults to the value of `version`. Version is ignored if Tag
+                    is set.
                   type: string
                 version:
                   description: Version describes the version of Thanos to use.
@@ -2934,9 +3150,9 @@ spec:
               description: Version of Prometheus to be deployed.
               type: string
         status:
-          description: 'Most recent observed status of the Prometheus cluster. Read-only.
-            Not included when requesting from the apiserver, only from the Prometheus
-            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          description: 'PrometheusStatus is the most recent observed status of the
+            Prometheus cluster. Read-only. Not included when requesting from the apiserver,
+            only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             availableReplicas:
               description: Total number of available pods (ready for at least minReadySeconds)

--- a/upstream-community-operators/prometheus/prometheus.package.yaml
+++ b/upstream-community-operators/prometheus/prometheus.package.yaml
@@ -1,5 +1,5 @@
-#! package-manifest: deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.22.2.clusterserviceversion.yaml
+#! package-manifest: deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.27.0.clusterserviceversion.yaml
 packageName: prometheus
 channels:
-- name: preview
-  currentCSV: prometheusoperator-community.0.22.2
+- name: beta
+  currentCSV: prometheusoperator.0.27.0

--- a/upstream-community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
@@ -6,7 +6,15 @@ metadata:
   name: prometheusoperator.0.14.0
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
+    capabilities: Seamless Upgrades
+    categories: Monitoring
+    description: Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.
+    containerImage: quay.io/coreos/prometheus-operator:v0.14.0
+    createdAt: 2019-01-08T16:12:00Z
+    repository: https://github.com/coreos/prometheus-operator
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.7.1","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{},"ruleSelector":{},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
+    certified: "false"
+    support: Frederic Branczyk
 spec:
   displayName: Prometheus
   description: |

--- a/upstream-community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: prometheusoperator-community.0.14.0
+  name: prometheusoperator.0.14.0
   namespace: placeholder
   annotations:
     capabilities: Full Lifecycle

--- a/upstream-community-operators/prometheus/prometheusoperator.0.15.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/prometheus/prometheusoperator.0.15.0.clusterserviceversion.yaml
@@ -6,9 +6,15 @@ metadata:
   name: prometheusoperator.0.15.0
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
-    tectonic-visibility: ocs
-    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+    capabilities: Seamless Upgrades
+    categories: Monitoring
+    description: Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.
+    containerImage: quay.io/coreos/prometheus-operator:v0.15.0
+    createdAt: 2019-01-08T16:12:00Z
+    repository: https://github.com/coreos/prometheus-operator
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.7.1","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{},"ruleSelector":{},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
+    certified: "false"
+    support: Frederic Branczyk
 spec:
   replaces: prometheusoperator.0.14.0
   displayName: Prometheus

--- a/upstream-community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -6,10 +6,15 @@ metadata:
   name: prometheusoperator.0.22.2
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
-    categories: "OpenShift Optional, Monitoring"
-    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.3.2","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
-    description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
+    capabilities: Seamless Upgrades
+    categories: Monitoring
+    description: Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.
+    containerImage: quay.io/coreos/prometheus-operator:v0.22.2
+    createdAt: 2019-01-08T16:12:00Z
+    repository: https://github.com/coreos/prometheus-operator
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.7.1","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{},"ruleSelector":{},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"PrometheusRule","metadata":{"creationTimestamp":null,"labels":{"prometheus":"example","role":"alert-rules"},"name":"prometheus-example-rules"},"spec":{"groups":[{"name":"./example.rules","rules":[{"alert":"ExampleAlert","expr":"vector(1)"}]}]}}]'
+    certified: "false"
+    support: Frederic Branczyk
 spec:
   replaces: prometheusoperator.0.15.0
   displayName: Prometheus Operator

--- a/upstream-community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: prometheusoperator-community.0.22.2
+  name: prometheusoperator.0.22.2
   namespace: placeholder
   annotations:
     capabilities: Full Lifecycle
@@ -11,7 +11,7 @@ metadata:
     alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.3.2","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
     description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 spec:
-  replaces: prometheusoperator-community.0.15.0
+  replaces: prometheusoperator.0.15.0
   displayName: Prometheus Operator
   description: |
     The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.

--- a/upstream-community-operators/prometheus/prometheusoperator.0.27.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/prometheus/prometheusoperator.0.27.0.clusterserviceversion.yaml
@@ -3,65 +3,65 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: prometheusoperator.0.15.0
+  name: prometheusoperator.0.27.0
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
-    tectonic-visibility: ocs
-    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+    capabilities: Seamless Upgrades
+    categories: Monitoring
+    description: Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.
+    containerImage: quay.io/coreos/prometheus-operator:v0.27.0
+    createdAt: 2019-01-08T16:12:00Z
+    repository: https://github.com/coreos/prometheus-operator
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.7.1","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{},"ruleSelector":{},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"PrometheusRule","metadata":{"creationTimestamp":null,"labels":{"prometheus":"example","role":"alert-rules"},"name":"prometheus-example-rules"},"spec":{"groups":[{"name":"./example.rules","rules":[{"alert":"ExampleAlert","expr":"vector(1)"}]}]}}]'
+    certified: "false"
+    support: Frederic Branczyk
 spec:
-  replaces: prometheusoperator.0.14.0
-  displayName: Prometheus
+  replaces: prometheusoperator.0.22.2
+  displayName: Prometheus Operator
   description: |
-    An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+    The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 
-    _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+    Once installed, the Prometheus Operator provides the following features:
 
-    ### Monitoring applications
+    * **Create/Destroy**: Easily launch a Prometheus instance for your Kubernetes namespace, a specific application or team easily using the Operator.
 
-    Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+    * **Simple Configuration**: Configure the fundamentals of Prometheus like versions, persistence, retention policies, and replicas from a native Kubernetes resource.
 
-    [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+    * **Target Services via Labels**: Automatically generate monitoring target configurations based on familiar Kubernetes label queries; no need to learn a Prometheus specific configuration language.
 
-    ### Supported Features
-
+    ### Other Supported Features
 
     **High availability**
 
-
     Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
-
 
     **Updates via automated operations**
 
-
     New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
-
 
     **Handles the dynamic nature of containers**
 
-
     Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
 
-  keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+  keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting', 'observability']
 
   maintainers:
-  - name: CoreOS, Inc
-    email: support@coreos.com
+  - name: Red Hat
+    email: openshift-operators@redhat.com
 
   provider:
-    name: CoreOS, Inc
+    name: Red Hat
 
   links:
   - name: Prometheus
     url: https://www.prometheus.io/
   - name: Documentation
-    url: https://coreos.com/operators/prometheus/docs/latest/
-  - name: Prometheus Operator Source Code
+    url: https://github.com/coreos/prometheus-operator/tree/master/Documentation
+  - name: Prometheus Operator
     url: https://github.com/coreos/prometheus-operator
 
   labels:
-    alm-status-descriptors: prometheusoperator.0.15.0
+    alm-status-descriptors: prometheusoperator.0.27.0
     alm-owner-prometheus: prometheusoperator
 
   selector:
@@ -78,10 +78,10 @@ spec:
   - type: SingleNamespace
     supported: true
   - type: MultiNamespace
-    supported: false
-  - type: AllNamespaces
     supported: true
-    
+  - type: AllNamespaces
+    supported: false
+
   install:
     strategy: deployment
     spec:
@@ -99,48 +99,69 @@ spec:
           resources:
           - configmaps
           verbs: ["get"]
-      - serviceAccountName: prometheus-operator-0-14-0
+      - serviceAccountName: prometheus-operator-0-27-0
         rules:
         - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
-          verbs: ["get", "list"]
+          verbs:
+          - '*'
         - apiGroups:
           - monitoring.coreos.com
           resources:
           - alertmanagers
           - prometheuses
+          - prometheuses/finalizers
+          - alertmanagers/finalizers
           - servicemonitors
+          - prometheusrules
           verbs:
-          - "*"
+          - '*'
         - apiGroups:
           - apps
           resources:
           - statefulsets
-          verbs: ["*"]
-        - apiGroups: [""]
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
           resources:
           - configmaps
           - secrets
-          verbs: ["*"]
-        - apiGroups: [""]
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
           resources:
           - pods
-          verbs: ["list", "delete"]
-        - apiGroups: [""]
+          verbs:
+          - list
+          - delete
+        - apiGroups:
+          - ""
           resources:
           - services
           - endpoints
-          verbs: ["get", "create", "update"]
-        - apiGroups: [""]
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ""
           resources:
           - nodes
-          verbs: ["list", "watch"]
-        - apiGroups: [""]
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - ""
           resources:
           - namespaces
-          verbs: ['list']
+          verbs:
+          - get
+          - list
+          - watch
       deployments:
       - name: prometheus-operator
         spec:
@@ -153,23 +174,21 @@ spec:
               labels:
                 k8s-app: prometheus-operator
             spec:
-              serviceAccount: prometheus-operator-0-14-0
+              serviceAccount: prometheus-operator-0-27-0
               containers:
               - name: prometheus-operator
-                image: quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d
-                command:
-                  - sh
-                  - -c
-                  - >
-                    /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
-                    --labels alm-status-descriptors=prometheusoperator.0.15.0,alm-owner-prometheus=prometheusoperator
-                    --kubelet-service=kube-system/kubelet
-                    --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                image: quay.io/coreos/prometheus-operator@sha256:933cd5bf380cf7db330808ff54f75f26fda0b1501021d499a1766b7d16224188
+                args:
+                - -namespaces=$(NAMESPACES)
+                - -manage-crds=false
+                - -logtostderr=true
+                - --config-reloader-image=quay.io/coreos/configmap-reload@sha256:e2fd60ff0ae4500a75b80ebaa30e0e7deba9ad107833e8ca53f0047c42c5a057
+                - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader@sha256:61b7969fd1336fd4bbac0622f9e4281f2a2b4ae02ad55748b6fdc65e2be69b73
                 env:
-                  - name: K8S_NAMESPACE
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.namespace
+                - name: NAMESPACES
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 ports:
                 - containerPort: 8080
                   name: http
@@ -180,8 +199,13 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 50Mi
-  maturity: alpha
-  version: 0.15.0
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+              nodeSelector:
+                beta.kubernetes.io/os: linux
+  maturity: beta
+  version: 0.27.0
   customresourcedefinitions:
     owned:
     - name: prometheuses.monitoring.coreos.com
@@ -190,79 +214,76 @@ spec:
       displayName: Prometheus
       description: A running Prometheus instance
       resources:
-        - kind: StatefulSet
-          version: v1beta2
-        - kind: Pod
-          version: v1
+      - kind: StatefulSet
+        version: v1beta2
+      - kind: Pod
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: Service
+        version: v1
       specDescriptors:
       - description: Desired number of Pods for the cluster
         displayName: Size
         path: replicas
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
       - description: A selector for the ConfigMaps from which to load rule files
         displayName: Rule Config Map Selector
         path: ruleSelector
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
       - description: ServiceMonitors to be selected for target discovery
         displayName: Service Monitor Selector
         path: serviceMonitorSelector
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
       - description: The ServiceAccount to use to run the Prometheus pods
         displayName: Service Account
         path: serviceAccountName
         x-descriptors:
-          - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+        - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
       - description: Limits describes the minimum/maximum amount of compute resources required/allowed
         displayName: Resource Requirements
         path: resources
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
-      statusDescriptors:
-        - description: The current number of Pods for the cluster
-          displayName: Cluster Size
-          path: replicas
-        - path: prometheusSelector
-          displayName: Prometheus Service Selector
-          description: Label selector to find the service that routes to this prometheus
-          x-descriptors:
-          - 'urn:alm:descriptor:label:selector'
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+    - name: prometheusrules.monitoring.coreos.com
+      version: v1
+      kind: PrometheusRule
+      displayName: Prometheus Rule
+      description: A Prometheus Rule configures groups of sequentially evaluated recording and alerting rules.
     - name: servicemonitors.monitoring.coreos.com
       version: v1
       kind: ServiceMonitor
       displayName: Service Monitor
       description: Configures prometheus to monitor a particular k8s service
       resources:
-        - kind: Pod
-          version: v1
+      - kind: Pod
+        version: v1
       specDescriptors:
-      - description: Selector to select which namespaces the Endpoints objects are discovered from
-        displayName: Monitoring Namespaces
-        path: namespaceSelector
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
       - description: The label to use to retrieve the job name from
         displayName: Job Label
         path: jobLabel
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
       - description: A list of endpoints allowed as part of this ServiceMonitor
         displayName: Endpoints
         path: endpoints
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+        - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
     - name: alertmanagers.monitoring.coreos.com
       version: v1
       kind: Alertmanager
-      displayName: Alert Manager
-      description: Configures an Alert Manager for the namespace
+      displayName: Alertmanager
+      description: Configures an Alertmanager for the namespace
       resources:
-        - kind: StatefulSet
-          version: v1beta2
-        - kind: Pod
-          version: v1
+      - kind: StatefulSet
+        version: v1beta2
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
       specDescriptors:
       - description: Desired number of Pods for the cluster
         displayName: Size
@@ -273,4 +294,4 @@ spec:
         displayName: Resource Requirements
         path: resources
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'

--- a/upstream-community-operators/prometheus/prometheusrule.crd.yaml
+++ b/upstream-community-operators/prometheus/prometheusrule.crd.yaml
@@ -1,6 +1,8 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -11,6 +13,295 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: ObjectMeta is metadata that all persisted resources must have,
+            which includes all objects users must create.
+          properties:
+            annotations:
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+            clusterName:
+              description: The name of the cluster which the object belongs to. This
+                is used to distinguish resources with same name and namespace in different
+                clusters. This field is not set anywhere right now and apiserver is
+                going to ignore it if set in create or update request.
+              type: string
+            creationTimestamp:
+              description: Time is a wrapper around time.Time which supports correct
+                marshaling to YAML and JSON.  Wrappers are provided for many of the
+                factory methods that the time package offers.
+              format: date-time
+              type: string
+            deletionGracePeriodSeconds:
+              description: Number of seconds allowed for this object to gracefully
+                terminate before it will be removed from the system. Only set when
+                deletionTimestamp is also set. May only be shortened. Read-only.
+              format: int64
+              type: integer
+            deletionTimestamp:
+              description: Time is a wrapper around time.Time which supports correct
+                marshaling to YAML and JSON.  Wrappers are provided for many of the
+                factory methods that the time package offers.
+              format: date-time
+              type: string
+            finalizers:
+              description: Must be empty before the object is deleted from the registry.
+                Each entry is an identifier for the responsible component that will
+                remove the entry from the list. If the deletionTimestamp of the object
+                is non-nil, entries in this list can only be removed.
+              items:
+                type: string
+              type: array
+            generateName:
+              description: |-
+                GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+              type: string
+            generation:
+              description: A sequence number representing a specific generation of
+                the desired state. Populated by the system. Read-only.
+              format: int64
+              type: integer
+            initializers:
+              description: Initializers tracks the progress of initialization.
+              properties:
+                pending:
+                  description: Pending is a list of initializers that must execute
+                    in order before this object is visible. When the last pending
+                    initializer is removed, and no failing result is set, the initializers
+                    struct will be set to nil and the object is considered as initialized
+                    and visible to all clients.
+                  items:
+                    description: Initializer is information about an initializer that
+                      has not yet completed.
+                    properties:
+                      name:
+                        description: name of the process that is responsible for initializing
+                          this object.
+                        type: string
+                    required:
+                    - name
+                  type: array
+                result:
+                  description: Status is a return value for calls that don't return
+                    other objects.
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    code:
+                      description: Suggested HTTP return code for this status, 0 if
+                        not set.
+                      format: int32
+                      type: integer
+                    details:
+                      description: StatusDetails is a set of additional properties
+                        that MAY be set by the server to provide additional information
+                        about a response. The Reason field of a Status object defines
+                        what attributes will be set. Clients must ignore fields that
+                        do not match the defined type of each attribute, and should
+                        assume that any attribute may be empty, invalid, or under
+                        defined.
+                      properties:
+                        causes:
+                          description: The Causes array includes more details associated
+                            with the StatusReason failure. Not all StatusReasons may
+                            provide detailed causes.
+                          items:
+                            description: StatusCause provides more information about
+                              an api.Status failure, including cases when multiple
+                              errors are encountered.
+                            properties:
+                              field:
+                                description: |-
+                                  The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                  Examples:
+                                    "name" - the field "name" on the current resource
+                                    "items[0].name" - the field "name" on the first array entry in "items"
+                                type: string
+                              message:
+                                description: A human-readable description of the cause
+                                  of the error.  This field may be presented as-is
+                                  to a reader.
+                                type: string
+                              reason:
+                                description: A machine-readable description of the
+                                  cause of the error. If this value is empty there
+                                  is no information available.
+                                type: string
+                          type: array
+                        group:
+                          description: The group attribute of the resource associated
+                            with the status StatusReason.
+                          type: string
+                        kind:
+                          description: 'The kind attribute of the resource associated
+                            with the status StatusReason. On some operations may differ
+                            from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: The name attribute of the resource associated
+                            with the status StatusReason (when there is a single name
+                            which can be described).
+                          type: string
+                        retryAfterSeconds:
+                          description: If specified, the time in seconds before the
+                            operation should be retried. Some errors may indicate
+                            the client must take an alternate action - for those errors
+                            this field may indicate how long to wait before taking
+                            the alternate action.
+                          format: int32
+                          type: integer
+                        uid:
+                          description: 'UID of the resource. (when there is a single
+                            resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    message:
+                      description: A human-readable description of the status of this
+                        operation.
+                      type: string
+                    metadata:
+                      description: ListMeta describes metadata that synthetic resources
+                        must have, including lists and various status objects. A resource
+                        may have only one of {ObjectMeta, ListMeta}.
+                      properties:
+                        continue:
+                          description: continue may be set if the user set a limit
+                            on the number of items returned, and indicates that the
+                            server has more data available. The value is opaque and
+                            may be used to issue another request to the endpoint that
+                            served this list to retrieve the next set of available
+                            objects. Continuing a consistent list may not be possible
+                            if the server configuration has changed or more than a
+                            few minutes have passed. The resourceVersion field returned
+                            when using this continue value will be identical to the
+                            value in the first response, unless you have received
+                            this token from an error message.
+                          type: string
+                        resourceVersion:
+                          description: 'String that identifies the server''s internal
+                            version of this object that can be used by clients to
+                            determine when objects have changed. Value must be treated
+                            as opaque by clients and passed unmodified back to the
+                            server. Populated by the system. Read-only. More info:
+                            https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        selfLink:
+                          description: selfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                    reason:
+                      description: A machine-readable description of why this operation
+                        is in the "Failure" status. If this value is empty there is
+                        no information available. A Reason clarifies an HTTP status
+                        code but does not override it.
+                      type: string
+                    status:
+                      description: 'Status of the operation. One of: "Success" or
+                        "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                      type: string
+              required:
+              - pending
+            labels:
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: |-
+                Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+              type: string
+            ownerReferences:
+              description: List of objects depended by this object. If ALL objects
+                in the list have been deleted, this object will be garbage collected.
+                If this object is managed by a controller, then an entry in this list
+                will point to this controller, with the controller field set to true.
+                There cannot be more than one managing controller.
+              items:
+                description: OwnerReference contains enough information to let you
+                  identify an owning object. An owning object must be in the same
+                  namespace as the dependent, or be cluster-scoped, so there is no
+                  namespace field.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  blockOwnerDeletion:
+                    description: If true, AND if the owner has the "foregroundDeletion"
+                      finalizer, then the owner cannot be deleted from the key-value
+                      store until this reference is removed. Defaults to false. To
+                      set this field, a user needs "delete" permission of the owner,
+                      otherwise 422 (Unprocessable Entity) will be returned.
+                    type: boolean
+                  controller:
+                    description: If true, this reference points to the managing controller.
+                    type: boolean
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                - uid
+              type: array
+            resourceVersion:
+              description: |-
+                An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+              type: string
+            selfLink:
+              description: SelfLink is a URL representing this object. Populated by
+                the system. Read-only.
+              type: string
+            uid:
+              description: |-
+                UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+              type: string
         spec:
           description: PrometheusRuleSpec contains specification parameters for a
             Rule.
@@ -34,7 +325,9 @@ spec:
                         annotations:
                           type: object
                         expr:
-                          type: string
+                          anyOf:
+                          - type: string
+                          - type: integer
                         for:
                           type: string
                         labels:

--- a/upstream-community-operators/prometheus/servicemonitor.crd.yaml
+++ b/upstream-community-operators/prometheus/servicemonitor.crd.yaml
@@ -1,6 +1,8 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -11,6 +13,16 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
         spec:
           description: ServiceMonitorSpec contains specification parameters for a
             ServiceMonitor.
@@ -125,6 +137,51 @@ spec:
                     description: ProxyURL eg http://proxyserver:2195 Directs scrapes
                       to proxy through this endpoint.
                     type: string
+                  relabelings:
+                    description: 'RelabelConfigs to apply to samples before ingestion.
+                      More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
                   scheme:
                     description: HTTP scheme to use for scraping.
                     type: string
@@ -158,7 +215,7 @@ spec:
               description: The label to use to retrieve the job name from.
               type: string
             namespaceSelector:
-              description: A selector for selecting namespaces either selecting all
+              description: NamespaceSelector is a selector for selecting either all
                 namespaces or a list of namespaces.
               properties:
                 any:
@@ -170,6 +227,17 @@ spec:
                   items:
                     type: string
                   type: array
+            podTargetLabels:
+              description: PodTargetLabels transfers labels on the Kubernetes Pod
+                onto the target.
+              items:
+                type: string
+              type: array
+            sampleLimit:
+              description: SampleLimit defines per-scrape limit on number of scraped
+                samples that will be accepted.
+              format: int64
+              type: integer
             selector:
               description: A label selector is a label query over a set of resources.
                 The result of matchLabels and matchExpressions are ANDed. An empty
@@ -208,9 +276,9 @@ spec:
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
                     {key,value} in the matchLabels map is equivalent to an element
-                                 of matchExpressions, whose key field is "key", the operator is
-                                 "In", and the values array contains only "value". The requirements
-                                 are ANDed.
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
                   type: object
             targetLabels:
               description: TargetLabels transfers labels on the Kubernetes Service


### PR DESCRIPTION
This PR adds a ClusterServiceVersion for the Prometheus Operator v0.27.0. I chose this version as it is what we are currently building RHEL based images for for the cluster-monitoring stack.

@mxinden @s-urbaniak @metalmatze @squat @ant31 please keep an eye on this as I'm about to go on PTO.