### PR TITLE
.travis.yml: bump minikube memory allocation to 4gb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - scripts/ci/install-deps $DISTRO_TYPE
 
 before_script:
-- sudo minikube start --vm-driver=none --kubernetes-version="v1.11.0" --extra-config=apiserver.v=4
+- sudo minikube start --memory=4096 --vm-driver=none --kubernetes-version="v1.11.0" --extra-config=apiserver.v=4
 - sudo chown -R $USER ${HOME}/.{mini,}kube
 - kubectl config use-context minikube
 - scripts/ci/install-olm-local


### PR DESCRIPTION
Some operators require more memory. This should be sufficient for CI.