### PR TITLE
remove the etcd annotations

### DIFF
--- a/community-operators/etcd/etcdoperator.v0.9.2.clusterserviceversion.yaml
+++ b/community-operators/etcd/etcdoperator.v0.9.2.clusterserviceversion.yaml
@@ -15,10 +15,7 @@ metadata:
           "apiVersion": "etcd.database.coreos.com/v1beta2",
           "kind": "EtcdCluster",
           "metadata": {
-            "name": "example",
-            "annotations": {
-              "etcd.database.coreos.com/scope": "clusterwide"
-            }
+            "name": "example"
           },
           "spec": {
             "size": 3,
@@ -29,10 +26,7 @@ metadata:
           "apiVersion": "etcd.database.coreos.com/v1beta2",
           "kind": "EtcdRestore",
           "metadata": {
-            "name": "example-etcd-cluster-restore",
-            "annotations": {
-              "etcd.database.coreos.com/scope": "clusterwide"
-            }
+            "name": "example-etcd-cluster-restore"
           },
           "spec": {
             "etcdCluster": {
@@ -49,10 +43,7 @@ metadata:
           "apiVersion": "etcd.database.coreos.com/v1beta2",
           "kind": "EtcdBackup",
           "metadata": {
-            "name": "example-etcd-cluster-backup",
-            "annotations": {
-              "etcd.database.coreos.com/scope": "clusterwide"
-            }
+            "name": "example-etcd-cluster-backup"
           },
           "spec": {
             "etcdEndpoints": ["<etcd-cluster-endpoints>"],


### PR DESCRIPTION
For now, the etcd-operator only support watching single namespace. So, the below annotations are inappropriate. Remove it, fixed [bug 1659875](https://bugzilla.redhat.com/show_bug.cgi?id=1659875)
```console
  annotations:
    etcd.database.coreos.com/scope: clusterwide
```