### PR TITLE
[scripts] Use python base in ci.Dockerfile

### DIFF
--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-stretch
+FROM python:3.6-stretch
 ARG DISTRO_TYPE
 ENV DISTRO_TYPE ${DISTRO_TYPE}
 RUN ./scripts/ci/install-deps ${DISTRO_TYPE}

--- a/scripts/ci/install-deps
+++ b/scripts/ci/install-deps
@@ -17,18 +17,6 @@ if [[ "$DISTRO_TYPE" != "$DISTRO_TYPE_UPSTREAM" && "$DISTRO_TYPE" != "$DISTRO_TY
   exit 1
 fi
 
-#$SUDO apt-get update
-#$SUDO apt-get -y upgrade
-# golang
-pushd /tmp
-wget https://dl.google.com/go/go1.11.linux-amd64.tar.gz
-$SUDO tar -xf go1.11.linux-amd64.tar.gz
-$SUDO mv go /usr/local
-export GOROOT=/usr/local/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
-popd
-go version
 # jq, yq
 curl -Lo jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
 chmod +x jq


### PR DESCRIPTION
- Use python:3.6-stretch as base image in ci.Dockerfile

This change is required as install-deps installs go manually due
as part of reworking travis-ci tests.

/cc @estroz 