### PR TITLE
Updated the Crunchy Data descriptors

### DIFF
--- a/upstream-community-operators/postgresql/postgres-operator.v3.5.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/postgresql/postgres-operator.v3.5.0.clusterserviceversion.yaml
@@ -9,13 +9,13 @@ metadata:
     containerImage: crunchydata/postgres-operator:centos7-3.5.0
     createdAt: 2019-02-01T11:59:59Z
     description: PostgreSQL is a powerful, open source object-relational database system with over 30 years of active development.
-    support: Crunchy Data Solutions, Inc.
+    support: Crunchy Data
   name: postgres-operator.v3.5.0
   namespace: placeholder
 spec: 
   version: 3.5.0
   maturity: alpha
-  displayName: PostgreSQL Enterprise
+  displayName: Crunchy PostgreSQL
   description: |
     The PostgreSQL Operator runs within a Kubernetes cluster and provides a means to deploy and manage PostgreSQL clusters.
 


### PR DESCRIPTION
    support: Crunchy Data
  name: postgres-operator.v3.5.0
  namespace: placeholder
spec: 
  version: 3.5.0
  maturity: alpha
  displayName: Crunchy PostgreSQL