### PR TITLE
LOG-375. Move CLO and EO to v1

### DIFF
--- a/community-operators/cluster-logging/cluster-logging.package.yaml
+++ b/community-operators/cluster-logging/cluster-logging.package.yaml
@@ -1,5 +1,5 @@
-#! package-manifest: ./deploy/chart/catalog_resources/rh-operators/clusterlogging.v0.0.1.clusterserviceversion.yaml
+#! package-manifest: ./deploy/chart/catalog_resources/rh-operators/clusterlogging.v4.1.0.clusterserviceversion.yaml
 packageName: cluster-logging
 channels:
 - name: preview
-  currentCSV: clusterlogging.v0.0.1
+  currentCSV: clusterlogging.v4.1.0

--- a/community-operators/cluster-logging/cluster-logging.v4.1.0.clusterserviceversion.yaml
+++ b/community-operators/cluster-logging/cluster-logging.v4.1.0.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: clusterlogging.v0.0.1
+  name: clusterlogging.v4.1.0
   namespace: placeholder
   annotations:
     capabilities: Seamless Upgrades
@@ -18,7 +18,7 @@ metadata:
     alm-examples: |-
         [
             {
-              "apiVersion": "logging.openshift.io/v1alpha1",
+              "apiVersion": "logging.openshift.io/v1",
               "kind": "ClusterLogging",
               "metadata": {
                 "name": "instance",
@@ -232,11 +232,11 @@ spec:
                     value: "quay.io/openshift/origin-oauth-proxy:latest"
                   - name: RSYSLOG_IMAGE
                     value: "docker.io/viaq/rsyslog:latest"
-  version: 0.0.1
+  version: 4.1.0
   customresourcedefinitions:
     owned:
     - name: clusterloggings.logging.openshift.io
-      version: v1alpha1
+      version: v1
       kind: ClusterLogging
       displayName: Cluster Logging
       description: A Cluster Logging instance

--- a/community-operators/cluster-logging/cluster-loggings.crd.yaml
+++ b/community-operators/cluster-logging/cluster-loggings.crd.yaml
@@ -10,7 +10,7 @@ spec:
     plural: clusterloggings
     singular: clusterlogging
   scope: Namespaced
-  version: v1alpha1
+  version: v1
   validation:
     openAPIV3Schema:
       properties:

--- a/community-operators/elasticsearch-operator/elasticsearch-operator.package.yaml
+++ b/community-operators/elasticsearch-operator/elasticsearch-operator.package.yaml
@@ -1,5 +1,5 @@
-#! package-manifest: ./deploy/chart/catalog_resources/rh-operators/elasticsearch-operator.v0.0.1.clusterserviceversion.yaml
+#! package-manifest: ./deploy/chart/catalog_resources/rh-operators/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
 packageName: elasticsearch-operator
 channels:
 - name: preview
-  currentCSV: elasticsearch-operator.v0.0.1
+  currentCSV: elasticsearch-operator.v4.1.0

--- a/community-operators/elasticsearch-operator/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
+++ b/community-operators/elasticsearch-operator/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: elasticsearch-operator.v0.0.1
+  name: elasticsearch-operator.v4.1.0
   namespace: placeholder
   annotations:
     categories: "OpenShift Optional, Logging & Tracing"
@@ -25,7 +25,7 @@ metadata:
     alm-examples: |-
         [
             {
-                "apiVersion": "logging.openshift.io/v1alpha1",
+                "apiVersion": "logging.openshift.io/v1",
                 "kind": "Elasticsearch",
                 "metadata": {
                   "name": "elasticsearch"
@@ -186,11 +186,11 @@ spec:
                       value: "elasticsearch-operator"
                     - name: PROXY_IMAGE
                       value: "quay.io/openshift/origin-oauth-proxy:latest"
-  version: 0.0.1
+  version: 4.1.0
   customresourcedefinitions:
     owned:
     - name: elasticsearches.logging.openshift.io
-      version: v1alpha1
+      version: v1
       kind: Elasticsearch
       displayName: Elasticsearch
       description: An Elasticsearch cluster instance

--- a/community-operators/elasticsearch-operator/elasticsearches.crd.yaml
+++ b/community-operators/elasticsearch-operator/elasticsearches.crd.yaml
@@ -10,7 +10,7 @@ spec:
     plural: elasticsearches
     singular: elasticsearch
   scope: Namespaced
-  version: v1alpha1
+  version: v1
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
This bumps CLO and EO to v1 of the CRD and 4.1.0 of release

Ref: https://jira.coreos.com/browse/LOG-375

Depends on:
* https://github.com/openshift/cluster-logging-operator/pull/130
* https://github.com/openshift/elasticsearch-operator/pull/106
* https://github.com/openshift/cluster-logging-operator/pull/136