### PR TITLE
[docs] Add instructions for testing operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ my-operator-crd1.crd.yaml
 my-operator-crd2.crd.yaml
 my-operator.package.yaml
 ```
+Please note that the directory name should match the name of your operator in it's package.yaml.
 
 Each OperatorHub entry contains all of the Custom Resource Definitions (CRDs), access control rules and references to the container image needed to install and securely run your Operator, plus other info like a description of its features and supported Kubernetes versions. [Follow this guide to create an OLM-compatible CSV for your operator](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md), CRDs, and the package.yaml file for your operator.
 

--- a/docs/testing-operators.md
+++ b/docs/testing-operators.md
@@ -1,9 +1,42 @@
 # Testing Operators
 
+This guide is targeted towards operator authors who are targetting their operators to be available on OpenShift 4.0
+clusters through OperatorHub and want to test that end to end workflow.
+
 ## Testing the full end-to-end flow
 
-todo: add guide
+### Pre-Requisite
 
-## Testing locally or offline
+You need to have an account with `quay.io`. If you don't have one you can sign up for it at [quay.io](https://quay.io).
 
-todo: add guide
+### Create your Quay app-registry repository
+
+OperatorHub uses Quay's application repositories for storing the operator bundle. Follow [these instructions](https://docs.quay.io/guides/create-repo.html)
+to create your own application repository. Please note that the name of the repository should match the name of the
+operator in it's package. Example: for the following package, the Quay repository name will be `myoperator`:
+```
+packageName: myoperator
+channels:
+- name: preview
+  currentCSV: myoperator.0.1.1
+```
+
+### Pushing your operator bundle to Quay
+
+Collect all your operator bundles files into a directory. You can then use the
+[operator-courier](https://github.com/operator-framework/operator-courier/#usage)
+tool to verify and push your operator bundle to the Quay application repository you created.
+
+Please note that we only support CRDs, CSVs and Packages to be present in your bundle.
+
+### Linking the Quay application repository to your OpenShift 4.0 cluster
+
+For OpenShift to become aware of the Quay application repository, an
+[`OperatorSource` CR](https://github.com/operator-framework/operator-marketplace#description)
+need to be added to the cluster. An example `OperatorSource` is provided [here](https://github.com/operator-framework/operator-marketplace/blob/master/deploy/examples/operatorsource.cr.yaml).
+If your Quay repository is private, please follow [these](https://github.com/operator-framework/operator-marketplace/blob/master/docs/how-to-authenticate-private-repositories.md) instructions.
+
+### Testing your operator
+
+Once the `OperatorSource` CR has been added to the cluster, the new operator will show up on the OperatorHub UI. You can
+then either install it from the UI or follow the command line [instructions](https://github.com/operator-framework/operator-marketplace#installing-an-operator-using-marketplace).


### PR DESCRIPTION
Add instructions for end to end testing of operators, starting from their bundle, pushing to Quay and installing their operator.