### PR TITLE
*: remove non-functional Couchbase members UI field

### DIFF
--- a/certified-operators/couchbase-enterprise/couchbase.1.1.0.clusterserviceversion.yaml
+++ b/certified-operators/couchbase-enterprise/couchbase.1.1.0.clusterserviceversion.yaml
@@ -103,12 +103,6 @@ spec:
             path: reason
             x-descriptors:
               - 'urn:alm:descriptor:io.kubernetes.phase:reason'
-          - description: The status of each of the member Pods for the Couchbase cluster.
-            displayName: Member Status
-            path: members
-            x-descriptors:
-              # FIXME: Format doesn't match with what the OpenShift console's donut chart expects
-              - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
           - description: The current version of the Couchbase cluster.
             displayName: Current Version
             path: currentVersion

--- a/upstream-community-operators/couchbase-enterprise/couchbase-v1.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/couchbase-v1.1.0.clusterserviceversion.yaml
@@ -111,11 +111,6 @@ spec:
         path: reason
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase:reason
-      - description: The status of each of the member Pods for the Couchbase cluster.
-        displayName: Member Status
-        path: members
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       - description: The current version of the Couchbase cluster.
         displayName: Current Version
         path: currentVersion


### PR DESCRIPTION
Because of the presence of `index: 3`, the UI field doesn't render correctly. This removes it.