### PR TITLE
Updated MongoDB Enterprise Operator to 0.9.0

### DIFF
--- a/certified-operators/mongodb-enterprise/mongodb-enterprise.package.yaml
+++ b/certified-operators/mongodb-enterprise/mongodb-enterprise.package.yaml
@@ -1,5 +1,5 @@
-#! package-manifest: deploy/chart/catalog_resources/certified-operators/mongodb-enterprise.v0.3.2.clusterserviceversion.yaml
+#! package-manifest: deploy/chart/catalog_resources/certified-operators/mongodb-enterprise.v0.9.0.clusterserviceversion.yaml
 packageName: mongodb-enterprise
 channels:
 - name: preview
-  currentCSV: mongodboperator.v0.3.2
+  currentCSV: mongodboperator.v0.9.0

--- a/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.9.0.clusterserviceversion.yaml
+++ b/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.9.0.clusterserviceversion.yaml
@@ -7,8 +7,13 @@ metadata:
   replaces: mongodboperator.v0.3.2
   namespace: placeholder
   annotations:
+    repository: https://github.com/mongodb/mongodb-enterprise-kubernetes
+    containerImage: registry.connect.redhat.com/mongodb/enterprise-database:0.9.1
+    support: MongoDB Community Support
+    createdAt: 2019-03-21T10:30:00Z
     capabilities: Full Lifecycle
     categories: "Database"
+    certified: "true"
     description: The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB into Kubernetes clusters, using our management, monitoring and backup platforms, Ops Manager and Cloud Manager.
     alm-examples: >-
       [{"apiVersion":"mongodb.com/v1","kind":"MongoDbStandalone","metadata":{"name":"my-standalone","namespace":"mongodb"},"spec":{"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}},{"apiVersion":"mongodb.com/v1","kind":"MongoDbReplicaSet","metadata":{"name":"my-replica-set","namespace":"mongodb"},"spec":{"members":3,"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}},{"apiVersion":"mongodb.com/v1","kind":"MongoDbShardedCluster","metadata":{"name":"my-sharded-cluster","namespace":"mongodb"},"spec":{"shardCount": 2, "mongodsPerShardCount": 3, "mongosCount": 2, "configServerCount": 3,"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}}]

--- a/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.9.0.clusterserviceversion.yaml
+++ b/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.9.0.clusterserviceversion.yaml
@@ -4,7 +4,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: mongodboperator.v0.9.0
-  replaces: mongodboperator.v0.3.2
   namespace: placeholder
   annotations:
     repository: https://github.com/mongodb/mongodb-enterprise-kubernetes
@@ -23,6 +22,7 @@ spec:
     name: 'MongoDB, Inc'
   maturity: stable
   version: 0.9.0
+  replaces: mongodboperator.v0.3.2
   keywords: ["mongodb", "database", "nosql"]
   maintainers:
   - email: support@mongodb.com

--- a/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.9.0.clusterserviceversion.yaml
+++ b/certified-operators/mongodb-enterprise/mongodb-enterprise.v0.9.0.clusterserviceversion.yaml
@@ -1,0 +1,320 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: mongodboperator.v0.9.0
+  replaces: mongodboperator.v0.3.2
+  namespace: placeholder
+  annotations:
+    capabilities: Full Lifecycle
+    categories: "Database"
+    description: The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB into Kubernetes clusters, using our management, monitoring and backup platforms, Ops Manager and Cloud Manager.
+    alm-examples: >-
+      [{"apiVersion":"mongodb.com/v1","kind":"MongoDbStandalone","metadata":{"name":"my-standalone","namespace":"mongodb"},"spec":{"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}},{"apiVersion":"mongodb.com/v1","kind":"MongoDbReplicaSet","metadata":{"name":"my-replica-set","namespace":"mongodb"},"spec":{"members":3,"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}},{"apiVersion":"mongodb.com/v1","kind":"MongoDbShardedCluster","metadata":{"name":"my-sharded-cluster","namespace":"mongodb"},"spec":{"shardCount": 2, "mongodsPerShardCount": 3, "mongosCount": 2, "configServerCount": 3,"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}}]
+spec:
+  displayName: MongoDB
+  provider:
+    name: 'MongoDB, Inc'
+  maturity: stable
+  version: 0.9.0
+  keywords: ["mongodb", "database", "nosql"]
+  maintainers:
+  - email: support@mongodb.com
+    name: 'MongoDB, Inc'
+  description: |
+    The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB
+    into Kubernetes clusters, using our management, monitoring and backup
+    platforms, Ops Manager and Cloud Manager.
+
+
+    ## Before You Start
+
+    To start using the operator you'll need an account in MongoDB Cloud Manager.
+
+    * [Create a Secret with your OpsManager API key](https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/#create-credentials)
+
+
+    * [Create a ConfigMap with your OpsManager project ID and URL](https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/#create-onprem-project)
+
+
+    By installing this integration, you will be able to deploy MongoDB instances
+    with a single simple command.
+
+    ## Required Parameters
+
+    * `project` - Enter the name of the ConfigMap containing project information
+
+
+    * `credentials` - Enter the name of the Secret containing your OpsManager credentials
+
+
+    ## Supported MongoDB Deployment Types ##
+
+
+    * Standalone: An instance of mongod that is running as a single server and
+    not as part of a replica set, this is, it does not do any kind of
+    replication.
+
+
+    * Replica Set: A replica set in MongoDB is a group of mongod processes that
+    maintain the same data set. Replica sets provide redundancy and high
+    availability, and are the basis for all production deployments. This section
+    introduces replication in MongoDB as well as the components and architecture
+    of replica sets. The section also provides tutorials for common tasks
+    related to replica sets.
+
+
+    * Sharded Cluster: The set of nodes comprising a sharded MongoDB deployment.
+    A sharded cluster consists of config servers, shards, and one or more mongos
+    routing processes. Sharding is a A database architecture that partitions
+    data by key ranges and distributes the data among two or more database
+    instances. Sharding enables horizontal scaling.
+  links:
+  - name: Documentation
+    url: 'https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/index.html'
+  icon:
+  - base64data: >-
+        iVBORw0KGgoAAAANSUhEUgAAAH8AAAB/CAYAAADGvR0TAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4ggYEhkp9JVi8gAAFENJREFUeNrtnXmcVeV5x7/Pe86dGUZQUdwAo4Kaam1cUAdm3DAYl1ZjmmhMYkUlkMYtMVVrVExqY7q4oabNp6EuMdpEq8ZGpf1oJCbKJgxqlWiIgIrACCgimwJznv5xlvue5d65dxjsvXPP4+d4t3OB+/7e37O/7wsNKhdNv9iZ8uqNQgOLadhfLnLA7CV/OOrT/3JMDn7D/XDh02s3bRr/h4ufz8FvNOnu1s9v2rL5/EZW+06j/eCJT09i1Pijdhb46ZpNGwa4Jw4x7097+9mGtHyN+KMn/fob/yyYK998byWLV727FXQPgfcXXjIjV/v9Uc7/nwkATHhq4t+q6pWKUjAOgroCf73wkhkc+KOOnPn9dwJceIkx5k6DwRjDyg/XsmD52+Eg7LHwkhkrc+b3Izl32nkAnDftgkcV7kRBUVQVxxhAw1ufOfBHHaaR2N+vwf/KE+fS7W0Z8LVp5z2t6BcIQPfhViSu9w4BLlt4yQxG3NmRg1/v8vO/uB/EmY3qOFDUC3iuiiq4xsHXBOAB3cptI+/s+KvFl87ggAaYAP3S5n/pV18WjNnBUZllxBwiAo44CIIYgxHBiMP6jzcxd8kixFIBAp7AV/546YyHcubXoXy03gVPf6noIaGS93xLT6DxAcU1DhIMQngJGFUe3P+OjhMB9r+jI2d+PciZj30JcUWkW6Yb5AQxBgeDiGCMYDCIBMw3ho82b2XOooUx5lviASe9cdmM6Tnz60AeO/NhdKveBHqCRgh6Edsjex+8doz0RIxn9r+j41BfA7TnzK9VGff0WbSu964V4QdGDIJgQpYHjyImYL/giKFblecXvo6RcsOgHrDHG5fNXN3fwHf7yw9pWbe1DZEbQNBoVvvPNHxHFSR8D1Q1dp/lECS14//uf0f7/t3CRuPBom/NzMGvFTnl4TP2VHS2IqAB3AKqgieKo4IHGAkifFVUFNcxKIogKdA1/rgXMGvJpTMPzW1+jcjJD5/u2y7hwZDJSRB9WIvve9FzP9YPX3kUn2vxFqR4fWbk7e33Aoy8vX/Y/7ot6Y576DSePutJTn749O+DjAd82y0SZe5EAk0QvCcUH0FA4K33VvvvV/bXHrbLqXu/suhbM1/LHb7/RznxodMwyJ+ImFccEdd36ASDH8b5Dl8Q3gVhXuj8SfC+4zg8+9rve3D40h4gMAp4sd5tf92q/elnT0PR/0Q914spdgJ1roE61+i1F5mAwMUT6S1h7u8PTl/dgj/2wVNvVThEAzx8e2/bdBJef2jMLd9Atbd//cEjb29/LAf/E5ZjfzGK439xyi6q+o2wQqfqUXT4Am8+8Nw8y7FLagXdtn/K50dMaT8OYMSU9hz8T0KeO6cTD+9nCq2hCbYJrBnPovvs/H4vma9avICHARZ/e2YO/ichHf9x0qkopyVr82GDBpE2KDZtqHWvhpogeL+lUCgJbtaVkN1GTGmfmqv97SyjH/hsyNfvpZMwCdWeUuqhdogS/CXB7oWcO2JK+3Bf/Y/Jwd8eMvtrzzD6gc8eC9rmqaXC1c/RqfoFHE81075HvgCWBthWq+//qS2gj+bM386i8IiStu+R8leNWXjb67dDvMgxrBp8zbgAOGrElDFfWPztWTn4fS2j7h/LkQ+ceKaiu0VAaqjOk2zGsvvF19ZDZPfRLPi1zFVWrgUYeduYHPy+ksPvH0vnub9B4W+8BGsjSGL2PAGVxplP4vt+Sb9igKMsjxDL+yPKqJG3jTl50eWzcvD7Sl489zccdv/Yg1T1mBg3LeRDhnuZXr+t/hNaQqHgOj1CngQ7OU+s4tCjAPvVCfvrQu2r6r1gVd80bs9Dey+AemrX7YqRgGrC69fIfJRgcnRF0YD1b7Avay607nfbmDPZsiUHf1vlT+87nkN+dsLexTRu3JVTjSduvIR6Twd8dhRgpX9LMzle6q3EMKheseSqeex36+gc/G2RBef9FlRPUWj1U7aaAEIDmy4Z6t1iOxpL+GA5gl4Gm8uC3HMWqGO/W0cftuQ7s3Pweyv73ndcyObJIavjSRvbU/fifrpGjVsxb59EgFecPGWZ3Jss0L/Wg9qv6Xr+gfcd1+bAbCeozTviPwrghvV6kUSzZrGG74hBwH8UgwiEzZ2OGFzH4dW3l7Fu00d9NhDBn7MROBh4a3ENa4CaVvuiXBxT82qHepbXL/HQL5b0EUmVedmGDJ/0cAXSCpyyuMZVf002cI786bEItCi021k5FX/4QxstqsWmXJGiLRcJ7vcfRSRKBdjNnapUFOb1LkJhMvBvuc2vUhaNfw6FQQojwyXVWM4YqjGvH5VEsVaLqd6MeN+2/64xlTA5Ow9ouQJe4lIYtu8tozty8HshnuqXvXj1naxcnP/cSyV80l4/VnJHoySPY6RH+kehnw2uVhT+fScHv3dyeXzwNeq/KC7FSoIdDwND0KP2bdUMSONM9rJY3Pty75H73jK6NQe/CtnvnvbBqowopmxJlWHTGkFT+Xs0I0ljN3daKrsS+98L+RSwRw5+hTL87na6VcbZ9hrNAFATmT6NR/Hx9K4mcoPxhVzbK4YOUsaX5uBXKO9cOBPfyy9n7232B80cVi9fmA3ESvhkNXdq34CbeVnz7KIc/OrkzzwbSEtd26ocqy+PhJOX8vpJN3d621DGreKrzfvc3HZYDn6lMTJ6UBHwEKSMjpykVlAt7fVnNHdGwEp5FvcMdrF+4GVcwMn73NyWg9+TDLtrtKMwFEpU5EJHzvrQixie5QymJ0LsDnuVZkUTMwvsHhVBx1tXzMkzfD1JNzLWsRmugooPsETZPcW/R2IFHN+DV8LQXVRRMUEKMPxMYgma0kxOmgoyzEdFmT6Aw3O1X5mM1WTEZoVu8UZMUmVem9BRCZdkG1eyEuBFXUAVMrks2BlFwOH73tS2Yw5+z2p1XFaRxqvI609z1s7yxU2HWhpfKmZ0T+X80DE0iQs4Kwe/Z/APTa6viK27s7J1ttdfbXOnJl35KsEtBXJ2TUABPSG3+WVkt7vaBgEFjaJ38JDAvqeZLyWehyAhQf+eiNXNE34mUcyvHiWrOJKeHxW7hQk5Jge/7JjJEBXfsfMiFoWUlcBpI3Lo1C7hkiz9UtxtJ6jrq6eokZRLJ71SgVrFXYL6qd5c7ZeRnYNwO8bwLAcs+VnKS1dKNnfaWT9T0ZYsPS/gKH4ieMHVHT33P9v7prYhOfglxIMhsZ46jdttuxQbX2xZfXNn2LpdcA3lV+lkAV0EtzsGspSLFATIwS/DsB2ChFtmNi9ksO39q/auuTMxfcpyPQ10hUo/mUhQHZTb/AwZPLUNYGcPMBQ3SkRBRYNuHX9m+EkeuyYnMTNgYuz3k0Rhy5f/OnQnQ21h+mKnDog2dSw5AXbJmZ8haybOQWFgejPEeMq2VJnXs5o7PXvcJavM62f7wnu9Sku7qki5q/y3BRiQg196bAfGnTVSS6/CnL5nq2dNLse2l2dZSR6NL+UuklIqA3vbf2IhB78MO7I8+hAkz4/YYuCFyzPC1TZZzZ3JvF9sJU/vmdwbGZiDX1r20MTOKWECx4uFcHFVrclevNhzDxL782BNKlNFzN7LjKU9iWtqkUxNJXkUXS+RI1bcDtlDMYHjpgkl7QXungabK4f7Knqov8LW2mhRk16/KK5r+gTgWGhaJ1Jj4LNOiDdlSjHHl1nmdaLPLc/fXqhhfU+iFR69a9hUa+ZplQpDtq+CqX/wSXFeLIb7QHsKjhAu0wlCQaxVPFb6N4rrJbg1SPwE6/3K9fFpKSZrDwCXvFcBNufgl5bV9vq7MMZPTweNGjnsoo79WTSVxAT2XvxCj81+wDHGdyQrZW85nd+zfJQ7fGXC/axxTfbc99Tc6VmsVs06REGjtK+UOGcnc+lWun+cKto+FFifM7+EeMqHRgJeBupcokRN0fe3tYOHX5zRmMkAzQKagP1Blg8tbuci2Wq6r2Vdzvwyah8oEcRlLbDKDKeKmoH4Hj6aTA6FMWTyeI3t55mtzcEvLe96mraimuq5tdV9Vmt3Yv+9jOROBLZsH7AzNm9SD97PwS+lEye9sCL8N6l1SEKsBaua5s4UlzXe3FltvFYZyLGyrtX7Lx6szMEvP5wvJ7N0sRi/THNnvAwbP1ghy2RUw/keQSZ74YclH6y4eu7WHPzy8lRy1L2kzdf4ku2wuTOaJJa697dlIb7lOumNmtKTJ35FUUCPK3pKNoXU3LGstQj+Q1piG1UyGJ+eFOk0bkyD2Dt3EqzBz4CqsrV5Ve3P+1QOfo92f+48YItmeP3pHn57V83k2XiasXmTvcwqDPO0t0yu9qf9Mge/Uruv2RF3chdNz8rwkfAPsvbwKf4hyZp+KTb3TYj3znfnrRr+D0fm4FcgL0SJnxJePwn7H2/uJHHAAtnNnfKJxfevArzz3Xk5+OVk0E+OAvh1qbNtyYj9yzd3SvxbGt+fY/NWb/vpr+JKn85aZFgt2nyAx1KAa7H33o6hY15/LOGTbACLO4ihryCS7BDoE7CT5mR6Dn7lE0CBB2MnY2Tw39um5s7q9+Cs8uQtW57Mwa9ObshKxKQOTbK47SXUf1ZzZywrCGwtofarBLec/Peya+ZtzcGvzu4vAV2qatvrDJ/cbu4kq7kzWeaNr+CNFmv2DdBZ8v1aZVetqn3WTZq7ybaVqdCbnps7S63vKzqF2tdAJ2UVsGDYD4+sSfBdaluuBh0fdubYnTqVNHfaZ+l4QStX6Cs4wfKfrVs9ZPv11M5fds28DTnze6H6102a2wU8mqnuS2yhni7zxhs8U3F/H1O/mBZWgB/WMrNqFvx1k+aGtv8GoDt5nl6m1x9L4JMq83qprKHS3e31GdhiOQ0Kbyy7Zt7vht84Kge/97LlZdClWXbf9vq9MsmfeEtXMczzAM+rDtwkyF54kSr1XgHwzrWdNTuyQh3IoJ8cdQzIc0b83nuDf7iC/drgvzYIjpHgeBWJ3ncQRARXgvtFcI1h2dtr6e7W9IBoOrNQhYFYA4wAPlhew+CbOgCedZPmPg88kQJBExk7SLR3pb38ZCa/e4sXi/GSTK66P9e/bll+bWdNA19HzD8a4EgR5orFcqF44FLI5kgDBIctOYGWcAIN4QQHNUnwuHTxB7339rNnxOrl13XuVg/jWhcnaq6b9ALrJr0wT5VfJcc9eyl3afarlfDxVCtlcjXl/OupE6mrI9SBs4H3SjV3UqK5UxNef/i1yNb3Sa8GAB8CU4f+YFRdDKZTT8hvfnxZd8sZwzYDp/gLMHwTQGACwv31JEjoiP+/xD3BcxG8bmXj2s29Nn4Zq3qOX35d59J101fkzN8esnbiC1OAWSFjk2pd1Gr7DmieLvMG3+khxq/wDL3w739i2XWdc4bVCevrEvydph4N8OcKG8s1dybbvWJl3lDtJ1ZoVnKsWtbqoOCMnosBll3XmYO/ndm/RtGrifFZMxI6JZo7g46eJnVioGeBXOqkrcT6/jNWTO58e6+/H1VX4yj1CP5OU49m7cQXGDy17QGBrxoJbHxWwkfEP1c3CgWLCZ8dNxZYvPK9aCMH6d3OGtMFxinoismdOfifhAT79g0E3jbCYBMAKhG4xcfoEGYER8LJIQzd0MpLq7p8h7B3of1moKVrcqfW4xiaegV/zcQ5rJk4Zz1whMLmrNZtteZ3uA9nsblTGZKxLV7lob0CjO2a3Kl71pm6r3vwQ/avmTjnTYGz00uxrJbu1N59/n+70lqy8aOcqxcUiW/smtw5E6CrztR9vwB/zcQ57DK1jfe+Pue/QCfan3lJniaaOz1gT7NDopOnCK4Em7IaDS+iS5Qfd02ef92QG4+o5+GrryRPlmx6fBm7/nsb7319zvwdzhg+FGFUmPAJfYAw4SPi+/Xhhk0dW4ay6OP32aAfR/UB0R5P0J4DfHHQ2L303cnz63rshH4mQ+4a/YhB/jL0+p0gCnCCvXfcwPFTUa7aeDRPbvgjszYsrdTpWwAcvvz6+Vv6w1iZfga8rJ4w+4vA42o5eGGyx473W9XFxfCZAXvSXaLAkzjQ4RWFY/sL8P0O/NUTZuvud41h5YRZZwC/S2b2bH9gL28gHsrQwo4MMG7ZjReAJQptmtgtrN7FpR/K7neNoQXGfgyPKZxerAKGXb7K8O5BYPxunt0Lg3hnc8m9kuYDY7uun7+pv42T6W8/aOWEWaycMIuPwevyNcDP7eSMBrt47OPthAq4jsMRA4exVb0spf8ydI+mxrZQy8HvQbomzGLoXWNYPmHmVxWuDIEHKOAwmBbECCKGk4ccxGB3QBTxB3H8j4FRXde/vKXr+vmag19nsnzCLIbd3c6yC2feDHxToRtgR68JFx94YwweylUjPkerFEB1M8qVXde/eBHB/f1VhAaSfe7p2FeQBQfozq3neAfhOAWaCk00NTXT3NyCNLXwT68/fvBzl097ba+/O5wV33uxX4+HaRTgP3V3B29dMOPNN2X50GO6h/mt38ZEl2NcWp3Cxc9dPu21S+/5Zr8HvuGYH8rUqVfc6zru+EKhiaZCE81NLTS3DFjluk0HGnE+OPGkCxtiHNxGBN8x5hERM96IwTEOxnEwxv39uM9N/KCRxsE0IvjGOAuNMVt8le/gOC6OcZ9tuHGgIUWXGuNsdYyDBPbecZyXcvAbQM6/4B83OkZWi3FwHRfHdTGOuzQHv2FUvzsj8vSdAq5bWJGD3zDgm07HMRingOO67DBghw9y8BvH43/diIPruriOi1tokhz8BvL4HccNVT5OoUAOfqP8cMdd5YPv4LpNFNzmHPxGkTPOvHyN4zg+8wtNNLe05OA3GPspuAUKhSYU2TkHv4Gk4BQ8t9BEU6GZ5qbmQTn4jeTxu4WX3EKBQnMzheaW3XPwG0Se++0DtB97zqjWloG7NhVa7m5pGjCYXBpHXlsQ3wZ/w/plDfX7/w9sJTyL9hMvGQAAAABJRU5ErkJggg==
+    mediatype: image/png
+  customresourcedefinitions:
+    owned:
+    - name: mongodbstandalones.mongodb.com
+      version: v1
+      kind: MongoDbStandalone
+      group: mongodb.com
+      displayName: MongoDB Standalone
+      description: MongoDB Deployment consisting of only one host. No replication of data.
+      resources:
+      # FIXME(alecmerdler): These are probably supposed to be different resources for the different CRD configurations
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1beta2
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Credentials for Ops Manager or Cloud Manager.
+        displayName: Credentials
+        path: credentials
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:Secret'
+      - description: Project this deployment belongs to.
+        displayName: Project
+        path: project
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:ConfigMap'
+      - description: MongoDB version to be installed.
+        displayName: Version
+        path: version
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The service where the MongoDB deployment will be listening.
+        displayName: Service
+        path: service
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:Service'
+    - name: mongodbreplicasets.mongodb.com
+      version: v1
+      kind: MongoDbReplicaSet
+      group: mongodb.com
+      displayName: MongoDB Replica Set
+      description: MongoDB Replica Set Deployment
+      resources:
+      # FIXME(alecmerdler): These are probably supposed to be different resources for the different CRD configurations
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1beta2
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Number of members in this Replica Set.
+        displayName: Members
+        path: members
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      - description: Credentials for Ops Manager or Cloud Manager.
+        displayName: Credentials
+        path: credentials
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:Secret'
+      - description: Project this deployment belongs to.
+        displayName: Project
+        path: project
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:ConfigMap'
+      - description: MongoDB version to be installed.
+        displayName: Version
+        path: version
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - description: The service where this MongoDB deployment will be listening.
+        displayName: Service
+        path: service
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:Service'
+    - name: mongodbshardedclusters.mongodb.com
+      description: MongoDB Sharded Cluster Deployment
+      displayName: MongoDB Sharded Cluster
+      group: mongodb.com
+      kind: MongoDbShardedCluster
+      version: v1
+      resources:
+      # FIXME(alecmerdler): These are probably supposed to be different resources for the different CRD configurations
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1beta2
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Credentials for Ops Manager or Cloud Manager.
+        displayName: Credentials
+        path: credentials
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:Secret'
+
+      - description: Project this deployment belongs to.
+        displayName: Project
+        path: project
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:ConfigMap'
+
+      - description: MongoDB version to be installed.
+        displayName: Version
+        path: version
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: How many Config Servers will be deployed
+        displayName: Config Server Count
+        path: configServerCount
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: How many MongoDB Servers per Shard will be deployed
+        displayName: MongoDB Servers per Shard
+        path: mongodsPerShardCount
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: How many mongos will be deployed
+        displayName: Mongos (MongoDB Shard) to be deployed
+        path: mongosCount
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: Amount of Shards to be deployed
+        displayName: Shards
+        path: shardCount
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: The service where this MongoDB deployment will be listening.
+        displayName: Service
+        path: service
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:Service'
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: mongodb-enterprise-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              k8s-app: mongodb-enterprise-operator
+          template:
+            metadata:
+              labels:
+                k8s-app: mongodb-enterprise-operator
+            spec:
+              serviceAccountName: mongodb-enterprise-operator
+              imagePullSecrets:
+                - name: ''
+
+              containers:
+              - name: mongodb-enterprise-operator
+                image: registry.connect.redhat.com/mongodb/enterprise-operator:0.9.1
+                imagePullPolicy: Always
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 100Mi
+                  requests:
+                    cpu: 100m
+                    memory: 50Mi
+
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: MANAGED_SECURITY_CONTEXT
+                  value: 'true'
+                - name: OPERATOR_ENV
+                  value: prod
+                - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
+                  value: registry.connect.redhat.com/mongodb/enterprise-database:0.9.1
+                - name: IMAGE_PULL_POLICY
+                  value: Always
+                - name: IMAGE_PULL_SECRETS
+                  value: ''
+
+      permissions:
+      - serviceAccountName: mongodb-enterprise-operator
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - secrets
+          - services
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - mongodb.com
+          resources:
+          - '*'
+          verbs:
+          - '*'

--- a/upstream-community-operators/mongodb-enterprise/mongodb.package.yaml
+++ b/upstream-community-operators/mongodb-enterprise/mongodb.package.yaml
@@ -1,5 +1,5 @@
 packageName: mongodb-enterprise
 channels:
 - name: preview
-  currentCSV: mongodboperator.v0.3.2  
+  currentCSV: mongodboperator.v0.9.0
 defaultChannel: ""

--- a/upstream-community-operators/mongodb-enterprise/mongodb.v0.9.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/mongodb-enterprise/mongodb.v0.9.0.clusterserviceversion.yaml
@@ -1,0 +1,325 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: mongodboperator.v0.9.0
+  namespace: placeholder
+  annotations:
+    repository: https://github.com/mongodb/mongodb-enterprise-kubernetes
+    containerImage: registry.connect.redhat.com/mongodb/enterprise-database:0.9.1
+    support: MongoDB Community Support
+    createdAt: 2019-03-21T10:30:00Z
+    capabilities: Full Lifecycle
+    categories: "Database"
+    certified: "true"
+    description: The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB into Kubernetes clusters, using our management, monitoring and backup platforms, Ops Manager and Cloud Manager.
+    alm-examples: >-
+      [{"apiVersion":"mongodb.com/v1","kind":"MongoDbStandalone","metadata":{"name":"my-standalone","namespace":"mongodb"},"spec":{"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}},{"apiVersion":"mongodb.com/v1","kind":"MongoDbReplicaSet","metadata":{"name":"my-replica-set","namespace":"mongodb"},"spec":{"members":3,"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}},{"apiVersion":"mongodb.com/v1","kind":"MongoDbShardedCluster","metadata":{"name":"my-sharded-cluster","namespace":"mongodb"},"spec":{"shardCount": 2, "mongodsPerShardCount": 3, "mongosCount": 2, "configServerCount": 3,"version":"4.0.2","persistent":false,"project":"my-project","credentials":"my-credentials"}}]
+spec:
+  displayName: MongoDB
+  provider:
+    name: 'MongoDB, Inc'
+  maturity: stable
+  version: 0.9.0
+  replaces: mongodboperator.v0.3.2
+  keywords: ["mongodb", "database", "nosql"]
+  maintainers:
+  - email: support@mongodb.com
+    name: 'MongoDB, Inc'
+  description: |
+    The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB
+    into Kubernetes clusters, using our management, monitoring and backup
+    platforms, Ops Manager and Cloud Manager.
+
+
+    ## Before You Start
+
+    To start using the operator you'll need an account in MongoDB Cloud Manager.
+
+    * [Create a Secret with your OpsManager API key](https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/#create-credentials)
+
+
+    * [Create a ConfigMap with your OpsManager project ID and URL](https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/#create-onprem-project)
+
+
+    By installing this integration, you will be able to deploy MongoDB instances
+    with a single simple command.
+
+    ## Required Parameters
+
+    * `project` - Enter the name of the ConfigMap containing project information
+
+
+    * `credentials` - Enter the name of the Secret containing your OpsManager credentials
+
+
+    ## Supported MongoDB Deployment Types ##
+
+
+    * Standalone: An instance of mongod that is running as a single server and
+    not as part of a replica set, this is, it does not do any kind of
+    replication.
+
+
+    * Replica Set: A replica set in MongoDB is a group of mongod processes that
+    maintain the same data set. Replica sets provide redundancy and high
+    availability, and are the basis for all production deployments. This section
+    introduces replication in MongoDB as well as the components and architecture
+    of replica sets. The section also provides tutorials for common tasks
+    related to replica sets.
+
+
+    * Sharded Cluster: The set of nodes comprising a sharded MongoDB deployment.
+    A sharded cluster consists of config servers, shards, and one or more mongos
+    routing processes. Sharding is a A database architecture that partitions
+    data by key ranges and distributes the data among two or more database
+    instances. Sharding enables horizontal scaling.
+  links:
+  - name: Documentation
+    url: 'https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/index.html'
+  icon:
+  - base64data: >-
+        iVBORw0KGgoAAAANSUhEUgAAAH8AAAB/CAYAAADGvR0TAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4ggYEhkp9JVi8gAAFENJREFUeNrtnXmcVeV5x7/Pe86dGUZQUdwAo4Kaam1cUAdm3DAYl1ZjmmhMYkUlkMYtMVVrVExqY7q4oabNp6EuMdpEq8ZGpf1oJCbKJgxqlWiIgIrACCgimwJznv5xlvue5d65dxjsvXPP4+d4t3OB+/7e37O/7wsNKhdNv9iZ8uqNQgOLadhfLnLA7CV/OOrT/3JMDn7D/XDh02s3bRr/h4ufz8FvNOnu1s9v2rL5/EZW+06j/eCJT09i1Pijdhb46ZpNGwa4Jw4x7097+9mGtHyN+KMn/fob/yyYK998byWLV727FXQPgfcXXjIjV/v9Uc7/nwkATHhq4t+q6pWKUjAOgroCf73wkhkc+KOOnPn9dwJceIkx5k6DwRjDyg/XsmD52+Eg7LHwkhkrc+b3Izl32nkAnDftgkcV7kRBUVQVxxhAw1ufOfBHHaaR2N+vwf/KE+fS7W0Z8LVp5z2t6BcIQPfhViSu9w4BLlt4yQxG3NmRg1/v8vO/uB/EmY3qOFDUC3iuiiq4xsHXBOAB3cptI+/s+KvFl87ggAaYAP3S5n/pV18WjNnBUZllxBwiAo44CIIYgxHBiMP6jzcxd8kixFIBAp7AV/546YyHcubXoXy03gVPf6noIaGS93xLT6DxAcU1DhIMQngJGFUe3P+OjhMB9r+jI2d+PciZj30JcUWkW6Yb5AQxBgeDiGCMYDCIBMw3ho82b2XOooUx5lviASe9cdmM6Tnz60AeO/NhdKveBHqCRgh6Edsjex+8doz0RIxn9r+j41BfA7TnzK9VGff0WbSu964V4QdGDIJgQpYHjyImYL/giKFblecXvo6RcsOgHrDHG5fNXN3fwHf7yw9pWbe1DZEbQNBoVvvPNHxHFSR8D1Q1dp/lECS14//uf0f7/t3CRuPBom/NzMGvFTnl4TP2VHS2IqAB3AKqgieKo4IHGAkifFVUFNcxKIogKdA1/rgXMGvJpTMPzW1+jcjJD5/u2y7hwZDJSRB9WIvve9FzP9YPX3kUn2vxFqR4fWbk7e33Aoy8vX/Y/7ot6Y576DSePutJTn749O+DjAd82y0SZe5EAk0QvCcUH0FA4K33VvvvV/bXHrbLqXu/suhbM1/LHb7/RznxodMwyJ+ImFccEdd36ASDH8b5Dl8Q3gVhXuj8SfC+4zg8+9rve3D40h4gMAp4sd5tf92q/elnT0PR/0Q914spdgJ1roE61+i1F5mAwMUT6S1h7u8PTl/dgj/2wVNvVThEAzx8e2/bdBJef2jMLd9Atbd//cEjb29/LAf/E5ZjfzGK439xyi6q+o2wQqfqUXT4Am8+8Nw8y7FLagXdtn/K50dMaT8OYMSU9hz8T0KeO6cTD+9nCq2hCbYJrBnPovvs/H4vma9avICHARZ/e2YO/ichHf9x0qkopyVr82GDBpE2KDZtqHWvhpogeL+lUCgJbtaVkN1GTGmfmqv97SyjH/hsyNfvpZMwCdWeUuqhdogS/CXB7oWcO2JK+3Bf/Y/Jwd8eMvtrzzD6gc8eC9rmqaXC1c/RqfoFHE81075HvgCWBthWq+//qS2gj+bM386i8IiStu+R8leNWXjb67dDvMgxrBp8zbgAOGrElDFfWPztWTn4fS2j7h/LkQ+ceKaiu0VAaqjOk2zGsvvF19ZDZPfRLPi1zFVWrgUYeduYHPy+ksPvH0vnub9B4W+8BGsjSGL2PAGVxplP4vt+Sb9igKMsjxDL+yPKqJG3jTl50eWzcvD7Sl489zccdv/Yg1T1mBg3LeRDhnuZXr+t/hNaQqHgOj1CngQ7OU+s4tCjAPvVCfvrQu2r6r1gVd80bs9Dey+AemrX7YqRgGrC69fIfJRgcnRF0YD1b7Avay607nfbmDPZsiUHf1vlT+87nkN+dsLexTRu3JVTjSduvIR6Twd8dhRgpX9LMzle6q3EMKheseSqeex36+gc/G2RBef9FlRPUWj1U7aaAEIDmy4Z6t1iOxpL+GA5gl4Gm8uC3HMWqGO/W0cftuQ7s3Pweyv73ndcyObJIavjSRvbU/fifrpGjVsxb59EgFecPGWZ3Jss0L/Wg9qv6Xr+gfcd1+bAbCeozTviPwrghvV6kUSzZrGG74hBwH8UgwiEzZ2OGFzH4dW3l7Fu00d9NhDBn7MROBh4a3ENa4CaVvuiXBxT82qHepbXL/HQL5b0EUmVedmGDJ/0cAXSCpyyuMZVf002cI786bEItCi021k5FX/4QxstqsWmXJGiLRcJ7vcfRSRKBdjNnapUFOb1LkJhMvBvuc2vUhaNfw6FQQojwyXVWM4YqjGvH5VEsVaLqd6MeN+2/64xlTA5Ow9ouQJe4lIYtu8tozty8HshnuqXvXj1naxcnP/cSyV80l4/VnJHoySPY6RH+kehnw2uVhT+fScHv3dyeXzwNeq/KC7FSoIdDwND0KP2bdUMSONM9rJY3Pty75H73jK6NQe/CtnvnvbBqowopmxJlWHTGkFT+Xs0I0ljN3daKrsS+98L+RSwRw5+hTL87na6VcbZ9hrNAFATmT6NR/Hx9K4mcoPxhVzbK4YOUsaX5uBXKO9cOBPfyy9n7232B80cVi9fmA3ESvhkNXdq34CbeVnz7KIc/OrkzzwbSEtd26ocqy+PhJOX8vpJN3d621DGreKrzfvc3HZYDn6lMTJ6UBHwEKSMjpykVlAt7fVnNHdGwEp5FvcMdrF+4GVcwMn73NyWg9+TDLtrtKMwFEpU5EJHzvrQixie5QymJ0LsDnuVZkUTMwvsHhVBx1tXzMkzfD1JNzLWsRmugooPsETZPcW/R2IFHN+DV8LQXVRRMUEKMPxMYgma0kxOmgoyzEdFmT6Aw3O1X5mM1WTEZoVu8UZMUmVem9BRCZdkG1eyEuBFXUAVMrks2BlFwOH73tS2Yw5+z2p1XFaRxqvI609z1s7yxU2HWhpfKmZ0T+X80DE0iQs4Kwe/Z/APTa6viK27s7J1ttdfbXOnJl35KsEtBXJ2TUABPSG3+WVkt7vaBgEFjaJ38JDAvqeZLyWehyAhQf+eiNXNE34mUcyvHiWrOJKeHxW7hQk5Jge/7JjJEBXfsfMiFoWUlcBpI3Lo1C7hkiz9UtxtJ6jrq6eokZRLJ71SgVrFXYL6qd5c7ZeRnYNwO8bwLAcs+VnKS1dKNnfaWT9T0ZYsPS/gKH4ieMHVHT33P9v7prYhOfglxIMhsZ46jdttuxQbX2xZfXNn2LpdcA3lV+lkAV0EtzsGspSLFATIwS/DsB2ChFtmNi9ksO39q/auuTMxfcpyPQ10hUo/mUhQHZTb/AwZPLUNYGcPMBQ3SkRBRYNuHX9m+EkeuyYnMTNgYuz3k0Rhy5f/OnQnQ21h+mKnDog2dSw5AXbJmZ8haybOQWFgejPEeMq2VJnXs5o7PXvcJavM62f7wnu9Sku7qki5q/y3BRiQg196bAfGnTVSS6/CnL5nq2dNLse2l2dZSR6NL+UuklIqA3vbf2IhB78MO7I8+hAkz4/YYuCFyzPC1TZZzZ3JvF9sJU/vmdwbGZiDX1r20MTOKWECx4uFcHFVrclevNhzDxL782BNKlNFzN7LjKU9iWtqkUxNJXkUXS+RI1bcDtlDMYHjpgkl7QXungabK4f7Knqov8LW2mhRk16/KK5r+gTgWGhaJ1Jj4LNOiDdlSjHHl1nmdaLPLc/fXqhhfU+iFR69a9hUa+ZplQpDtq+CqX/wSXFeLIb7QHsKjhAu0wlCQaxVPFb6N4rrJbg1SPwE6/3K9fFpKSZrDwCXvFcBNufgl5bV9vq7MMZPTweNGjnsoo79WTSVxAT2XvxCj81+wDHGdyQrZW85nd+zfJQ7fGXC/axxTfbc99Tc6VmsVs06REGjtK+UOGcnc+lWun+cKto+FFifM7+EeMqHRgJeBupcokRN0fe3tYOHX5zRmMkAzQKagP1Blg8tbuci2Wq6r2Vdzvwyah8oEcRlLbDKDKeKmoH4Hj6aTA6FMWTyeI3t55mtzcEvLe96mraimuq5tdV9Vmt3Yv+9jOROBLZsH7AzNm9SD97PwS+lEye9sCL8N6l1SEKsBaua5s4UlzXe3FltvFYZyLGyrtX7Lx6szMEvP5wvJ7N0sRi/THNnvAwbP1ghy2RUw/keQSZ74YclH6y4eu7WHPzy8lRy1L2kzdf4ku2wuTOaJJa697dlIb7lOumNmtKTJ35FUUCPK3pKNoXU3LGstQj+Q1piG1UyGJ+eFOk0bkyD2Dt3EqzBz4CqsrV5Ve3P+1QOfo92f+48YItmeP3pHn57V83k2XiasXmTvcwqDPO0t0yu9qf9Mge/Uruv2RF3chdNz8rwkfAPsvbwKf4hyZp+KTb3TYj3znfnrRr+D0fm4FcgL0SJnxJePwn7H2/uJHHAAtnNnfKJxfevArzz3Xk5+OVk0E+OAvh1qbNtyYj9yzd3SvxbGt+fY/NWb/vpr+JKn85aZFgt2nyAx1KAa7H33o6hY15/LOGTbACLO4ihryCS7BDoE7CT5mR6Dn7lE0CBB2MnY2Tw39um5s7q9+Cs8uQtW57Mwa9ObshKxKQOTbK47SXUf1ZzZywrCGwtofarBLec/Peya+ZtzcGvzu4vAV2qatvrDJ/cbu4kq7kzWeaNr+CNFmv2DdBZ8v1aZVetqn3WTZq7ybaVqdCbnps7S63vKzqF2tdAJ2UVsGDYD4+sSfBdaluuBh0fdubYnTqVNHfaZ+l4QStX6Cs4wfKfrVs9ZPv11M5fds28DTnze6H6102a2wU8mqnuS2yhni7zxhs8U3F/H1O/mBZWgB/WMrNqFvx1k+aGtv8GoDt5nl6m1x9L4JMq83qprKHS3e31GdhiOQ0Kbyy7Zt7vht84Kge/97LlZdClWXbf9vq9MsmfeEtXMczzAM+rDtwkyF54kSr1XgHwzrWdNTuyQh3IoJ8cdQzIc0b83nuDf7iC/drgvzYIjpHgeBWJ3ncQRARXgvtFcI1h2dtr6e7W9IBoOrNQhYFYA4wAPlhew+CbOgCedZPmPg88kQJBExk7SLR3pb38ZCa/e4sXi/GSTK66P9e/bll+bWdNA19HzD8a4EgR5orFcqF44FLI5kgDBIctOYGWcAIN4QQHNUnwuHTxB7339rNnxOrl13XuVg/jWhcnaq6b9ALrJr0wT5VfJcc9eyl3afarlfDxVCtlcjXl/OupE6mrI9SBs4H3SjV3UqK5UxNef/i1yNb3Sa8GAB8CU4f+YFRdDKZTT8hvfnxZd8sZwzYDp/gLMHwTQGACwv31JEjoiP+/xD3BcxG8bmXj2s29Nn4Zq3qOX35d59J101fkzN8esnbiC1OAWSFjk2pd1Gr7DmieLvMG3+khxq/wDL3w739i2XWdc4bVCevrEvydph4N8OcKG8s1dybbvWJl3lDtJ1ZoVnKsWtbqoOCMnosBll3XmYO/ndm/RtGrifFZMxI6JZo7g46eJnVioGeBXOqkrcT6/jNWTO58e6+/H1VX4yj1CP5OU49m7cQXGDy17QGBrxoJbHxWwkfEP1c3CgWLCZ8dNxZYvPK9aCMH6d3OGtMFxinoismdOfifhAT79g0E3jbCYBMAKhG4xcfoEGYER8LJIQzd0MpLq7p8h7B3of1moKVrcqfW4xiaegV/zcQ5rJk4Zz1whMLmrNZtteZ3uA9nsblTGZKxLV7lob0CjO2a3Kl71pm6r3vwQ/avmTjnTYGz00uxrJbu1N59/n+70lqy8aOcqxcUiW/smtw5E6CrztR9vwB/zcQ57DK1jfe+Pue/QCfan3lJniaaOz1gT7NDopOnCK4Em7IaDS+iS5Qfd02ef92QG4+o5+GrryRPlmx6fBm7/nsb7319zvwdzhg+FGFUmPAJfYAw4SPi+/Xhhk0dW4ay6OP32aAfR/UB0R5P0J4DfHHQ2L303cnz63rshH4mQ+4a/YhB/jL0+p0gCnCCvXfcwPFTUa7aeDRPbvgjszYsrdTpWwAcvvz6+Vv6w1iZfga8rJ4w+4vA42o5eGGyx473W9XFxfCZAXvSXaLAkzjQ4RWFY/sL8P0O/NUTZuvud41h5YRZZwC/S2b2bH9gL28gHsrQwo4MMG7ZjReAJQptmtgtrN7FpR/K7neNoQXGfgyPKZxerAKGXb7K8O5BYPxunt0Lg3hnc8m9kuYDY7uun7+pv42T6W8/aOWEWaycMIuPwevyNcDP7eSMBrt47OPthAq4jsMRA4exVb0spf8ydI+mxrZQy8HvQbomzGLoXWNYPmHmVxWuDIEHKOAwmBbECCKGk4ccxGB3QBTxB3H8j4FRXde/vKXr+vmag19nsnzCLIbd3c6yC2feDHxToRtgR68JFx94YwweylUjPkerFEB1M8qVXde/eBHB/f1VhAaSfe7p2FeQBQfozq3neAfhOAWaCk00NTXT3NyCNLXwT68/fvBzl097ba+/O5wV33uxX4+HaRTgP3V3B29dMOPNN2X50GO6h/mt38ZEl2NcWp3Cxc9dPu21S+/5Zr8HvuGYH8rUqVfc6zru+EKhiaZCE81NLTS3DFjluk0HGnE+OPGkCxtiHNxGBN8x5hERM96IwTEOxnEwxv39uM9N/KCRxsE0IvjGOAuNMVt8le/gOC6OcZ9tuHGgIUWXGuNsdYyDBPbecZyXcvAbQM6/4B83OkZWi3FwHRfHdTGOuzQHv2FUvzsj8vSdAq5bWJGD3zDgm07HMRingOO67DBghw9y8BvH43/diIPruriOi1tokhz8BvL4HccNVT5OoUAOfqP8cMdd5YPv4LpNFNzmHPxGkTPOvHyN4zg+8wtNNLe05OA3GPspuAUKhSYU2TkHv4Gk4BQ8t9BEU6GZ5qbmQTn4jeTxu4WX3EKBQnMzheaW3XPwG0Se++0DtB97zqjWloG7NhVa7m5pGjCYXBpHXlsQ3wZ/w/plDfX7/w9sJTyL9hMvGQAAAABJRU5ErkJggg==
+    mediatype: image/png
+  customresourcedefinitions:
+    owned:
+    - name: mongodbstandalones.mongodb.com
+      version: v1
+      kind: MongoDbStandalone
+      group: mongodb.com
+      displayName: MongoDB Standalone
+      description: MongoDB Deployment consisting of only one host. No replication of data.
+      resources:
+      # FIXME(alecmerdler): These are probably supposed to be different resources for the different CRD configurations
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1beta2
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Credentials for Ops Manager or Cloud Manager.
+        displayName: Credentials
+        path: credentials
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:Secret'
+      - description: Project this deployment belongs to.
+        displayName: Project
+        path: project
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:ConfigMap'
+      - description: MongoDB version to be installed.
+        displayName: Version
+        path: version
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The service where the MongoDB deployment will be listening.
+        displayName: Service
+        path: service
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:Service'
+    - name: mongodbreplicasets.mongodb.com
+      version: v1
+      kind: MongoDbReplicaSet
+      group: mongodb.com
+      displayName: MongoDB Replica Set
+      description: MongoDB Replica Set Deployment
+      resources:
+      # FIXME(alecmerdler): These are probably supposed to be different resources for the different CRD configurations
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1beta2
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Number of members in this Replica Set.
+        displayName: Members
+        path: members
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      - description: Credentials for Ops Manager or Cloud Manager.
+        displayName: Credentials
+        path: credentials
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:Secret'
+      - description: Project this deployment belongs to.
+        displayName: Project
+        path: project
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:ConfigMap'
+      - description: MongoDB version to be installed.
+        displayName: Version
+        path: version
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - description: The service where this MongoDB deployment will be listening.
+        displayName: Service
+        path: service
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:Service'
+    - name: mongodbshardedclusters.mongodb.com
+      description: MongoDB Sharded Cluster Deployment
+      displayName: MongoDB Sharded Cluster
+      group: mongodb.com
+      kind: MongoDbShardedCluster
+      version: v1
+      resources:
+      # FIXME(alecmerdler): These are probably supposed to be different resources for the different CRD configurations
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1beta2
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Credentials for Ops Manager or Cloud Manager.
+        displayName: Credentials
+        path: credentials
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:Secret'
+
+      - description: Project this deployment belongs to.
+        displayName: Project
+        path: project
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:core:v1:ConfigMap'
+
+      - description: MongoDB version to be installed.
+        displayName: Version
+        path: version
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: How many Config Servers will be deployed
+        displayName: Config Server Count
+        path: configServerCount
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: How many MongoDB Servers per Shard will be deployed
+        displayName: MongoDB Servers per Shard
+        path: mongodsPerShardCount
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: How many mongos will be deployed
+        displayName: Mongos (MongoDB Shard) to be deployed
+        path: mongosCount
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: Amount of Shards to be deployed
+        displayName: Shards
+        path: shardCount
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+
+      - description: The service where this MongoDB deployment will be listening.
+        displayName: Service
+        path: service
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:Service'
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: mongodb-enterprise-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              k8s-app: mongodb-enterprise-operator
+          template:
+            metadata:
+              labels:
+                k8s-app: mongodb-enterprise-operator
+            spec:
+              serviceAccountName: mongodb-enterprise-operator
+              imagePullSecrets:
+                - name: ''
+
+              containers:
+              - name: mongodb-enterprise-operator
+                image: registry.connect.redhat.com/mongodb/enterprise-operator:0.9.1
+                imagePullPolicy: Always
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 100Mi
+                  requests:
+                    cpu: 100m
+                    memory: 50Mi
+
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: MANAGED_SECURITY_CONTEXT
+                  value: 'true'
+                - name: OPERATOR_ENV
+                  value: prod
+                - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
+                  value: registry.connect.redhat.com/mongodb/enterprise-database:0.9.1
+                - name: IMAGE_PULL_POLICY
+                  value: Always
+                - name: IMAGE_PULL_SECRETS
+                  value: ''
+
+      permissions:
+      - serviceAccountName: mongodb-enterprise-operator
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - secrets
+          - services
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - mongodb.com
+          resources:
+          - '*'
+          verbs:
+          - '*'

--- a/upstream-community-operators/mongodb-enterprise/mongodb.v0.9.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/mongodb-enterprise/mongodb.v0.9.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: placeholder
   annotations:
     repository: https://github.com/mongodb/mongodb-enterprise-kubernetes
-    containerImage: registry.connect.redhat.com/mongodb/enterprise-database:0.9.1
+    containerImage: quay.io/mongodb/mongodb-enterprise-operator:0.9
     support: MongoDB Community Support
     createdAt: 2019-03-21T10:30:00Z
     capabilities: Full Lifecycle
@@ -260,7 +260,7 @@ spec:
 
               containers:
               - name: mongodb-enterprise-operator
-                image: registry.connect.redhat.com/mongodb/enterprise-operator:0.9.1
+                image: quay.io/mongodb/mongodb-enterprise-operator:0.9
                 imagePullPolicy: Always
                 resources:
                   limits:
@@ -276,11 +276,11 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: MANAGED_SECURITY_CONTEXT
-                  value: 'true'
+                  value: 'false'
                 - name: OPERATOR_ENV
                   value: prod
                 - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
-                  value: registry.connect.redhat.com/mongodb/enterprise-database:0.9.1
+                  value: quay.io/mongodb/mongodb-enterprise-database:0.9
                 - name: IMAGE_PULL_POLICY
                   value: Always
                 - name: IMAGE_PULL_SECRETS


### PR DESCRIPTION
@robszumski I removed the old PR because we decided to not make the change from 3 to 1 CRD in this release.

## Changes

- Updates the CSV from 0.3.2 to 0.9 to match the operator version
- Changes the `WATCH_NAMESPACE` to `metadata.annotations['olm.targetNamespaces']` as detailed in the old PR
- Sets the image version to `0.9.1` which is our current `0.9` version in RedHat registry
- Checked with `operator-courier` and made sure all missing attributes were added