### PR TITLE
install logging in openshift-logging namespace only

### DIFF
--- a/community-operators/cluster-logging/cluster-logging.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/cluster-logging/cluster-logging.v0.0.1.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: clusterlogging.v0.0.1
-  namespace: placeholder
+  namespace: openshift-logging
   annotations:
     capabilities: Seamless Upgrades
     categories: "OpenShift Optional, Logging & Tracing"
@@ -92,7 +92,7 @@ spec:
   - type: OwnNamespace
     supported: true
   - type: SingleNamespace
-    supported: true
+    supported: false
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
@@ -204,7 +204,7 @@ spec:
                   - name: WATCH_NAMESPACE
                     valueFrom:
                       fieldRef:
-                        fieldPath: metadata.annotations['olm.targetNamespaces']
+                        fieldPath: metadata.namespace
                   - name: OPERATOR_NAME
                     value: "cluster-logging-operator"
                   - name: ELASTICSEARCH_IMAGE


### PR DESCRIPTION
Do not use `placeholder` for the logging operator namespace,
hardcode it to `openshift-logging`