### PR TITLE
add expanded cluster-reader role rules

### DIFF
--- a/community-operators/cluster-logging/clusterlogging.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/cluster-logging/clusterlogging.v0.0.1.clusterserviceversion.yaml
@@ -216,6 +216,489 @@ spec:
           - clusterrolebindings
           verbs:
           - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - componentstatuses
+          - nodes
+          - nodes/status
+          - persistentvolumeclaims/status
+          - persistentvolumes
+          - persistentvolumes/status
+          - pods/binding
+          - pods/eviction
+          - podtemplates
+          - securitycontextconstraints
+          - services/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - controllerrevisions
+          - daemonsets
+          - daemonsets/status
+          - deployments
+          - deployments/scale
+          - deployments/status
+          - replicasets
+          - replicasets/scale
+          - replicasets/status
+          - statefulsets
+          - statefulsets/scale
+          - statefulsets/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          - customresourcedefinitions/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          - apiservices/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          - horizontalpodautoscalers/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - cronjobs/status
+          - jobs
+          - jobs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - daemonsets
+          - daemonsets/status
+          - deployments
+          - deployments/scale
+          - deployments/status
+          - horizontalpodautoscalers
+          - horizontalpodautoscalers/status
+          - ingresses
+          - ingresses/status
+          - jobs
+          - jobs/status
+          - networkpolicies
+          - podsecuritypolicies
+          - replicasets
+          - replicasets/scale
+          - replicasets/status
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          - storageclasses
+          - thirdpartyresources
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          - poddisruptionbudgets/status
+          - podsecuritypolicies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - settings.k8s.io
+          resources:
+          - podpresets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          - volumeattachments
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - certificates.k8s.io
+          resources:
+          - certificatesigningrequests
+          - certificatesigningrequests/approval
+          - certificatesigningrequests/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - authorization.openshift.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindingrestrictions
+          - rolebindings
+          - roles
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - buildconfigs/webhooks
+          - buildlogs
+          - builds
+          - builds/details
+          - builds/log
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - images
+          - imagesignatures
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/layers
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - oauth.openshift.io
+          resources:
+          - oauthclientauthorizations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projectrequests
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - quota.openshift.io
+          resources:
+          - appliedclusterresourcequotas
+          - clusterresourcequotas
+          - clusterresourcequotas/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - network.openshift.io
+          resources:
+          - clusternetworks
+          - egressnetworkpolicies
+          - hostsubnets
+          - netnamespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - rangeallocations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - template.openshift.io
+          resources:
+          - brokertemplateinstances
+          - processedtemplates
+          - templateconfigs
+          - templateinstances
+          - templateinstances/status
+          - templates
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - user.openshift.io
+          resources:
+          - groups
+          - identities
+          - useridentitymappings
+          - users
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - authorization.openshift.io
+          resources:
+          - localresourceaccessreviews
+          - localsubjectaccessreviews
+          - resourceaccessreviews
+          - selfsubjectrulesreviews
+          - subjectaccessreviews
+          - subjectrulesreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - localsubjectaccessreviews
+          - selfsubjectaccessreviews
+          - selfsubjectrulesreviews
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - security.openshift.io
+          resources:
+          - podsecuritypolicyreviews
+          - podsecuritypolicyselfsubjectreviews
+          - podsecuritypolicysubjectreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - nodes/metrics
+          - nodes/spec
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes/stats
+          verbs:
+          - create
+          - get
+        - nonResourceURLs:
+          - '*'
+          verbs:
+          - get
+        - apiGroups:
+          - packages.apps.redhat.com
+          resources:
+          - ""
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          - catalogsources
+          - installplans
+          - subscriptions
+          - packagemanifests
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resourceNames:
+          - clusterloggings.logging.openshift.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+        - apiGroups:
+          - logging.openshift.io
+          resources:
+          - clusterloggings
+          - elasticsearches
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreamimages
+          - imagestreammappings
+          - imagestreams
+          - imagestreams/status
+          - imagestreamtags
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - bindings
+          - configmaps
+          - endpoints
+          - events
+          - limitranges
+          - namespaces
+          - namespaces/status
+          - persistentvolumeclaims
+          - pods
+          - pods/log
+          - pods/status
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          - replicationcontrollers/status
+          - resourcequotas
+          - resourcequotas/status
+          - resourcequotausages
+          - serviceaccounts
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/log
+          - deploymentconfigs/scale
+          - deploymentconfigs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/status
+          verbs:
+          - get
+          - list
+          - watch
       deployments:
       - name: cluster-logging-operator
         spec:


### PR DESCRIPTION
the cluster-logging-operator needs the cluster-reader clusterrole
rights - we cannot add a `roleRef: cluster-reader` so add the
full list of rules from `oc get clusterrole cluster-reader`
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1680504