### PR TITLE
Use a smaller base image for upstream dockerfile

### DIFF
--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -1,13 +1,18 @@
-FROM python:3 as builder
+FROM python:3 as manifests
 
 RUN pip3 install operator-courier==1.0.2
-
 WORKDIR /usr/src
 COPY upstream-community-operators /usr/src/upstream-community-operators
 RUN for file in /usr/src/upstream-community-operators/*; do operator-courier nest $file /manifests/$(basename $file); done
 
-FROM quay.io/openshift/origin-operator-registry:latest
-COPY --from=builder /manifests manifests
-RUN initializer
-CMD ["registry-server"]
+FROM quay.io/operator-framework/upstream-registry-builder:v1.1.0 as builder
+COPY --from=manifests /manifests manifests
+RUN ./bin/initializer -o ./bundles.db
 
+FROM scratch
+COPY --from=builder /build/bundles.db /bundles.db
+COPY --from=builder /build/bin/registry-server /registry-server
+COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+EXPOSE 50051
+ENTRYPOINT ["/registry-server"]
+CMD ["--database", "bundles.db"]


### PR DESCRIPTION
This switches the upstream dockerfile to output a much smaller image

Previous image size: 121.9 MB
New image size: 46.7MB