### PR TITLE
[Kubernetes] Add Jaeger Operator.

### DIFF
--- a/upstream-community-operators/jaeger/jaeger.crd.yaml
+++ b/upstream-community-operators/jaeger/jaeger.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: jaegers.io.jaegertracing
+spec:
+  group: io.jaegertracing
+  names:
+    kind: Jaeger
+    listKind: JaegerList
+    plural: jaegers
+    singular: jaeger
+  scope: Namespaced
+  version: v1alpha1

--- a/upstream-community-operators/jaeger/jaeger.package.yaml
+++ b/upstream-community-operators/jaeger/jaeger.package.yaml
@@ -1,0 +1,4 @@
+packageName: jaeger
+channels:
+- name: alpha
+  currentCSV: jaeger-operator.v1.8.2

--- a/upstream-community-operators/jaeger/jaeger.v1.8.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/jaeger/jaeger.v1.8.2.clusterserviceversion.yaml
@@ -1,0 +1,182 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: jaeger-operator.v1.8.2
+  namespace: placeholder
+  annotations:
+    categories: "Logging & Tracing"
+    certified: "false"
+    containerImage: docker.io/jaegertracing/jaeger-operator:1.8.2
+    createdAt:  2019-01-09T12:00:00Z
+    support: Jaeger
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "io.jaegertracing/v1alpha1",
+          "kind": "Jaeger",
+          "metadata": {
+            "name": "my-jaeger"
+          },
+          "spec": {
+            "strategy": "allInOne",
+            "allInOne": {
+              "image": "jaegertracing/all-in-one:1.8",
+              "options": {
+                "log-level": "debug",
+                "query": {
+                  "base-path": "/jaeger"
+                }
+              }
+            },
+            "ui": {
+              "options": {
+                "dependencies": {
+                  "menuEnabled": false
+                },
+                "tracking": {
+                  "gaID": "UA-000000-2"
+                },
+                "menu": [
+                  {
+                    "label": "About Jaeger",
+                    "items": [
+                      {
+                        "label": "Documentation",
+                        "url": "https://www.jaegertracing.io/docs/latest"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "storage": {
+              "options": {
+                "memory": {
+                  "max-traces": 100000
+                }
+              }
+            }
+          }
+        }
+      ]
+spec:
+  displayName: jaeger-operator
+  description: |-
+    Provides monitoring and troubleshooting microservices-based distributed systems
+  keywords: ['tracing', 'monitoring', 'troubleshooting']
+  version: 1.8.2
+  maintainers:
+  - name: Jaeger Google Group
+    email: jaeger-tracing@googlegroups.com
+  provider:
+    name: Jaeger
+  labels:
+    name: jaeger-operator
+  selector:
+    matchLabels:
+      name: jaeger-operator
+  links:
+  - name: Jaeger Operator Source Code
+    url: https://github.com/jaegertracing/jaeger-operator
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: jaeger-operator
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - io.jaegertracing
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - "*"
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          - cronjobs
+          verbs:
+          - "*"
+      deployments:
+      - name: jaeger-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: jaeger-operator
+          template:
+            metadata:
+              labels:
+                name: jaeger-operator
+            spec:
+              serviceAccountName: jaeger-operator
+              containers:
+                - name: jaeger-operator
+                  image: jaegertracing/jaeger-operator:1.8.2
+                  ports:
+                  - containerPort: 60000
+                    name: metrics
+                  args: ["start"]
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.annotations['olm.targetNamespaces']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "jaeger-operator"
+  customresourcedefinitions:
+    owned:
+    - name: jaegers.io.jaegertracing
+      version: v1alpha1
+      kind: Jaeger
+      displayName: Jaeger
+      description: A configuration file for a Jaeger custom resource.


### PR DESCRIPTION
	* Create community-operators/upstream-community-operators directory to host k8s versions of operators
	* Create community-operators/upstream-community-operators/jaeger directory to host csv, crd and package yamls