### PR TITLE
certified: move get/watch PV into cluster permission

### DIFF
--- a/certified-operators/couchbase-enterprise/couchbase.1.1.0.clusterserviceversion.yaml
+++ b/certified-operators/couchbase-enterprise/couchbase.1.1.0.clusterserviceversion.yaml
@@ -201,6 +201,16 @@ spec:
                       initialDelaySeconds: 3
                       periodSeconds: 3
                 serviceAccountName: couchbase-operator
+      clusterPermissions:
+        - serviceAccountName: couchbase-operator
+          rules:
+            - apiGroups:
+                - ''
+              resources:
+                - persistentvolumes
+              verbs:
+                - get
+                - watch
       permissions:
         - rules:
             - apiGroups:
@@ -232,13 +242,6 @@ spec:
                 - secrets
               verbs:
                 - '*'
-            - apiGroups:
-                - ''
-              resources:
-                - persistentvolumes
-              verbs:
-                - get
-                - watch
             - apiGroups:
                 - apps
               resources:


### PR DESCRIPTION
Fixes https://github.com/operator-framework/community-operators/issues/79