### PR TITLE
[scripts] Support more CSV names in operators-env

### DIFF
--- a/scripts/ci/operators-env
+++ b/scripts/ci/operators-env
@@ -33,7 +33,7 @@ for op_distro in "${!OP_TYPES[@]}"; do
         # Get latest CSV version for the changed operator.
         OP_VER="$(yq r --tojson "$PKG_FILE" "channels" \
           | jq ".[] | .currentCSV" | sort -V | tail -1 \
-          | 's/"[a-zA-Z\-]+\.?v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?)"/\1/')"
+          | sed -E 's/"[a-zA-Z\-]+\.?v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?)"/\1/')"
         declare $OP_TYPE_VAR="${!OP_TYPE_VAR}${!OP_TYPE_VAR:+" "}${OP_PATH}:${OP_VER}"
       fi
     done


### PR DESCRIPTION
Previously operators-env failed to pull the operator version when
the CSV name didn't use 'v'