### PR TITLE
[scripts] Pin OLM version to 0.8.1

### DIFF
--- a/scripts/ci/install-olm-local
+++ b/scripts/ci/install-olm-local
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-TMP_OLM="$(mktemp -d)"
-git clone https://github.com/operator-framework/operator-lifecycle-manager.git "$TMP_OLM"
-pushd "$TMP_OLM"
-NO_MINIKUBE=true make run-local
-popd
+# Try twice, since order matters
+kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.8.1/olm.yaml
+kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.8.1/olm.yaml
+
+# Delete "operatorhubio-catalog"
+kubectl delete catalogsource operatorhubio-catalog -n olm

--- a/scripts/ci/test-operator
+++ b/scripts/ci/test-operator
@@ -55,7 +55,7 @@ mkdir -p "$CR_DIR"
 # Organize expected dir structure for the registry image build.
 operator-courier nest "${OP_PATH}" "${DEPLOY_DIR}/${PKG_NAME}"
 pushd "$DEPLOY_DIR"
-NAMESPACE="local"
+NAMESPACE="operators"
 CATALOGSOURCE_FILE="${PKG_NAME}.catalogsource.yaml"
 SUBSCRIPTION_FILE="${PKG_NAME}.subscription.yaml"
 SC_PROXY_IMAGE="quay.io/operator-framework/scorecard-proxy:master"


### PR DESCRIPTION
- Use OLM's 0.8.1 github release to download OLM manifests
- Change namespace from 'local' to 'operators'

/cc @estroz @aravindhp @dmesser 