### PR TITLE
scripts/lib/cluster: bump readiness check timeout

### DIFF
--- a/scripts/lib/cluster
+++ b/scripts/lib/cluster
@@ -3,7 +3,7 @@
 function wait_on_deployment() {
   local dep="$1"
   local namespace="$2"
-  local retries=10
+  local retries=20 # 2 minute timeout
 
   while ! kubectl rollout status -w "deployment/${dep}" --namespace=${namespace}; do
       sleep 6


### PR DESCRIPTION
Bump operator readiness check timeout to 2 minutes.