### PR TITLE
[upstream] Add Postgres-Operator from Zalando

### DIFF
--- a/upstream-community-operators/postgres-operator/postgres-operator.crd.yaml
+++ b/upstream-community-operators/postgres-operator/postgres-operator.crd.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: postgresqls.acid.zalan.do
+spec:
+  group: acid.zalan.do
+  names:
+    kind: postgresql
+    listKind: postgresqlList
+    plural: postgresqls
+    singular: postgresql
+    shortNames:
+    - pg
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1

--- a/upstream-community-operators/postgres-operator/postgres-operator.package.yaml
+++ b/upstream-community-operators/postgres-operator/postgres-operator.package.yaml
@@ -1,0 +1,4 @@
+packageName: postgres-operator
+channels:
+- name: stable
+  currentCSV: postgres-operator.v1.2.0

--- a/upstream-community-operators/postgres-operator/postgres-operator.v1.2.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/postgres-operator/postgres-operator.v1.2.0.clusterserviceversion.yaml
@@ -1,0 +1,340 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: postgres-operator.v1.2.0
+  namespace: placeholder
+  annotations:
+    capabilities: Full Lifecycle
+    categories: Database
+    certified: "false"
+    repository: https://github.com/zalando/postgres-operator
+    containerImage: registry.opensource.zalan.do/acid/postgres-operator:v1.1.0-25-g2c02b37
+    createdAt: 2019-05-10T10:30:00Z
+    description: Postgres operator creates and manages PostgreSQL clusters running in Kubernetes.
+    support: Zalando SE
+    alm-examples: |-
+      [
+          {
+              "apiVersion": "acid.zalan.do/v1",
+              "kind": "postgresql",
+              "metadata": {
+                  "name": "acid-minimal-cluster"
+              },
+              "spec": {
+                  "databases": {
+                      "foo": "zalando"
+                  },
+                  "numberOfInstances": 2,
+                  "postgresql": {
+                      "version": "11"
+                  },
+                  "teamId": "ACID",
+                  "users": {
+                      "foo_user": [],
+                      "zalando": [
+                          "superuser",
+                          "createdb"
+                      ]
+                  },
+                  "volume": {
+                      "size": "1Gi"
+                  }
+              }
+          }
+      ]
+spec:
+  version: 1.2.0
+  minKubeVersion: 1.10.0
+  maturity: stable
+  displayName: Postgres-Operator
+  description: |
+    The Postgres operator manages PostgreSQL clusters on Kubernetes:
+    1. The operator watches additions, updates, and deletions of PostgreSQL cluster manifests and changes the running clusters accordingly. For example, when a user submits a new manifest, the operator spawns a new Postgres cluster with necessary entities such as StatefulSets, Services, and also Postgres roles. See this Postgres cluster manifest for settings that a manifest may contain.
+    2. The operator also watches updates to its own configuration and alters running Postgres clusters if necessary. For instance, if a pod Docker image is changed, the operator carries out the rolling update. That is, the operator re-spawns one-by-one pods of each StatefulSet it manages with the new Docker image.
+    3. Finally, the operator periodically synchronizes the actual state of each Postgres cluster with the desired state defined in the cluster's manifest.
+    4. The operator aims to be hands free and configuration happens only via manifests and its own config. This enables easy integration in automated deploy pipelines with no access to Kubernetes directly.
+
+    Please, check out the user documentation for more details about how to use the operator: https://github.com/zalando/postgres-operator/blob/master/docs/user.md
+  keywords: ['postgresql', 'kubernetes', 'database', 'managed-services', 'data-infrastructure', 'cloud-native', 'postgres-operator']
+  maintainers:
+  - name: Zalando SE
+    email: opensource@zalando.de
+  provider:
+    name: Zalando SE
+  labels:
+    name: postgres-operator
+  selector:
+    matchLabels:
+      name: postgres-operator
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAhwAAAHqCAMAAAB4A2fXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAACxFBMVEX////6+vrn5+fV1dXDw8O5ubmysrKsrKzm5ubr6+vGxsaoqKiPj4+MjIzFxcXq6ur5+fnNzc2ioqKhoaHMzMz39/eUlJSWlpb+/v7w8PCnp6empqbb29uSkpLY2Nifn5+kpKTExMS/v7+Ojo7Kysrl5eX4+Pi3t7f9/f2bm5v19fX29vaYmJjU1NTCwsLT09O+vr7S0tLs7OyRkZGVlZXd3d2QkJDp6en8/Pyamprt7e2cnJyenp77+/vHx8fy8vLz8/Pv7++Xl5e2traNjY3h4eG1tbXx8fHIyMju7u68vLy6urqTk5Pi4uLj4+OpqanX19exsbHf39+wsLCZmZno6OjAwMDBwcHOzs7g4OC7u7urq6vLy8udnZ2vr6+9vb3Z2dmjo6O4uLjW1tazs7Otra3a2trR0dH09PTQ0NCgoKDPz8/Jycmurq7e3t60tLShoqK0tbWCg4OPkJC1traFhobc3NyMjY2LjIyYmZmXmJisra2goaG/wMCdnp7X2NiHiIiKi4vk5OSTlJSvsLCio6OQkZGGh4eEhYW4ubmNjo6bnJyDhISJiorGx8eBgYGAgIC2t7eRkpKFhYWoqamDg4PAwcGtrq6IiIiJiYmGhoaCgoLr7OzR0tKUlZXp6uqEhISlpaWHh4eqqqqcnZ2ur6+VlpbExcWmp6eKioq5urqIiYnq6+vHyMiOj4/V1taSk5PW19eZmprS09OLi4vZ2tqlpqaam5vm5+eys7PJysrY2dnDxMS9vr7Cw8PFxMSrqamfnp6Zl5eioKCura3Lysrv7u61s7OamJi/vr739vbh4OCfnZ2mpKSbmZmhn5+trKzZ2Nidm5urqqrf3t7KycnAv7/T0tK8urrOzc2+vb3Qz8/Hxsbb2trW1dX19PS1tLTJyMjs6+v5+PjEw8Olo6OnpaWtq6vR0NDn5ubd3Nzo5+cXPGVjAAAAAWJLR0QAiAUdSAAAAAlwSFlzAAAEsAAABLAAkCsXMAAAAAd0SU1FB+MCBg8HFrNmq5sAAAAQY2FOdgAAAoAAAAKAAAAAAAAAAABwkhZkAAAaZElEQVR42u3d+WMT6X0GcBvf2OOVFx8yIAzYa+QDsLEZ39gYAwaMwYC5jL0YFhsMmETJkjZNky5NmrurZkuzG9o0LOmRNumVNL2btmnTNGmTHumRHmnT+/gnaklzSvPOvKM5viPp+fyya1szmnfeB+md6/sWFQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkpuJNJaVl5RUV5WWlJZXF1FsDwVG1ubpG0Kiprn2OepsgCEJ1zwsGttSHqLcMiDXUNgoMjbUN1FsHlEqaBBONdWHqDQQqzVsFC9uaqbcRaGxvtMqGIER2UG8lUKhND0JTy86dLRnfM7uotxP8t1ubgNaKthfaU79vr2yraNX+bU+UelPBZ2Wa7u+o79T/sauuQ5sO6m0Ff5Wqfd+91+CjIVrSrb5iH/XWgp/2qz3fEzJ+SahHfU0v9faCfw70yd3ef5D9qoP98qvEAeotBr8Mtsi9PjRs9rrmEfl1o2PU2ww+OaSMRMfNXzihpGMz9TaDP5pF+cTGYauXHp6Uv1hwqrQwHJE6fOqo9Wsr5VMex6i3GvxwXO7vQzyvnpaTdIJ6u8EHJ6XubuE68xndIr38FPV2g/fGZqTePs33+ln5EhxuHsx/O6TOruZd4Iy0wFnqLQfPzUl9fZB3gXPSAueptxy8FpZu4ujmvskrfCG1xAxuC8t389LnwEX+RS5Ji2yi3nbw2GWpp8/xL3JFWqSeetvBY9KBbKuNY48x6aGWq65vTPHxgaObDrdT7xOQLEhX0uwsI12nO+PqhsxPz8l3FF2Yu3acer/AhsVUfyzZWUY6wOlwbysGXrygv1N1amEHxrvkJrM43yl9FfW7tAnh69WCgWXOs3LgmT7bBytFRftSy9S4swUHWwSGPTgJS0saXJbaWUZ6iGHKjfd/7ozAtsXyHgLwknQOrMfOMtJTDBHn7x6tbRXM9FdR75+CNpTqhSN2lrkhnVR1/ObPbREsTOLOAELLqU7YamcZafy4xel73+yzyoYgDHVR76EC9lIWRx7SI5Llzt45vM86GhtuUe+hAiY/IWvj4/uwoB3EXsvyEktxBVc2BOEy9S4qXCtSF6zyL7IqLZJ84H44EmmpzeJu43bLcg+yvtvU+6hgdU2luqCCfxH5n3yy02ojCdV3bA4NOi2HoirckEhG6qWpcd4FOqWjz7XED+HRSEp/+fZB/jdtWOPPhtA6zL9icJX8CDV33Q15lJJ8nHo2orrQ8wLnKoq5v1OS3L/8C3xOSD0ww3mlPCTX/0men7oa0eEbfgzyjkUlkRD1TipYO6UuuMT3cvk+sOXED2PdkXQcw4+r9rIhCHep91HBuil/tXOdqj4gn+8uSfx0PWLAavix1242XL5zBPiFF6UuWOO4CDomV7DtSD4CNRcxZjb8eKHGdjhaUQGVilK55Yb1a5XqUMn6LV2NESbW8KOh23Y28IwMnfA2uQ8sCytsll+5nLxP627ElOHw46UssoFTHXTmp+ROmDZ/4T35dVOVyZ+3RixkDj9umoZgam1u973V1buHeu4PaX+/TL2LCtgupRdeNHmaOvqi8rLUSZFhq2xkDj/GZ9jJ6Lh0NKR5acPKKeUbqMbGCTZwV3hB6aGtzDOl4+qZq+pUhGp5wrFheVoZfsyxklFzxOACXnj9vHRwhCJkdG6rH+J9mw3/lYZX1X/zQxOp31l+q6hulYQSS1xhRKO1h3V17cSD5Hfeduo9VJgakkPLw5oy1qOZhUijJaPq3/vlax3h06eauOOxMfyIDo4aZ+OW2Q0DA4n7kXDdnkL0LXeS/92krYo/ubtS89RIeNPuSc0fZyo1i7fvreD/+Oi4bxiNiEVZ0+h0K+riknhr7G2pc18H9I8Vzdy/1Lty5cpK76X7+jHkZPrX/0T9Mm86RKNsjFrfYj7bxHEKBtzWFovF3p763+PLAodlowcVh2s7eLJheGp0geeC3zjnhR9w0dGXN8IRe5j6IcpxU+cRRnVanuFHn1E4KvjK3Yao91ThOfyORDZi3yOPMM+NmEdjZN1kZaGzS/Y/OBZQCjmgQt8bS3mn/NE+tjnCjkZks1VPTtQ/b/LBYTTeQLmFoPq+mOxdIfl3DZv7jaPBOTnkwCXW8MNgNBrBDYBB9f0x1bvVf8KDK+czvgBqlla4T2Czhh9TmeHYS70LgOE9MS3dU6nFV/YtKOdMhxb2XbH5uHu7wfDD4FvFxh3v4Kv5H9CFI/bK9bQXFDcPPHo00JxlGYSM4UfmcLQGxfUDqusHY+ne6/JjqfrhR+YHB24qD6jo+2KZ3nHP5QPLwXVl+JE5HBUnqHcCGHt7zNAP3XP7bk15+JFZhwOTcgRUfYzl/e99j9vnHsY3hh99mccqs9Q7AQydfjlm4gPv+uDlWXefXq7MvMlniHongKHmD8Us1bn7lpcywoHhaCCNfdg6GzHex145ZT5U/5B6N4CRWxzZ+Ii7VR67Mg9k8ZxSEF3iyEZs0t33XM/IxgXq3QAGdnyEJxy2yl1bm84IB0p9BVDVR3myEfthd98182AF49HgMThrbmjd+VtpdWSEw1bJZGXrK6+X2HbzKGqZcjE8a26k0923zTwFZn8mn+i1kVfj2am5wV3UqoD9CGc2Pubu2x4WnIdjNpJlMpJeq8UMHRbucGYj9qPuvq/Bg273bK5i72Mn2dhwC+kwNfsybzh+zN037s0MR629NZx2mo14vIx69wcaz1lzyXvcfee2zHDssbWCsVbH2YjHuWfOLUBcZ80lLt+jtSszHPbKfO1yIRtxnHdj+zh/Nl5x+a17MsNh7xTsjBvhiGMiXJZS/mzE3ufye5dlhkOw8+E07Eo24nimkuEh11lzidsluE4ZhOOmjeWv20jA49ffeOMTTwz/dJ+6EwLqx/nOmkt+wuV3P2kQjgc2lr/MmwxhV+oDKXy4ZE/mV5Hj2YPyU9cn7WQj9pMuv/1ug3BEbNzMfM04Cq9GzpTtamurPVnR/ankL6p19wEMHxrVn1K1NbNywQhvs5WNl6PO31Kn1CAcwnX+5Y3C8WRrr+ZWxrFzGx8UTzO2+4UIwmHlhq1sxD7s9vtfNgqHjWnlMsPxWsbVkgfxNw3ue73diHCYW7WXjZid4QCX7UbhEPiPLDPCsTOzGtBI3PAugAOfQDjM8J81l1xzewvmDcPxjHv5tHA8Mai0PPaYcRrjHsJhYuJtNrMRc/2Jki7DcAjneJfXh+O1HQYvqYy/YXxlLdyEcDCNfdpuNj4Scn0jhgzDMcp7wKILx2PDmqQ34y2MhUsQDqafspuN2E+7vxGMwsUvci6uC4dxSdLLcdZtr+E+hIPhZ2xnI/Zx97fikHE4BM4LpdpwzBm/5HKcWY1yH8JhzNZZc4nNWy14vMAIR4RrdihtOGoYT/KWsO/XGEY4DB14xX42Yh7c9xCeZKRjiOvmTk04WJdkZuPs2dMbEQ4DDfbOmku8mAH6BiMcQsdxjqXVcDD7tyHOnpPlGMKRKfyz2WTjbV5syjlWOISh56yXVsPB/lSLfIZ5k+gqwpHp52Kxn3/l/XbDYeO0tg2LzHT07bBcWAlHN/s1L8VPs/40gHBkaD+evEgZbmj+7PbPvfUtv8AZjt2ebEy9wFZmVS5GCYfJudt13XGMrsBpMcJhaeIX3/pLHOH4ZU/evL3fJB3dFh8ecjiemJS0Czc+Vp9sO67/+nkV4eBx4nO/YhUOjx4erBPMPG96iCSHw7Qa0M34mnLJvkyfoscIB6fPXvqYWTY+6tHbRhdN0yEstrGPkuRwHCsKm0S3Ii7XoGte0/8F4eAX/vw72eF4l1fvenTKPB3C1M5dR42f0ZXD0VZ02aTqcfFofClVc2Zb2vN0CIctK+9mheODnr1nqcCh6a7BknI4Sm5/odXkDYrPxyMl0UQBspD+D08QDnt+lVGM4Y5n7xitts5GxPCSqxyOkx3x+LzZW5zb+eQLW0c+kTaAieJoxa6xS4anQOadr5ml3XKisG3GQwrthTeLqi9d6/t3pA9ehhEOI9GG5qqq5gbGDcPDX8zMxstezv3csMU0GuI1xklObTgE+xu4H+HQu71j84NlZRqLvuUHtTsMjgbqMu4g/DVPtypUbpKNJebUPBz3c5iZQzhUYysnDWf3HT25kn7v1a+njzx+w+NtqxcZ0XhqcnOiLhx9dqv3D34G4ZDN95icjJw5ckX/6vYFfTjavN688VMGh7RTC6Y1a/X3kNotJyZfdyv4cAz2LloN+kZW9d/a+rqkp7N8YxsGruqnMRaWD1k8Va0Px6cqrd8jemdhlzSAGWxEOBLG6i5YRSOhu05Xn/g3tXeL+TJd49jKxepIajD09Gqv9R0daY8m1ISsFjiduOVc+p66ZH0zSCF4OMQTjWQ8SrTLff4DSjY+6d/WDt5u7uQ88kh/qMniOt3ES4krbW+mHpw99wTh2PgyL+eNRsIz7aHBbynpCOacfOnhMB8YPXo9+aJUvcLK1+MIR9H+PjvZ2PhA79Us3CuH47epm2GIHQ6DEyPh/uRrUvWz19+MIxxjp+xFI2FOM76olcKxPftN8FB6OJTrL+daR1Kj04F65SzObPIlTaHE/+sLVBZoOE6M2s+GIIxqvlpOpcIxQd0SQ+nhOCv9flDY+KH7/pG5oVfjjfL4pTbxisfJB2frUZ+jqGi+yeTro5H9fdOoTrkTTp5K/xB1S4ylh0M+Xzar/aX8NflS4odkJcvVtHLYBRmO0xGjnu+fm77+XGrE3vDc9enzjUbJUZ9l7kw8b/1F6qYYSw+HfFpku/aXcsWvM4kfEh8cVZ+KIxznMid7FkanB9LHauH52szJC2rUq9tHNw5Zfoe6LcbSSzDIFxIrtb+Vy4xuTfyQuGmoLI5wbMr42qgpY9VFmX2Qfu5afKT88XdjsRK+t/RbWjhE+ffFjw1+u5D4ITFM7UE4TqSPN8TdZo8YntiTFo8Z5aGi8KdjwxxvSCAtHGqxhTWDcCQzkXjeN1RR6OHoSj8rumRV/XXgqX6BIeVO7cqPBnRmgbRwqPVENWV74h3S75Kj1Kbk/94q8HCc1/d0E8eMnOHL+svm6nRrh6hbw5AWDrWGbqfme0VuRrgm8VPyC3JPYYfjmj4bz/gegh5Y1C2lnHC0e6eEb63Ud7KmTPUzg9/eSPw0tbEn1l8r6HDMt+p6uZT3ayFUoV2sNegV45lfK0U71N8qg+mbyR+H7p5Jn/WrsMIR3qnt4ykbN44PPtAuueZ2VVqXpYXj1TblH0GV+lulcsf+OENhhUNX/HXK+ml1jbCuYobLM9e7LaMO6dSZGz27e64+eKq55vp4cenUxYsvlq89Rjg2dOruqOq1t3BYW8QtMkHdFlPX4q4oqHDoJiOwffNnsfY7KdhzACMctnVqj0hfsr/8uOZG5JoJ6taY6XUnHNuo2+Gji5psLIayWMFBzQq8KdniknPuhCOLf0C5qiGiORjlKKxlYI+6hr6urNbgj3bnE4cmePcYcOBoD1WynL1MO6IN9AHLTjey8cTdOdgDTTOeHCrOch2acjvLWa7CF1fcCIfrM4UE1wnNB0fWV9qjmst2fMWEiZxxno3PTFA3wj+aiXxHsj/Bqbk2s4+6RWZCTU6z8YR7Ao88oKl1sT/7tYTUmwefp26Rqc41Z9l4o5AmK29X79mZcXIxVX2kYSrIxytFRYOlbzrIxsJh51uQOzTTpp10sp5ZdT0r1G2y0HBnYUh43bY3+p8vDfR4yn2a6eEdXXAPd7sTMgiQM0qfTjpbkXoirJq6TeASdQKTI85W1KusqIm6TeCOkAsnOVIOq2vypTYHeE4zU6vTxwnUx144KuZADlAvqNY4vcWvRVlVMB+xB7vOKj265nRVS259QUFArCo9et/pqtTTYHedrgoCQb0m4vBgpahot7Kqe05XBYEwrfQo76zOTOpkBpupWwWuUG/EcHwxtVZZVT11q8AV+5UedXzzp3oifpW6VeCK60qPOn6o4IiyKltPRUFgXXFvQKoeyq5TtwpcoZ70fuZ0VWohwoCWbgGbwkodsCGHaxpUHtRvDfjj1MBL+fc+5XBqpSrlg2ORuk3gEvUxaIfFNe4oK1qibhO45J7Sp9ecrUhN2TR1m8Alm5Q+Pe9oPWH19nNcsc8XYeVJxoijSl7qMXEE49G8oZYRdHTuSi3/5PjyLgTGXle+V9rV+8AcPBoFAVOsdGvrePZraVOyIeIO0jxyzIVrb8VqbewCega9AKhDyb6GbNehfnDgwkp+WXP80dGpHseOBrTsOWRHvck4y6pPmkMV4WZ2a4CACi8qXVud1b/7dTUbHTjJkWfUo9msTn1rS03iODbfhLepXyyPbC8d3apmYxkjjrxTpU6a0G09I3waTZ3JqaBPmwBZ0FTpGLV5PKstcev48QYIoGLNZMPbbJ3irNVkI6vyxxB4VZr65y0T3IuFr2qyUTNP3Qrwxqqml0cOcC7UvqRZSiigqs+FRjupjsg358r8iDYbe6hbAJ7RTaojHLGuFzl4SDeD9X2c/spjY9Xavm6sszhlcXRU+3JhZ7Zl0yEnNOimARRaSkzi8Ug32hCE5WBXpgXHim/pe3y0znjyiPZefYwE4VmIetvBa9EbaZ3eurSaXs/5+N5yMe1VwlxQZxkGN023pne8MDRXuvf0/OGJ5vnZm6XlIxl/F6amcUWlMGwaEmxqukK9zeCXrjl72ThfQJNaQfpBqqkL16m3Fvw1Vhvhi0ZfLUaihSd0r9E6GpF9OLlRmELXWsyj0dIWot5GoDPfM8lKxmQPLs8XvKq68xnfL41LdQU2m1WhW7/N/FPn7OrFsvKFbdsWym9cXD1928ZaIS9UDx11toIQHkrIVwdEse+ek5Pg8y39uGafpy6JG55m/WDB4PSMKOJByPw0eCERDrGvLLvH7NcXE0svULcCPLEiSob227/Zr+q+tDAKF+elJVGxeNdesdqqY8qipdTNAA9M9IkaQ3X8Q8vZW9oFcYtxHpoW9WbK13mOXLrqW/TLHaRuCLgvrY8TLuyuNP8cmLhTnbFQOXVDwHVHRUORZ/XDhuOPcOf2PUOGS+Dsad45IrIN3dr8sGq8KzQYjQ4Wt3cOP7qzZ0uE+WqH5dMhcBpmRLe0ULcFXHbXtWyIov26QBBoT10Mxw3qxoCr5l3MhtiI2tZ55UU3w8FZuwFyw9ikq+HYSt0ecNFZV7MhilnWQIYgWnA5HBepGwSuaXY5G2K3wxlIITh2uR0O8Tp1k8Al0Q7Xw4Ep3vLFQdezIYrN1I0Cd5R7EI5D1I0CV3RGnGchwwjq/OSFax5kQxRR6ScvbPEkHMeomwUueORJNsQZlO3IA2XehEO8TN0wcKy436NwbKFuGTi236NsiCJm88p51c5TwHCSumng0AHPsiH2h6gbB85c9C4cYgl148ARqeyCN55Rtw4cWfEwG6J4grp54MR95wkwgXIMuUxfdsF1KMeQy6adB8DUQ+oGQtbCix6HY466hZC1o86731zfOHUTIVvHvA6H2EbdRMiSi2UXWEap2whZcrPsAsssdSMhOzt9CAfKMeQmV8susKAcQ25yt+wCyyp1MyELLpddYNlG3U7Iwk1fsoFyDDnJ7bILLLupGwq2nfApG+IkZp3NOe6XXWDZQd1UsMmDsgsst6jbCjZ5UXaBBeUYcky5j+HYTN1YsMWTsgssKMeQW7wpu8Byjrq5YIc3ZRdYHlA3F2zwqOwCy0wndYOBn1dlF1jqqBsM3NobfQ4HyjHkjl6fsyGKldRNBl5bfQ/HVeomA6cq37OBcgw546L/4RD3UjcauHhadoHlDHWrgct1gmyI4jB1s4GHt2UXWPZRNxs4jHtbdoHlAubnyQGHSLIhitupGw6WPC+7wHKeuuVg6QpRNlCOIQccowqHeI+66WDBh7ILLKO4ISzgLpNlA+UYAs+PsgssKMcQbJsIsyHOoBxDoJ2kDId4h7r5YKK4iTQcO6nbDyZKSLOBcgyB9ow4HCjHEFy+lV1gQTmG4CqlDod4lnoXAIOPZRdYKqj3ATA8pI7GhsPUOwGMzVEnQ0Q5hqDytewCC8oxBFMbdTCSUI4hkNaoc5GEcgxBNEsdi5QIyjEE0A3qWEhQjiF4fC+7wIJyDMGzSh0KBcoxBM426kwoUI4haAjKLrCgHEPQ7KaOhAbKMQQLSdkFFpRjCJYd1IHQOUC9O0DrFnUedFCOIUiO05RdYOlGOYYA2UwdhzQoxxAcZGUXWFCOITjIyi6woBxDcByjDkMGlGMICsKyCywoxxAUddRRMHCaeqdACmXZBZY91DsFkkjLLrDMdFHvFkigLbvAgnIMQUBcdoFlJ/V+gSL6sgssA9Q7BujLLrD0UO8YoC+7wIJyDPT2UYeA6Sz1roFQYOGTAwAAAAAAoOBs+tLv/f4f5Lkv/+EffYV6P+egr/wxdcf55Kt/8jXqfZ1rvv6n1J3mnz/DhMW2bPoGdY/56ZvHqfd3Lmn4JnV/+evPcT8yvy9R95bf/oJ6j+eOsb+k7iy//RX1Ls8d36LuK/9h1MHrr6m7yn8Hqfd5zvgb6q7y399S7/Oc8XfUXeW/b1Pv85yBcAATwgFMCAcwIRzAhHAAE8IBTAgHMCEcwIRwABPCAUwIBzAhHMCEcAATwgFMCAcwIRzAhHAAE8IBTAgHMCEcwIRwABPCAUwIBzAhHMCEcAATwgFMCAcwIRzAhHAAE8IBTAgHMCEcwIRwABPCAUx/T91V/vsH6n2eM/6Ruqv890/U+zxnfIe6q/yH+at5/TN1V/nuyyh+zu1fqDvLb9+l3uM55F+/St1b/vrmv1Hv8Vzyberu8tVXv069v3PLv1N3mI++8R3qvZ1rvlMw83j9xyz1vs49X/vuf1J3mx/+67/HqPd0bhr/n4P/m9e+9X9d1PsYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgND/A6qC7ll+ZzrHAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE5LTAyLTA2VDE0OjA3OjIyKzAxOjAwIVuTsgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxOS0wMi0wNlQxNDowNzoyMiswMTowMFAGKw4AAAAASUVORK5CYII=
+      mediatype: image/png
+  links:
+  - name: Documentation
+    url: https://postgres-operator.readthedocs.io/en/latest/
+  - name: GitHub
+    url: https://github.com/zalando/postgres-operator
+  customresourcedefinitions:
+    owned:
+    - name: postgresqls.acid.zalan.do
+      version: v1
+      kind: postgresql
+      displayName: PostgreSQL
+      description: Creates a PostgreSQL cluster managed by Postgres-Operator.
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: zalando-postgres-operator
+        rules:
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - "rbac.authorization.k8s.io"
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - get
+          - create
+          - delete
+          - patch
+          - list
+      permissions:
+      - serviceAccountName: zalando-postgres-operator
+        rules:
+        - apiGroups:
+          - acid.zalan.do
+          resources:
+          - postgresqls
+          - postgresqls/status
+          - operatorconfigurations
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch # needed if zalando-postgres-operator account is used for pods as well
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - update
+          - delete
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - delete
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - update # only for resizing AWS volumes
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - delete
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - "rbac.authorization.k8s.io"
+          resources:
+          - rolebindings
+          verbs:
+          - get
+          - create
+      deployments:
+      - name: postgres-operator
+        spec:
+          progressDeadlineSeconds: 600
+          replicas: 1
+          revisionHistoryLimit: 2
+          selector:
+            matchLabels:
+              name: postgres-operator
+          strategy:
+            rollingUpdate:
+              maxSurge: 25%
+              maxUnavailable: 25%
+            type: RollingUpdate
+          template:
+            metadata:
+              creationTimestamp: null
+              labels:
+                name: postgres-operator
+            spec:
+              serviceAccount: zalando-postgres-operator
+              serviceAccountName: zalando-postgres-operator
+              containers:
+              - env:
+                - name: API_PORT
+                  value: "8080"
+                - name: AWS_REGION
+                  value: eu-central-1
+                - name: CLUSTER_HISTORY_ENTRIES
+                  value: "1000"
+                - name: CLUSTER_LABELS
+                  value: application:spilo
+                - name: CLUSTER_NAME_LABEL
+                  value: version
+                - name: DB_HOSTED_ZONE
+                  value: db.example.com
+                - name: DEBUG_LOGGING
+                  value: "true"
+                - name: DOCKER_IMAGE
+                  value: registry.opensource.zalan.do/acid/spilo-11:1.5-p7
+                - name: ENABLE_TEAMS_API
+                  value: "false"
+                - name: ENABLE_MASTER_LOAD_BALANCER
+                  value: "true"
+                - name: ENABLE_REPLICA_LOAD_BALANCER
+                  value: "false"
+                - name: MASTER_DNS_NAME_FORMAT
+                  value: '{cluster}.{team}.staging.{hostedzone}'
+                - name: PDB_NAME_FORMAT
+                  value: "postgres-{cluster}-pdb"
+                - name: POD_DELETION_WAIT_TIMEOUT
+                  value: 10m
+                - name: POD_LABEL_WAIT_TIMEOUT
+                  value: 10m
+                - name: POD_MANAGEMENT_POLICY
+                  value: "ordered_ready"
+                - name: POD_ROLE_LABEL
+                  value: spilo-role
+                - name: POD_SERVICE_ACCOUNT_NAME
+                  value: "zalando-postgres-operator"
+                - name: POD_TERMINATE_GRACE_PERIOD
+                  value: 5m
+                - name: READY_WAIT_INTERVAL
+                  value: 3s
+                - name: READY_WAIT_TIMEOUT
+                  value: 30s
+                - name: REPLICA_DNS_NAME_FORMAT
+                  value: '{cluster}-repl.{team}.staging.{hostedzone}'
+                - name: REPLICATION_USERNAME
+                  value: standby
+                - name: RESOURCE_CHECK_INTERVAL
+                  value: 3s
+                - name: RESOURCE_CHECK_TIMEOUT
+                  value: 10m
+                - name: RESYNC_PERIOD
+                  value: 5m
+                - name: RING_LOG_LINES
+                  value: "100"
+                - name: SECRET_NAME_TEMPLATE
+                  value: '{username}.{cluster}.credentials'
+                - name: SPILO_PRIVILEGED
+                  value: "false"
+                - name: SUPER_USERNAME
+                  value: postgres
+                - name: WATCHED_NAMESPACE
+                  value: "*" # listen to all namespaces
+                - name: WORKERS
+                  value: "4"
+                image: registry.opensource.zalan.do/acid/postgres-operator:v1.1.0-25-g2c02b37
+                imagePullPolicy: IfNotPresent
+                name: postgres-operator
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 500Mi
+                  requests:
+                    cpu: 500m
+                    memory: 250Mi
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              dnsPolicy: ClusterFirst
+              restartPolicy: Always
+              schedulerName: default-scheduler
+              terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This PR adds a bundle for the Postgres-Operator from Zalando.
Verified with [operator-courier](https://github.com/operator-framework/operator-courier).
Tested on K8s. Runs in production at Zalando SE.