### PR TITLE
[community] Add example CRs for federation

### DIFF
--- a/community-operators/federationv2/federationv2.v0.0.2.clusterserviceversion.yaml
+++ b/community-operators/federationv2/federationv2.v0.0.2.clusterserviceversion.yaml
@@ -6,6 +6,389 @@ metadata:
   name: federationv2.v0.0.2
   namespace: placeholder
   annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedConfigMapOverride",
+          "metadata": {
+            "name": "test-configmap",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "overrides": [
+              {
+                "clusterName": "cluster2",
+                "clusterOverrides": [
+                  {
+                    "path": "data",
+                    "value": {
+                      "foo": "bar"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedConfigMapPlacement",
+          "metadata": {
+            "name": "test-configmap",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "clusterNames": [
+              "cluster2",
+              "cluster1"
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedConfigMap",
+          "metadata": {
+            "name": "test-configmap",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "template": {
+              "data": {
+                "A": "ala ma kota"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedDeploymentOverride",
+          "metadata": {
+            "name": "test-deployment",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "overrides": [
+              {
+                "clusterName": "cluster2",
+                "clusterOverrides": [
+                  {
+                    "path": "spec.replicas",
+                    "value": 5
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedDeploymentPlacement",
+          "metadata": {
+            "name": "test-deployment",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "clusterNames": [
+              "cluster2",
+              "cluster1"
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedDeployment",
+          "metadata": {
+            "name": "test-deployment",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "template": {
+              "metadata": {
+                "labels": {
+                  "app": "nginx"
+                }
+              },
+              "spec": {
+                "replicas": 3,
+                "selector": {
+                  "matchLabels": {
+                    "app": "nginx"
+                  }
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "nginx"
+                    }
+                  },
+                  "spec": {
+                    "containers": [
+                      {
+                        "image": "nginx",
+                        "name": "nginx"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedIngressPlacement",
+          "metadata": {
+            "name": "test-ingress",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "clusterNames": [
+              "cluster2",
+              "cluster1"
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedIngress",
+          "metadata": {
+            "name": "test-ingress",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "template": {
+              "spec": {
+                "rules": [
+                  {
+                    "host": "ingress.example.com",
+                    "http": {
+                      "paths": [
+                        {
+                          "backend": {
+                            "serviceName": "test-service",
+                            "servicePort": 80
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "FederatedJobOverride",
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "metadata": {
+            "name": "test-job",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "overrides": [
+              {
+                "clusterName": "cluster2",
+                "clusterOverrides": [
+                  {
+                    "path": "spec.parallelism",
+                    "value": 2
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedJobPlacement",
+          "metadata": {
+            "name": "test-job",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "clusterNames": [
+              "cluster2",
+              "cluster1"
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedJob",
+          "metadata": {
+            "name": "test-job",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "template": {
+              "spec": {
+                "parallelism": 1,
+                "selector": {
+                  "matchLabels": {
+                    "app": "busybox"
+                  }
+                },
+                "manualSelector": true,
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "app": "busybox"
+                    }
+                  },
+                  "spec": {
+                    "terminationGracePeriodSeconds": 0,
+                    "restartPolicy": "Never",
+                    "containers": [
+                      {
+                        "name": "busybox",
+                        "image": "busybox",
+                        "command": [
+                          "/bin/sh",
+                          "-c",
+                          "trap : TERM INT; (while true; do sleep 1000; done) & wait"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedNamespacePlacement",
+          "metadata": {
+            "name": "test-namespace",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "clusterNames": [
+              "cluster1",
+              "cluster2"
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedSecretOverride",
+          "metadata": {
+            "name": "test-secret",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "overrides": [
+              {
+                "clusterName": "cluster2",
+                "clusterOverrides": [
+                  {
+                    "path": "data",
+                    "value": {
+                      "A": null
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedSecretPlacement",
+          "metadata": {
+            "name": "test-secret",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "clusterNames": [
+              "cluster2",
+              "cluster1"
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedSecret",
+          "metadata": {
+            "name": "test-secret",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "template": {
+              "data": {
+                "A": "YWxhIG1hIGtvdGE="
+              },
+              "type": "Opaque"
+            }
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedServicePlacement",
+          "metadata": {
+            "name": "test-service",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "clusterNames": [
+              "cluster2",
+              "cluster1"
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedService",
+          "metadata": {
+            "name": "test-service",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "template": {
+              "spec": {
+                "selector": {
+                  "app": "nginx"
+                },
+                "type": "NodePort",
+                "ports": [
+                  {
+                    "name": "http",
+                    "port": 80
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedServiceAccountPlacement",
+          "metadata": {
+            "name": "test-serviceaccount",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "clusterNames": [
+              "cluster1",
+              "cluster2"
+            ]
+          }
+        },
+        {
+          "apiVersion": "primitives.federation.k8s.io/v1alpha1",
+          "kind": "FederatedServiceAccount",
+          "metadata": {
+            "name": "test-serviceaccount",
+            "namespace": "test-namespace"
+          },
+          "spec": {
+            "template": {
+              "automountServiceAccountToken": true
+            }
+          }
+        }
+      ]
     capabilities: Basic Install
     categories: "OpenShift Optional, Integration & Delivery"
     description: Gain Hybrid Cloud capabilities between your clusters with Kubernetes Federation.


### PR DESCRIPTION
- Add example CRs to `alm-examples` annotation for federation CSV

This does not include example CRs for all CRDs owned by federation
These CRs were obtained from here as suggested by @pmorie : https://github.com/openshift/federation-v2-operator/tree/master/vendor/github.com/kubernetes-sigs/federation-v2/example/sample1

/cc @pmorie @dmesser  