### PR TITLE
scripts/: delete objects by name within namespace

### DIFF
--- a/scripts/ci/test-operator
+++ b/scripts/ci/test-operator
@@ -108,8 +108,8 @@ fi
 
 apply_objects_incluster "$DEPLOY_DIR"
 # Clean up all created resources, CSV, and CRD's.
-trap_add_exit "delete_objects_incluster $DEPLOY_DIR"
-trap_add_exit "delete_objects_incluster $ABS_BUNDLE_PATH"
+trap_add_exit "delete_objects_incluster $DEPLOY_DIR $NAMESPACE"
+trap_add_exit "delete_objects_incluster $ABS_BUNDLE_PATH $NAMESPACE"
 
 # Create logs for operator debugging.
 LOG_FILE="${TMP}/info.log"

--- a/scripts/lib/cluster
+++ b/scripts/lib/cluster
@@ -57,9 +57,10 @@ function apply_objects_incluster() {
 # delete_objects_incluster deletes cluster resources using manifests in $1.
 function delete_objects_incluster() {
   local deploy_dir="$1"
+  local namespace="$2"
 
   for f in $(find "$deploy_dir" -maxdepth 1 -name "*.yaml" -print); do
-    kubectl delete --ignore-not-found=true -f "$f"
+    kubectl delete --ignore-not-found=true "$(yq r "$f" "kind" | awk '{ print tolower($0) }')" "$(yq r "$f" "metadata.name")" --namespace="$namespace"
   done
 }
 


### PR DESCRIPTION
Objects might have a different namespace than their file ex. CSV's. This method of deletion is more robust.