### PR TITLE
Move operator maturity levels into annotations

### DIFF
--- a/certified-operators/couchbase-enterprise/couchbase.1.0.0.clusterserviceversion.yaml
+++ b/certified-operators/couchbase-enterprise/couchbase.1.0.0.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    capabilities: Seamless Upgrades
     description: The Couchbase Autonomous Operator allows users to easily deploy, manage, and maintain Couchbase deployments on OpenShift.
     alm-examples: >-
       [{"apiVersion":"couchbase.com/v1","kind":"CouchbaseCluster","metadata":{"name":"cb-example","namespace":"default"},"spec":{"authSecret":"cb-example-auth","baseImage":"registry.connect.redhat.com/couchbase/server","buckets":[{"conflictResolution":"seqno","enableFlush":true,"evictionPolicy":"fullEviction","ioPriority":"high","memoryQuota":128,"name":"default","replicas":1,"type":"couchbase"}],"cluster":{"analyticsServiceMemoryQuota":1024,"autoFailoverMaxCount":3,"autoFailoverOnDataDiskIssues":true,"autoFailoverOnDataDiskIssuesTimePeriod":120,"autoFailoverServerGroup":false,"autoFailoverTimeout":120,"clusterName":"cb-example","dataServiceMemoryQuota":256,"eventingServiceMemoryQuota":256,"indexServiceMemoryQuota":256,"indexStorageSetting":"memory_optimized","searchServiceMemoryQuota":256},"servers":[{"name":"all_services","services":["data","index","query","search","eventing","analytics"],"size":3}],"version":"5.5.1-1"}}]
@@ -138,7 +139,7 @@ spec:
   displayName: Couchbase Operator
   provider:
     name: Couchbase
-  maturity: Seamless Upgrades
+  maturity: stable
   version: 1.0.0
   icon:
     - base64data: >-

--- a/certified-operators/couchbase-enterprise/couchbase.1.1.0.clusterserviceversion.yaml
+++ b/certified-operators/couchbase-enterprise/couchbase.1.1.0.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    capabilities: Seamless Upgrades
     categories: "Database"
     description: The Couchbase Autonomous Operator allows users to easily deploy, manage, and maintain Couchbase deployments on OpenShift.
     alm-examples: >-
@@ -139,7 +140,7 @@ spec:
   displayName: Couchbase Operator
   provider:
     name: Couchbase
-  maturity: Seamless Upgrades
+  maturity: stable
   version: 1.1.0
   replaces: couchbase-operator.v1.0.0
   icon:

--- a/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.3.2.clusterserviceversion.yaml
+++ b/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.3.2.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   name: mongodboperator.v0.3.2
   namespace: placeholder
   annotations:
+    capabilities: Full Lifecycle
     categories: "Database"
     description: The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB into Kubernetes clusters, using our management, monitoring and backup platforms, Ops Manager and Cloud Manager.
     alm-examples: >-
@@ -14,7 +15,7 @@ spec:
   displayName: MongoDB
   provider:
     name: 'MongoDB, Inc'
-  maturity: Full Lifecycle
+  maturity: stable
   version: 0.3.2
   keywords: ["mongodb", "database", "nosql"]
   maintainers:

--- a/community-operators/automationbroker/automationbrokeroperator.v0.2.0.clusterserviceversion.yaml
+++ b/community-operators/automationbroker/automationbrokeroperator.v0.2.0.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: placeholder
   annotations:
     alm-examples: '[{"apiVersion":"osb.openshift.io/v1alpha1","kind":"AutomationBroker","metadata":{"name":"ansible-service-broker","namespace":"openshift-ansible-service-broker"},"spec":{"createBrokerNamespace":"false","waitForBroker":"false"}}]'
+    capabilities: Seamless Upgrades
     categories: 'OpenShift Optional, Integration & Delivery'
     description: Automation Broker is an implementation of the Open Service Broker API managing applications defined in Ansible Playbook Bundles
 spec:
@@ -20,7 +21,7 @@ spec:
     Check out the [Keynote Demo from Red Hat Summit 2017](https://youtu.be/8MCbJmZQM9c?list=PLEGSLwUsxfEh4TE2GDU4oygCB-tmShkSn&t=4732)
   keywords: ['ansible', 'automation', 'broker', 'open service broker']
   version: 0.2.0
-  maturity: Seamless Upgrades
+  maturity: alpha
   maintainers:
   - name: Red Hat, Inc.
     email: ansible-service-broker@redhat.com

--- a/community-operators/cluster-logging/clusterlogging.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/cluster-logging/clusterlogging.v0.0.1.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   name: clusterlogging.v0.0.1
   namespace: placeholder
   annotations:
+    capabilities: Seamless Upgrades
     categories: "OpenShift Optional, Logging & Tracing"
     certified: "false"
     description: |-
@@ -66,8 +67,6 @@ spec:
     * **Simplified Configuration**: Configure your aggregated logging cluster's structure like components and end points easily.
 
   keywords: ['elasticsearch', 'kibana', 'fluentd', 'logging', 'aggregated', 'efk']
-
-  maturity: Seamless Upgrades
 
   maintainers:
   - name: Red Hat

--- a/community-operators/descheduler/descheduler.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/descheduler/descheduler.v0.0.1.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    capabilities: Seamless Upgrades
     categories: "OpenShift Optional"
     certifiedLevel: Primed
     containerImage: registry.svc.ci.openshift.org/openshift/origin-v4.0:descheduler-operator
@@ -45,7 +46,6 @@ spec:
       Any api could be changed any time with out any notice. That said, your feedback is
       very important and appreciated to make this project more stable and useful.
    
-  maturity: Seamless Upgrades
   customresourcedefinitions:
     owned:
     - description: Represents an instance of a Descheduler application

--- a/community-operators/etcd/etcdoperator.clusterserviceversion.yaml
+++ b/community-operators/etcd/etcdoperator.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   name: etcdoperator.v0.6.1
   namespace: placeholder
   annotations:
+    capabilities: Full Lifecycle
     tectonic-visibility: ocs
     description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
@@ -31,7 +32,7 @@ spec:
     Coming soon, the ability to schedule backups to happen on or off cluster.
   keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
   version: 0.6.1
-  maturity: Full Lifecycle
+  maturity: alpha
   maintainers:
   - name: CoreOS, Inc
     email: support@coreos.com

--- a/community-operators/etcd/etcdoperator.v0.9.0.clusterserviceversion.yaml
+++ b/community-operators/etcd/etcdoperator.v0.9.0.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   name: etcdoperator.v0.9.0
   namespace: placeholder
   annotations:
+    capabilities: Full Lifecycle
     tectonic-visibility: ocs
     alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
     description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
@@ -44,7 +45,7 @@ spec:
     Coming soon, the ability to schedule backups to happen on or off cluster.
   keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
   version: 0.9.0
-  maturity: Full Lifecycle
+  maturity: alpha
   replaces: etcdoperator.v0.6.1
   maintainers:
   - name: CoreOS, Inc

--- a/community-operators/etcd/etcdoperator.v0.9.2.clusterserviceversion.yaml
+++ b/community-operators/etcd/etcdoperator.v0.9.2.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: placeholder
   annotations:
     tectonic-visibility: ocs
+    capabilities: Full Lifecycle
     categories: "Database"
     alm-examples: |
       [
@@ -105,7 +106,7 @@ spec:
     Coming soon, the ability to schedule backups to happen on or off cluster.
   keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
   version: 0.9.2
-  maturity: Full Lifecycle
+  maturity: alpha
   replaces: etcdoperator.v0.9.0
   maintainers:
   - name: CoreOS, Inc

--- a/community-operators/federationv2/federationv2.v0.0.2.clusterserviceversion.yaml
+++ b/community-operators/federationv2/federationv2.v0.0.2.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   name: federationv2.v0.0.2
   namespace: placeholder
   annotations:
+    capabilities: Basic Install
     categories: "OpenShift Optional, Integration & Delivery"
     description: Kubernetes Federation V2 namespace-scoped installation
 spec:
@@ -14,7 +15,7 @@ spec:
     Kubernetes Federation V2 namespace-scoped installation
   keywords: ['kubernetes', 'federation', 'hybrid', 'hybrid cloud', 'multi-cluster', 'cluster']
   version: 0.0.2
-  maturity: Basic Install
+  maturity: alpha
   provider:
     name: Red Hat, Inc
   labels:

--- a/community-operators/jaeger/jaeger.v1.8.2.clusterserviceversion.yaml
+++ b/community-operators/jaeger/jaeger.v1.8.2.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   name: jaeger-operator.v1.8.2
   namespace: placeholder
   annotations:
+    capabilities: Seamless Upgrades
     categories: "Logging & Tracing"
     description: Provides monitoring and troubleshooting microservices-based distributed systems
     certified: "false"
@@ -66,7 +67,6 @@ spec:
     Provides monitoring and troubleshooting microservices-based distributed systems
   keywords: ['tracing', 'monitoring', 'troubleshooting']
   version: 1.8.2
-  maturity: Seamless Upgrades
   maintainers:
   - name: Jaeger Google Group
     email: jaeger-tracing@googlegroups.com

--- a/community-operators/kiecloud-operator/kiecloud-operator.v0.1.0.clusterserviceversion.yaml
+++ b/community-operators/kiecloud-operator/kiecloud-operator.v0.1.0.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kiecloud-operator.v0.1.0
   namespace: placeholder
   annotations:
+    capabilities: Basic Install
     categories: "Integration & Delivery"
     certified: "false"
     description: KieCloud can deploy RHPAM environments in the form of KieApp objects.
@@ -20,7 +21,7 @@ spec:
   description: KieCloud can deploy RHPAM environments in the form of KieApp objects.
   keywords: ['kieapp', 'rhpam', 'kie', 'cloud', 'pam', 'kiecloud']
   version: 0.1.0
-  maturity: Basic Install
+  maturity: beta
   maintainers:
     - name: Red Hat, Inc.
       email: bsig-cloud@redhat.com

--- a/community-operators/metering/metering-operator.v0.13.0.clusterserviceversion.yaml
+++ b/community-operators/metering/metering-operator.v0.13.0.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ kind: ClusterServiceVersion
 metadata:
   name: metering-operator.v0.13.0
   annotations:
+    capabilities: Seamless Upgrades
     tectonic-visibility: openshift-feature
     categories: "OpenShift Optional, Monitoring"
     description: Metering can generate reports based on historical usage data from a cluster, providing accountability for how resources have been used.
@@ -17,7 +18,7 @@ spec:
   description: Metering can generate reports based on historical usage data from a cluster, providing accountability for how resources have been used.
   keywords: ['metering', 'metrics', 'reporting', 'prometheus', 'chargeback']
   version: 0.13.0
-  maturity: Seamless Upgrades
+  maturity: alpha
   maintainers:
     - email: sd-operator-metering@redhat.com
       name: Red Hat

--- a/community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.14.0.clusterserviceversion.yaml
@@ -5,6 +5,8 @@ kind: ClusterServiceVersion
 metadata:
   name: prometheusoperator.0.14.0
   namespace: placeholder
+  annotations:
+    capabilities: Full Lifecycle
 spec:
   displayName: Prometheus
   description: |
@@ -164,7 +166,7 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 50Mi
-  maturity: Full Lifecycle
+  maturity: alpha
   version: 0.14.0
   customresourcedefinitions:
     owned:

--- a/community-operators/prometheus/prometheusoperator.0.15.0.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.15.0.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   name: prometheusoperator.0.15.0
   namespace: placeholder
   annotations:
+    capabilities: Full Lifecycle
     tectonic-visibility: ocs
     alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
 spec:
@@ -179,7 +180,7 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 50Mi
-  maturity: Full Lifecycle
+  maturity: alpha
   version: 0.15.0
   customresourcedefinitions:
     owned:

--- a/community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/community-operators/prometheus/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   name: prometheusoperator.0.22.2
   namespace: placeholder
   annotations:
+    capabilities: Full Lifecycle
     categories: "OpenShift Optional, Monitoring"
     alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.3.2","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
     description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
@@ -197,7 +198,7 @@ spec:
                   readOnlyRootFilesystem: true
               nodeSelector:
                 beta.kubernetes.io/os: linux
-  maturity: Full Lifecycle
+  maturity: beta
   version: 0.22.2
   customresourcedefinitions:
     owned:

--- a/community-operators/templateservicebroker/templateservicebrokeroperator.v0.2.0.clusterserviceversion.yaml
+++ b/community-operators/templateservicebroker/templateservicebrokeroperator.v0.2.0.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   name: templateservicebrokeroperator.v0.2.0
   namespace: placeholder
   annotations:
+    capabilities: Basic Install
     categories: "OpenShift Optional, Integration & Delivery"
     alm-examples: '[{"apiVersion":"osb.openshift.io/v1alpha1","kind":"TemplateServiceBroker","metadata":{"name":"template-service-broker","namespace":"openshift-template-service-broker"},"spec":{"size":3,"version":"3.2.13"}}]'
     description: The Template Service Broker implements the Open Service Broker API.
@@ -43,7 +44,7 @@ spec:
       is the only asynchronous operation.
   keywords: ['template', 'broker', 'open service broker']
   version: 0.2.0
-  maturity: Basic Install
+  maturity: alpha
   maintainers:
   - name: Red Hat, Inc.
     email: ansible-service-broker@redhat.com

--- a/docs/required-fields.md
+++ b/docs/required-fields.md
@@ -5,6 +5,7 @@ An Operator's CSV must contain the following annotations for it to be displayed 
 ```yaml
 metadata:
   annotations:
+    capabilities: The operator's maturity level. This field can be omitted until a process to get this values is defined at a later date.
     categories: A list of comma separated list of categories from the values below.
     certified: The operator's certification. This field should be set to false until a process to get this value is defined at a later date.
     description: |-
@@ -21,7 +22,6 @@ spec:
   version: The operator version.
   provider:
     name: The provider of the operator. This value should be a name, not an email.
-  maturity: The operator's maturity level. This field can be omitted until a process to get this value is defined at a later date.
 ```
 
 ## Categories
@@ -52,6 +52,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    capabilities: Seamless Upgrades
     categories: "OpenShift Optional"
     certified: "false"
     containerImage: registry.svc.ci.openshift.org/openshift/origin-v4.0:descheduler-operator

--- a/redhat-operators/amq-streams/amq-streams.v1.0.0.clusterserviceversion.yaml
+++ b/redhat-operators/amq-streams/amq-streams.v1.0.0.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   name: amqstreams.v1.0.0
   namespace: placeholder
   annotations:
+    capabilities: Full Lifecycle
     categories: "Streaming & Messaging"
     certified: "false"
     description: Red Hat AMQ Streams is a massively scalable, distributed, and high performance data streaming platform based on Apache Kafka.
@@ -27,7 +28,7 @@ spec:
 
   keywords: ['amq', 'streams', 'messaging', 'kafka', 'streaming']
   version: 1.0.0
-  maturity: Full Lifecycle
+  maturity: stable
   maintainers:
   - name: Red Hat, Inc.
     email: customerservice@redhat.com


### PR DESCRIPTION
- Reverts #63 changes to values of spec.maturity in operator CSVs
- Move operator maturity level to `metadata.annotations.capabilities`
- Update required-fields.md to include capabilities

OLM's catalog-operator requires spec.maturity to have certain values
as outlined here:
    spec.maturity in body should be one of [planning pre-alpha
        alpha beta stable mature inactive deprecated]
This value isn't required to be set, but if the value isn't one of
the expected values above the installPlan fails.

/cc @dmesser @jeff-phillips-18 