### PR TITLE
scripts/ci/install-deps: fix operator-sdk version to v0.6.0

### DIFF
--- a/scripts/ci/install-deps
+++ b/scripts/ci/install-deps
@@ -40,15 +40,10 @@ $SUDO mv yq /usr/local/bin/
 # export PATH="${HOME}/.local/bin:${PATH}"
 python3 -m pip install operator-courier
 # SDK
-# TODO(estroz): use curl download method once v0.6.0 is released, which contains scorecard updates.
-# SDK_VER="v0.6.0"
-# curl -Lo operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VER}/operator-sdk-${SDK_VER}-x86_64-linux-gnu"
-SDK_REPO_PATH="github.com/operator-framework/operator-sdk"
-go get -d "$SDK_REPO_PATH" || true
-pushd "${GOPATH}/src/${SDK_REPO_PATH}"
-GO111MODULE=off make build/operator-sdk
-chmod +x build/operator-sdk
-$SUDO mv build/operator-sdk /usr/local/bin/
+SDK_VER="v0.6.0"
+curl -Lo operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VER}/operator-sdk-${SDK_VER}-x86_64-linux-gnu"
+chmod +x operator-sdk
+$SUDO mv operator-sdk /usr/local/bin/
 popd
 # helm
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash


### PR DESCRIPTION
SDK v0.6.0 contains changes required to test OLM-deployed operators.