### PR TITLE
added missing quote to targetNamespace, added watch verb for secrets …

### DIFF
--- a/upstream-community-operators/mongodb-enterprise/mongodb.v0.3.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/mongodb-enterprise/mongodb.v0.3.2.clusterserviceversion.yaml
@@ -224,7 +224,7 @@ spec:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces]
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: MANAGED_SECURITY_CONTEXT
                   value: "true"
                 - name: OPERATOR_ENV
@@ -262,6 +262,7 @@ spec:
           - create
           - update
           - delete
+          - watch
         - apiGroups:
           - apps
           resources:


### PR DESCRIPTION
…and config maps. We fixed the single quote on olm.targetNamespace but it seems to have regressed. Also discovered that we were missing the watch verb in RBAC for secrets and configmaps. 