### PR TITLE
Add operator for EnMasse 0.27.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 before_script:
 - eval $(scripts/ci/operators-env) && scripts/ci/verify-operator
-- sudo minikube start --memory=4096 --vm-driver=none --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4
+- sudo minikube start --cpus 2 --memory=6144 --vm-driver=none --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4
 - sudo chown -R $USER ${HOME}/.{mini,}kube
 - kubectl config use-context minikube
 - scripts/ci/install-olm-local

--- a/community-operators/enmasse/addressplans.crd.yaml
+++ b/community-operators/enmasse/addressplans.crd.yaml
@@ -1,0 +1,77 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addressplans.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: AddressPlan
+    listKind: AddressPlanList
+    singular: addressplan
+    plural: addressplans
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          required:
+            - addressType
+            - resources
+          properties:
+            displayName:
+              type: string
+            displayOrder:
+              type: integer
+            shortDescription:
+              type: string
+            longDescription:
+              type: string
+            addressType:
+              type: string
+            partitions:
+              type: integer
+            resources:
+              type: object
+              properties:
+                router:
+                  type: number
+                broker:
+                  type: number
+        displayName:
+          type: string
+        displayOrder:
+          type: integer
+        shortDescription:
+          type: string
+        longDescription:
+          type: string
+        uuid:
+          type: string
+        addressType:
+          type: string
+        requiredResources:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - credit
+            properties:
+              name:
+                type: string
+              credit:
+                type: number

--- a/community-operators/enmasse/addressspaceplans.crd.yaml
+++ b/community-operators/enmasse/addressspaceplans.crd.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addressspaceplans.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: AddressSpacePlan
+    listKind: AddressSpacePlanList
+    singular: addressspaceplan
+    plural: addressspaceplans
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          required:
+            - addressSpaceType
+            - resourceLimits 
+            - addressPlans
+            - infraConfigRef
+          properties:
+            displayName:
+              type: string
+            displayOrder:
+              type: integer
+            shortDescription:
+              type: string
+            longDescription:
+              type: string
+            addressSpaceType:
+              type: string
+            infraConfigRef:
+              type: string
+            resourceLimits:
+              type: object
+              properties:
+                aggregate:
+                  type: number
+                router:
+                  type: number
+                broker:
+                  type: number
+            addressPlans:
+              type: array
+              items:
+                type: string
+        displayName:
+          type: string
+        displayOrder:
+          type: integer
+        shortDescription:
+          type: string
+        longDescription:
+          type: string
+        uuid:
+          type: string
+        addressSpaceType:
+          type: string
+        resources:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - max
+            properties:
+              name:
+                type: string
+              max:
+                type: number
+        addressPlans:
+          type: array
+          items:
+            type: string

--- a/community-operators/enmasse/authenticationservices.crd.yaml
+++ b/community-operators/enmasse/authenticationservices.crd.yaml
@@ -1,0 +1,190 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: authenticationservices.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: AuthenticationService
+    listKind: AuthenticationServiceList
+    singular: authenticationservice
+    plural: authenticationservices
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - none
+              - standard
+              - external
+            realm:
+              type: string
+            none:
+              type: object
+              properties:
+                certificateSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                image:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pullPolicy:
+                      type: string
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+            standard:
+              type: object
+              properties:
+                certificateSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                credentialsSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                initImage:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pullPolicy:
+                      type: string
+                jvmOptions:
+                  type: string
+                image:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pullPolicy:
+                      type: string
+                deploymentName:
+                  type: string
+                serviceName:
+                  type: string
+                routeName:
+                  type: string
+                storage:
+                  type: object
+                  required:
+                  - type
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                    class:
+                      type: string
+                    size:
+                      type: string
+                    claimName:
+                      type: string
+                    deleteClaim:
+                      type: boolean
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                datasource:
+                  type: object
+                  required:
+                  - type
+                  properties:
+                    type:
+                      type: string
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                    database:
+                      type: string
+                    credentialsSecret:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+            external:
+              type: object
+              required:
+              - host
+              - port
+              properties:
+                allowOverride:
+                  type: boolean
+                host:
+                  type: string
+                port:
+                  type: integer
+                caCertSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                clientCertSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+        status:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: integer

--- a/community-operators/enmasse/brokeredinfraconfigs.crd.yaml
+++ b/community-operators/enmasse/brokeredinfraconfigs.crd.yaml
@@ -1,0 +1,111 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: brokeredinfraconfigs.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: BrokeredInfraConfig
+    listKind: BrokeredInfraConfigList
+    singular: brokeredinfraconfig
+    plural: brokeredinfraconfigs
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            version:
+              type: string
+            networkPolicy:
+              type: object
+              properties:
+                ingress:
+                  type: array
+                egress:
+                  type: array
+            admin:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                        priorityClassName:
+                          type: string
+                        containers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              resources:
+                                type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+            broker:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                        priorityClassName:
+                          type: string
+                        resources:
+                          type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                    storage:
+                      type: string
+                addressFullPolicy:
+                  type: string
+                  enum:
+                  - PAGE
+                  - BLOCK
+                  - FAIL
+                  - DROP
+                storageClassName:
+                  type: string
+                updatePersistentVolumeClaim:
+                  type: boolean

--- a/community-operators/enmasse/consoleservices.crd.yaml
+++ b/community-operators/enmasse/consoleservices.crd.yaml
@@ -1,0 +1,63 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleservices.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: ConsoleService
+    listKind: ConsoleServiceList
+    singular: consoleservice
+    plural: consoleservices
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            discoveryMetadataURL:
+              type: string
+            certificateSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            oauthClientSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            ssoCookieSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            ssoCookieDomain:
+              type: string
+            scope:
+              type: string
+            host:
+              type: string
+        status:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: integer
+            caCertSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+

--- a/community-operators/enmasse/enmasse.0.27.2.clusterserviceversion.yaml
+++ b/community-operators/enmasse/enmasse.0.27.2.clusterserviceversion.yaml
@@ -1,0 +1,729 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: enmasse.0.27.2
+  namespace: placeholder
+  annotations:
+    categories: "Streaming & Messaging"
+    certified: "false"
+    description: EnMasse provides a self-service messaging platform with a uniform interface to manage different messaging infrastructure.
+    containerImage: docker.io/enmasseproject/enmasse-controller-manager:0.27
+    createdAt: 2019-02-19T00:00:00Z
+    capabilities: Seamless Upgrades
+    repository: https://github.com/EnMasseProject/enmasse
+    support: EnMasse
+    alm-examples: '[{"apiVersion":"admin.enmasse.io/v1beta1","kind":"StandardInfraConfig","metadata":{"name":"my-standard-infra"},"spec":{"version":"0.27","broker":{"resources":{"memory":"1Gi","storage":"5Gi"},"addressFullPolicy":"BLOCK"},"router":{"linkCapacity":50,"resources":{"memory":"512Mi"}}}},{"apiVersion":"admin.enmasse.io/v1beta1","kind":"BrokeredInfraConfig","metadata":{"name":"my-brokered-infra"},"spec":{"version":"0.27","broker":{"resources":{"memory":"4Gi"}}}},{"apiVersion":"admin.enmasse.io/v1beta2","kind":"AddressPlan","metadata":{"name":"small-standard-queue"},"spec":{"addressType":"queue","shortDescription":"Small Queue","resources":{"router":0.01,"broker":0.1}}},{"apiVersion":"admin.enmasse.io/v1beta2","kind":"AddressSpacePlan","metadata":{"name":"standard-small"},"spec":{"addressSpaceType":"standard","infraConfigRef":"my-standard-infra","shortDescription":"Small Address Space Plan","resourceLimits":{"router":1,"broker":2,"aggregate":2},"addressPlans":["small-standard-queue"]}},{"apiVersion":"admin.enmasse.io/v1beta1","kind":"AuthenticationService","metadata":{"name":"none-authservice"},"spec":{"type":"none"}},{"apiVersion":"enmasse.io/v1beta1","kind":"AddressSpace","metadata":{"name":"myspace"},"spec":{"type":"standard","plan":"standard-small"}},{"apiVersion":"enmasse.io/v1beta1","kind":"Address","metadata":{"name":"myspace.myqueue"},"spec":{"address":"myqueue","type":"queue","plan":"small-standard-queue"}},{"apiVersion":"user.enmasse.io/v1beta1","kind":"MessagingUser","metadata":{"name":"myspace.user"},"spec":{"username":"user","authentication":{"type":"password","password":"ZW5tYXNzZQ=="},"authorization":[{"operations":["send","recv"],"addresses":["myqueue"]}]}},{"apiVersion":"iot.enmasse.io/v1alpha1","kind":"IoTConfig","metadata":{"name":"default"},"spec":{}}]'
+spec:
+  maturity: beta
+  displayName: EnMasse
+  description: >
+    EnMasse provides a self-service messaging platform on Kubernetes and OpenShift with a uniform interface to manage different messaging infrastructure.
+    See our [website](http://enmasse.io) for more details about the project.
+
+    ### Supported features
+
+    * **Built-in authentication and authorization** - Use the built-in or plug in your own authentication service for authentication and authorization of messaging clients.
+
+    * **Self-service messaging for applications** - The service admin deploys and manages the messaging infrastructure, while applications can request messaging resources without caring about the messaging infrastructure.
+
+    * **Supports a wide variety of messaging patterns** - Choose between JMS-style messaging with strict guarantees, or messaging that supports a larger number of connections and higher throughput.
+
+    ### Examples
+
+    The example resources provided this operator can be categorized into resources managed by the operator admin and resources managed by messaging tenants.
+
+    The `AddressSpacePlan`, `AddressPlan`, `StandardInfraConfig`, `BrokeredInfraConfig` and `AuthenticationService` resources should be created by the operator admin in the same namespace where the operator is running.
+
+    The `AddressSpace`, `Address` and `MessagingUser` resources should be created by the messaging tenant in the same namespace as the application that will use messaging.
+
+    ### Documentation
+    
+    Documentation for the latest releases can be found on our [website](http://enmasse.io)
+
+    ### Getting help
+
+    * [EnMasse mailing list](https://www.redhat.com/mailman/listinfo/enmasse)
+
+    * [#enmasse IRC channel on Freenode](https://webchat.freenode.net/?randomnick=1&channels=enmasse&uio=d4)
+
+    ### Contributing
+
+    If you've got some great ideas and use cases for EnMasse, we would love to hear them!
+
+    * Raise issues on [GitHub](https://github.com/EnMasseProject/enmasse/issues).
+
+    * Read the [Hacking guide](https://github.com/EnMasseProject/enmasse/blob/master/HACKING.md) for details on how to build EnMasse.
+
+    * Fix issues and open Pull Requests
+
+    ### License
+
+    EnMasse is licensed under the [Apache License, Version 2.0](https://github.com/EnMasseProject/enmasse/blob/master/LICENSE) license.
+  version: 0.27.2
+  keywords: ['messaging', 'amqp', 'iot', 'mqtt']
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNzlweCIgaGVpZ2h0PSI3OXB4IiB2aWV3Qm94PSIwIDAgNzkgNzkiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDQyICgzNjc4MSkgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+dmVyc2lvbnM8L3RpdGxlPgogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZGVmcz48L2RlZnM+CiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0idmVyc2lvbnMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0zMDguMDAwMDAwLCAtNzIuMDAwMDAwKSI+CiAgICAgICAgICAgIDxlbGxpcHNlIGlkPSJDb21iaW5lZC1TaGFwZS1Db3B5LTIiIGZpbGw9IiMwMDQ5OUUiIGN4PSIzNDcuNSIgY3k9IjExMS41IiByeD0iMjQuNSIgcnk9IjI0LjUiPjwvZWxsaXBzZT4KICAgICAgICAgICAgPHBhdGggZD0iTTMzOSwxMDIuNjkxMDE0IEMzMzksMTAyLjY5MTAxNCAzNDIuNjkwMjE1LDk0LjQxMDUzMjMgMzUwLjIwNTY1MSwxMDAuOTM1OTEyIEwzNTEuMDE1Njk5LDEwMS43NDU5NTkgQzM1MS4wMTU2OTksMTAxLjc0NTk1OSAzNTIuNzI1Nzk4LDEwMy41MDEwNjEgMzUzLjQ0NTg0LDEwMy41MDEwNjEgQzM1NC4xNjU4ODIsMTAzLjUwMTA2MSAzNTQuMjU1ODg3LDEwMy40MTEwNTYgMzU1Ljk2NTk4NiwxMDEuNzAwOTU2IEMzNTcuNjc2MDg2LDk5Ljk5MDg1NjggMzU3LjQwNjA3LDEwMC4wMzU4NTkgMzU5Ljg4MTIxNCw5Ny43ODU3Mjg2IEMzNjIuMzU2MzU4LDk1LjUzNTU5NzcgMzY1LjY3MTUyMSw5My45MzA1MzQ0IDM2NS42NzE1MjEsOTMuOTMwNTM0NCBDMzY1LjY3MTUyMSw5My45MzA1MzQ0IDM2Ny4yOTE2MTUsOTIuOTEwNDE1MSAzNzAuMjYxNzg4LDkyLjE2MDQwMTUgQzM3My4yMzE5Niw5MS40MTAzODc5IDM3Ny40MDk3MzMsOTAuNjUyODEzOSAzODIsOTEuMTcwMzQ0IEMzODIsOTEuMTcwMzQ0IDM4MC4xMzIzOTEsOTIuMjUwNDA2NyAzNzcuOTI3MjYzLDk4Ljk1NTc5NjYgQzM3NS43MjIxMzUsMTA1LjY2MTE4NiAzNzQuNTA3MDY0LDEwNy43MzEzMDcgMzc0LjUwNzA2NCwxMDcuNzMxMzA3IEMzNzQuNTA3MDY0LDEwNy43MzEzMDcgMzcxLjg1MTkxLDExMy4zNTY2MzQgMzY1LjQ2MTUzOCwxMTQuNTcxNzA0IEMzNjUuNDYxNTM4LDExNC41NzE3MDQgMzY4LjY1NjcyNCwxMTguMzk2OTI3IDM3OS45OTczODQsMTE3LjEzNjg1NCBDMzc5Ljk5NzM4NCwxMTcuMTM2ODU0IDM1OC4wODExMDksMTMxLjE3NzY3IDM0OC4yNzA1MzksMTE0Ljg0MTcyIEMzNDguMDQ4OTQ2LDExNC4zNDQyNjEgMzQ1Ljg0OTM5OCwxMTAuMDI1NDUgMzQ1LjMwMDM2NiwxMDguMjExMzA1IEMzNDQuNjEwMjk2LDEwNS45MzEyMDIgMzQ0LjMwOTEzOSwxMDUuMTI1Mzg1IDM0My4yOTAyNzksMTA0LjE2MTA2OSBDMzQwLjc3MDEzMywxMDEuNzc1OTMxIDMzOSwxMDIuNjkxMDE0IDMzOSwxMDIuNjkxMDE0IiBpZD0iRmlsbC0xLUNvcHktNyIgZmlsbD0iIzc1QTBEMyI+PC9wYXRoPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+
+      mediatype: image/svg+xml
+  maintainers:
+  - name: EnMasse
+    email: enmasse@redhat.com
+  provider:
+    name: EnMasse
+  labels:
+    app: enmasse
+  selector:
+    matchLabels:
+      app: enmasse
+  links:
+  - name: Documentation
+    url: https://enmasse.io/documentation
+  - name: GitHub
+    url: https://github.com/EnMasseProject/enmasse
+
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: [ "apps" ]
+          resources: [ "deployments" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps", "secrets", "persistentvolumeclaims", "services" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
+        - apiGroups: [ "", "route.openshift.io" ]
+          resources: [ "routes", "routes/custom-host", "routes/status"]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "authenticationservices", "authenticationservices/finalizers" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch" ]
+      - serviceAccountName: address-space-controller
+        rules:
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "pods" ]
+          verbs: [ "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "events" ]
+          verbs: [ "create", "update", "patch", "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "services", "secrets", "persistentvolumeclaims" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "networking.k8s.io", "extensions" ]
+          resources: [ "networkpolicies" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "route.openshift.io", "" ]
+          resources: [ "routes", "routes/custom-host", "routes/status" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "apps" ]
+          resources: [ "statefulsets", "deployments", "replicasets" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+      - serviceAccountName: address-space-admin
+        rules:
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "pods", "secrets" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "events" ]
+          verbs: [ "create", "update", "patch", "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "persistentvolumeclaims", "services" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "apps" ]
+          resources: [ "statefulsets", "deployments" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+      - serviceAccountName: api-server
+        rules:
+        - apiGroups: [ "" ]
+          resources: [ "services", "secrets" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressspaceplans", "addressplans", "standardinfraconfigs", "brokeredinfraconfigs", "authenticationservices" ]
+          verbs: [ "get", "list", "watch" ]
+      clusterPermissions:
+      - serviceAccountName: standard-authservice
+        rules:
+        - apiGroups: [ "authentication.k8s.io" ]
+          resources: [ "tokenreviews" ]
+          verbs: [ "create" ]
+      - serviceAccountName: address-space-controller
+        rules:
+        - apiGroups: [ "", "user.openshift.io" ]
+          resources: [ "users" ]
+          verbs: [ "get" ]
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: [ "oauth.openshift.io" ]
+          resources: [ "oauthclients" ]
+          verbs: [ "create", "get", "list", "watch" ]
+      - serviceAccountName: api-server
+        rules:
+        - apiGroups: [ "authentication.k8s.io" ]
+          resources: [ "tokenreviews" ]
+          verbs: [ "create" ]
+        - apiGroups: [ "authorization.k8s.io" ]
+          resources: [ "subjectaccessreviews" ]
+          verbs: [ "create" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          resourceNames: [ "extension-apiserver-authentication" ]
+          verbs: [ "get" ]
+      deployments:
+      - name: enmasse-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              name: enmasse-operator
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                name: enmasse-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              serviceAccountName: enmasse-operator
+              containers:
+              - name: controller
+                image: docker.io/enmasseproject/enmasse-controller-manager:0.27
+                imagePullPolicy: Always
+                env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_NAME
+                  value: "enmasse-operator"
+                - name: ENMASSE_DEFAULT_PULL_POLICY
+                  value: "Always"
+                - name: CONTROLLER_DISABLE_ALL
+                  value: "true"
+                - name: CONTROLLER_ENABLE_AUTHENTICATION_SERVICE
+                  value: "true"
+                resources:
+                  limits:
+                    memory: 128Mi
+      - name: user-api-server
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              component: user-api-server
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                component: user-api-server
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc -Xlog:gc*
+                - name: CERT_DIR
+                  value: /api-server-cert
+                - name: ENABLE_RBAC
+                  value: "true"
+                - name: APISERVER_CLIENT_CA_CONFIG_NAME
+                  value: extension-apiserver-authentication
+                - name: APISERVER_CLIENT_CA_CONFIG_NAMESPACE
+                  value: kube-system
+                - name: APISERVER_ROUTE_NAME
+                  value: restapi
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                image: docker.io/enmasseproject/api-server:0.27
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  failureThreshold: 5
+                name: api-server
+                ports:
+                - containerPort: 8080
+                  name: http
+                - containerPort: 8443
+                  name: https
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /api-server-cert
+                  name: apiservice-cert
+                  readOnly: true
+              serviceAccountName: api-server
+      - name: api-server
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              component: api-server
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                component: api-server
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc -Xlog:gc*
+                - name: CERT_DIR
+                  value: /api-server-cert
+                - name: ENABLE_RBAC
+                  value: "true"
+                - name: APISERVER_CLIENT_CA_CONFIG_NAME
+                  value: extension-apiserver-authentication
+                - name: APISERVER_CLIENT_CA_CONFIG_NAMESPACE
+                  value: kube-system
+                - name: APISERVER_ROUTE_NAME
+                  value: restapi
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                image: docker.io/enmasseproject/api-server:0.27
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  failureThreshold: 5
+                name: api-server
+                ports:
+                - containerPort: 8080
+                  name: http
+                - containerPort: 8443
+                  name: https
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /api-server-cert
+                  name: apiservice-cert
+                  readOnly: true
+              serviceAccountName: api-server
+      - name: address-space-controller
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              name: address-space-controller
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                name: address-space-controller
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc
+                - name: ENABLE_EVENT_LOGGER
+                  value: "true"
+                - name: EXPOSE_ENDPOINTS_BY_DEFAULT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: exposeEndpointsByDefault
+                      name: address-space-controller-config
+                      optional: true
+                - name: ENVIRONMENT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: environment
+                      name: address-space-controller-config
+                      optional: true
+                - name: TEMPLATE_DIR
+                  value: /templates
+                - name: RESOURCES_DIR
+                  value: /
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                - name: WILDCARD_ENDPOINT_CERT_SECRET
+                  valueFrom:
+                    configMapKeyRef:
+                      key: wildcardEndpointCertSecret
+                      name: address-space-controller-config
+                      optional: true
+                - name: RESYNC_INTERVAL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: resyncInterval
+                      name: address-space-controller-config
+                      optional: true
+                - name: RECHECK_INTERVAL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: recheckInterval
+                      name: address-space-controller-config
+                      optional: true
+                image: docker.io/enmasseproject/address-space-controller:0.27
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                name: address-space-controller
+                ports:
+                - containerPort: 8080
+                  name: http
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 256Mi
+              serviceAccountName: address-space-controller
+  apiservicedefinitions:
+    owned:
+    - group: enmasse.io
+      version: v1beta1
+      kind: AddressSpace 
+      name: addressspaces
+      displayName: Address Space
+      description: A group of messaging addresses that can be accessed via the same endpoint
+      deploymentName: api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The address space type.
+          displayName: Type
+          path: type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The address space plan.
+          displayName: Plan
+          path: plan
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+      statusDescriptors:
+        - description: Address space ready.
+          displayName: Ready
+          path: isReady
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+    - group: enmasse.io
+      version: v1beta1
+      kind: Address
+      name: addresses
+      displayName: Address
+      description: A messaging address that can be used to send/receive messages to/from
+      deploymentName: api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The address type.
+          displayName: Type
+          path: type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The address plan.
+          displayName: Plan
+          path: plan
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+      statusDescriptors:
+        - description: Address ready.
+          displayName: Ready
+          path: isReady
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+        - description: Address phase
+          displayName: Phase
+          path: phase
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+    - group: user.enmasse.io
+      version: v1beta1
+      kind: MessagingUser
+      name: messagingusers
+      displayName: Messaging User
+      description: A messaging user that can connect to an Address Space
+      deploymentName: user-api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The user name.
+          displayName: Username
+          path: username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The authentication type
+          displayName: Authentication type
+          path: authentication.type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The password
+          displayName: Password
+          path: authentication.password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+  customresourcedefinitions:
+    owned:
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: AuthenticationService
+        name: authenticationservices.admin.enmasse.io
+        displayName: Authentication Service
+        description: Authentication service configuration available to address spaces.
+        specDescriptors:
+          - description: The type of authentication service
+            displayName: Type
+            path: type
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: StandardInfraConfig
+        name: standardinfraconfigs.admin.enmasse.io
+        displayName: Standard Infra Config
+        description: Infrastructure configuration template for the standard address space type
+        specDescriptors:
+          - description: The minimal number of AMQP router replicas to create.
+            displayName: Minimum Router Replicas
+            path: router.minReplicas
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+          - description: The link capacity of AMQP producer links attached to the routers.
+            displayName: Link capacity
+            path: router.linkCapacity
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for AMQP router pods.
+            displayName: Router Memory
+            path: router.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for message brokers.
+            displayName: Broker Memory
+            path: broker.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of storage to configure for message brokers.
+            displayName: Broker Storage
+            path: broker.resources.storage
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The storage class name to use for message broker persistent volumes.
+            displayName: Broker Storage Class
+            path: broker.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The policy to apply when message queues are full.
+            displayName: Broker Address Full Policy
+            path: broker.addressFullPolicy
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for the admin operator.
+            displayName: Admin Memory
+            path: admin.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: BrokeredInfraConfig
+        name: brokeredinfraconfigs.admin.enmasse.io
+        displayName: Brokered Infra Config
+        description: Infrastructure configuration template for the brokered address space type
+        specDescriptors:
+          - description: The amount of memory to configure for message brokers.
+            displayName: Broker Memory
+            path: broker.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of storage to configure for message brokers.
+            displayName: Broker Storage
+            path: broker.resources.storage
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The storage class name to use for message broker persistent volumes.
+            displayName: Broker Storage Class
+            path: broker.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The policy to apply when message queues are full.
+            displayName: Broker Address Full Policy
+            path: broker.addressFullPolicy
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for the admin operator.
+            displayName: Admin Memory
+            path: admin.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta2
+        kind: AddressSpacePlan
+        name: addressspaceplans.admin.enmasse.io
+        displayName: Address Space Plan
+        description: Plan describing the capabilities and resource limits of a given address space type
+        specDescriptors:
+          - description: The name to be displayed in the console UI.
+            displayName: Display Name
+            path: displayName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The reference to the infrastructure config used by this plan.
+            displayName: InfraConfig Reference
+            path: infraConfigRef
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The description to be shown in the console UI.
+            displayName: Short Description
+            path: shortDescription
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The quota for broker resources
+            displayName: Broker Quota
+            path: resourceLimits.broker
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The quota for router resources
+            displayName: Router Quota
+            path: resourceLimits.router
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The aggregate quota for all resources
+            displayName: Aggregate Quota
+            path: resourceLimits.aggregate
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta2
+        kind: AddressPlan
+        name: addressplans.admin.enmasse.io
+        displayName: Address Plan
+        description: Plan describing the resource usage of a given address type
+        specDescriptors:
+          - description: The name to be displayed in the console UI.
+            displayName: Display Name
+            path: displayName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The description to be shown in the console UI.
+            displayName: Short Description
+            path: shortDescription
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The broker resource usage.
+            displayName: Broker Usage
+            path: resources.broker
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The router resource usage.
+            displayName: Router Usage
+            path: resources.router
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: iot.enmasse.io
+        version: v1alpha1
+        kind: IoTConfig
+        name: iotconfigs.iot.enmasse.io
+        displayName: IoT Config
+        description: IoT Infrastructure Configuration

--- a/community-operators/enmasse/enmasse.0.28.0.clusterserviceversion.yaml
+++ b/community-operators/enmasse/enmasse.0.28.0.clusterserviceversion.yaml
@@ -1,0 +1,975 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: enmasse.0.28.0
+  namespace: placeholder
+  annotations:
+    categories: "Streaming & Messaging"
+    certified: "false"
+    description: EnMasse provides a self-service messaging platform with a uniform interface to manage different messaging infrastructure.
+    containerImage: docker.io/enmasseproject/controller-manager:0.28.0
+    createdAt: 2019-02-19T00:00:00Z
+    capabilities: Seamless Upgrades
+    repository: https://github.com/EnMasseProject/enmasse
+    support: EnMasse
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "StandardInfraConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "broker": {
+              "resources": {
+                "memory": "1Gi",
+                "storage": "5Gi"
+              },
+              "addressFullPolicy": "FAIL"
+            },
+            "router": {
+              "linkCapacity": 50,
+              "resources": {
+                "memory": "512Mi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "BrokeredInfraConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "broker": {
+              "resources": {
+                "memory": "4Gi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta2",
+          "kind": "AddressPlan",
+          "metadata": {
+            "name": "standard-small-queue"
+          },
+          "spec": {
+            "addressType": "queue",
+            "shortDescription": "Small Queue",
+            "resources": {
+              "router": 0.01,
+              "broker": 0.1
+            }
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta2",
+          "kind": "AddressSpacePlan",
+          "metadata": {
+            "name": "standard-small"
+          },
+          "spec": {
+            "addressSpaceType": "standard",
+            "infraConfigRef": "default",
+            "shortDescription": "Small Address Space Plan",
+            "resourceLimits": {
+              "router": 1.0,
+              "broker": 2.0,
+              "aggregate": 2.0
+            },
+            "addressPlans": [
+              "standard-small-queue"
+            ]
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "AuthenticationService",
+          "metadata": {
+            "name": "none-authservice"
+          },
+          "spec": {
+            "type": "none"
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "ConsoleService",
+          "metadata": {
+            "name": "console"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "iot.enmasse.io/v1alpha1",
+          "kind": "IoTConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "AddressSpace",
+          "metadata": {
+            "name": "myspace"
+          },
+          "spec": {
+            "plan": "standard-small",
+            "type": "standard"
+          }
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "Address",
+          "metadata": {
+            "name": "myspace.myqueue"
+          },
+          "spec": {
+            "address": "myqueue",
+            "plan": "standard-small-queue",
+            "type": "queue"
+          }
+        },
+        {
+          "apiVersion": "user.enmasse.io/v1beta1",
+          "kind": "MessagingUser",
+          "metadata": {
+            "name": "myspace.user"
+          },
+          "spec": {
+            "authentication": {
+              "password": "ZW5tYXNzZQ==",
+              "type": "password"
+            },
+            "authorization": [
+              {
+                "addresses": [
+                  "myqueue"
+                ],
+                "operations": [
+                  "send",
+                  "recv"
+                ]
+              }
+            ],
+            "username": "user"
+          }
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "AddressSpaceSchema",
+          "metadata": {
+            "name": "undefined"
+          },
+          "spec": {}
+        }
+      ]
+
+spec:
+  maturity: beta
+  displayName: EnMasse
+  description: >
+    EnMasse provides a self-service messaging platform on Kubernetes and OpenShift with a uniform interface to manage different messaging infrastructure.
+    See our [website](http://enmasse.io) for more details about the project.
+
+    ### Supported features
+
+    * **Built-in authentication and authorization** - Use the built-in or plug in your own authentication service for authentication and authorization of messaging clients.
+
+    * **Self-service messaging for applications** - The service admin deploys and manages the messaging infrastructure, while applications can request messaging resources without caring about the messaging infrastructure.
+
+    * **Supports a wide variety of messaging patterns** - Choose between JMS-style messaging with strict guarantees, or messaging that supports a larger number of connections and higher throughput.
+
+    ### Configuring
+
+    The example resources provided this operator can be categorized into resources managed by the operator admin to configure the infrastructure and resources managed by messaging tenants to provision messaging.
+
+    1. Create the `AddressSpacePlan`, `AddressPlan`, `StandardInfraConfig`, `BrokeredInfraConfig` and `AuthenticationService` resources in the namespace where the operator is installed. See the [minimal service configuration](https://enmasse.io/documentation/master/kubernetes/index.html#minimal-service-configuration-messaging) for examples.
+
+    2. Create the `AddressSpace`, `Address` and `MessagingUser` resources in the same namespace as the application that will use messaging. See the [minimal tenant configuration](https://enmasse.io/documentation/master/kubernetes/index.html#minimal-tenant-configuration-messaging) for examples.
+
+
+    ### Documentation
+    
+    Documentation for the latest releases can be found on our [website](http://enmasse.io)
+
+    ### Getting help
+
+    * [EnMasse mailing list](https://www.redhat.com/mailman/listinfo/enmasse)
+
+    * [#enmasse IRC channel on Freenode](https://webchat.freenode.net/?randomnick=1&channels=enmasse&uio=d4)
+
+    ### Contributing
+
+    If you've got some great ideas and use cases for EnMasse, we would love to hear them!
+
+    * Raise issues on [GitHub](https://github.com/EnMasseProject/enmasse/issues).
+
+    * Read the [Hacking guide](https://github.com/EnMasseProject/enmasse/blob/master/HACKING.md) for details on how to build EnMasse.
+
+    * Fix issues and open Pull Requests
+
+    ### License
+
+    EnMasse is licensed under the [Apache License, Version 2.0](https://github.com/EnMasseProject/enmasse/blob/master/LICENSE) license.
+  version: 0.28.0
+  keywords: ['messaging', 'amqp', 'iot', 'mqtt']
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNzlweCIgaGVpZ2h0PSI3OXB4IiB2aWV3Qm94PSIwIDAgNzkgNzkiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDQyICgzNjc4MSkgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+dmVyc2lvbnM8L3RpdGxlPgogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZGVmcz48L2RlZnM+CiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0idmVyc2lvbnMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0zMDguMDAwMDAwLCAtNzIuMDAwMDAwKSI+CiAgICAgICAgICAgIDxlbGxpcHNlIGlkPSJDb21iaW5lZC1TaGFwZS1Db3B5LTIiIGZpbGw9IiMwMDQ5OUUiIGN4PSIzNDcuNSIgY3k9IjExMS41IiByeD0iMjQuNSIgcnk9IjI0LjUiPjwvZWxsaXBzZT4KICAgICAgICAgICAgPHBhdGggZD0iTTMzOSwxMDIuNjkxMDE0IEMzMzksMTAyLjY5MTAxNCAzNDIuNjkwMjE1LDk0LjQxMDUzMjMgMzUwLjIwNTY1MSwxMDAuOTM1OTEyIEwzNTEuMDE1Njk5LDEwMS43NDU5NTkgQzM1MS4wMTU2OTksMTAxLjc0NTk1OSAzNTIuNzI1Nzk4LDEwMy41MDEwNjEgMzUzLjQ0NTg0LDEwMy41MDEwNjEgQzM1NC4xNjU4ODIsMTAzLjUwMTA2MSAzNTQuMjU1ODg3LDEwMy40MTEwNTYgMzU1Ljk2NTk4NiwxMDEuNzAwOTU2IEMzNTcuNjc2MDg2LDk5Ljk5MDg1NjggMzU3LjQwNjA3LDEwMC4wMzU4NTkgMzU5Ljg4MTIxNCw5Ny43ODU3Mjg2IEMzNjIuMzU2MzU4LDk1LjUzNTU5NzcgMzY1LjY3MTUyMSw5My45MzA1MzQ0IDM2NS42NzE1MjEsOTMuOTMwNTM0NCBDMzY1LjY3MTUyMSw5My45MzA1MzQ0IDM2Ny4yOTE2MTUsOTIuOTEwNDE1MSAzNzAuMjYxNzg4LDkyLjE2MDQwMTUgQzM3My4yMzE5Niw5MS40MTAzODc5IDM3Ny40MDk3MzMsOTAuNjUyODEzOSAzODIsOTEuMTcwMzQ0IEMzODIsOTEuMTcwMzQ0IDM4MC4xMzIzOTEsOTIuMjUwNDA2NyAzNzcuOTI3MjYzLDk4Ljk1NTc5NjYgQzM3NS43MjIxMzUsMTA1LjY2MTE4NiAzNzQuNTA3MDY0LDEwNy43MzEzMDcgMzc0LjUwNzA2NCwxMDcuNzMxMzA3IEMzNzQuNTA3MDY0LDEwNy43MzEzMDcgMzcxLjg1MTkxLDExMy4zNTY2MzQgMzY1LjQ2MTUzOCwxMTQuNTcxNzA0IEMzNjUuNDYxNTM4LDExNC41NzE3MDQgMzY4LjY1NjcyNCwxMTguMzk2OTI3IDM3OS45OTczODQsMTE3LjEzNjg1NCBDMzc5Ljk5NzM4NCwxMTcuMTM2ODU0IDM1OC4wODExMDksMTMxLjE3NzY3IDM0OC4yNzA1MzksMTE0Ljg0MTcyIEMzNDguMDQ4OTQ2LDExNC4zNDQyNjEgMzQ1Ljg0OTM5OCwxMTAuMDI1NDUgMzQ1LjMwMDM2NiwxMDguMjExMzA1IEMzNDQuNjEwMjk2LDEwNS45MzEyMDIgMzQ0LjMwOTEzOSwxMDUuMTI1Mzg1IDM0My4yOTAyNzksMTA0LjE2MTA2OSBDMzQwLjc3MDEzMywxMDEuNzc1OTMxIDMzOSwxMDIuNjkxMDE0IDMzOSwxMDIuNjkxMDE0IiBpZD0iRmlsbC0xLUNvcHktNyIgZmlsbD0iIzc1QTBEMyI+PC9wYXRoPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+
+      mediatype: image/svg+xml
+  maintainers:
+  - name: EnMasse
+    email: enmasse@redhat.com
+  provider:
+    name: EnMasse
+  labels:
+    app: enmasse
+  selector:
+    matchLabels:
+      app: enmasse
+  links:
+  - name: Documentation
+    url: https://enmasse.io/documentation
+  - name: GitHub
+    url: https://github.com/EnMasseProject/enmasse
+
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: [ "apps" ]
+          resources: [ "deployments" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps", "secrets", "persistentvolumeclaims", "services" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
+        - apiGroups: [ "", "route.openshift.io" ]
+          resources: [ "routes", "routes/custom-host", "routes/status"]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "authenticationservices", "authenticationservices/finalizers", "consoleservices", "consoleservices/finalizers" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch" ]
+        - apiGroups: [ "iot.enmasse.io" ]
+          resources: [ "iotconfigs", "iotconfigs/finalizers" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch" ]
+      - serviceAccountName: address-space-controller
+        rules:
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices", "consoleservices"]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "pods" ]
+          verbs: [ "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "events" ]
+          verbs: [ "create", "update", "patch", "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "services", "secrets", "persistentvolumeclaims" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "networking.k8s.io", "extensions" ]
+          resources: [ "networkpolicies" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "route.openshift.io", "" ]
+          resources: [ "routes", "routes/custom-host", "routes/status" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "apps", "extensions" ]
+          resources: [ "statefulsets", "deployments", "replicasets" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+      - serviceAccountName: address-space-admin
+        rules:
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices", "consoleservices"]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "pods", "secrets" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "events" ]
+          verbs: [ "create", "update", "patch", "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "persistentvolumeclaims", "services" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "apps" ]
+          resources: [ "statefulsets", "deployments" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+      - serviceAccountName: api-server
+        rules:
+        - apiGroups: [ "" ]
+          resources: [ "services", "secrets" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressspaceplans", "addressplans", "standardinfraconfigs", "brokeredinfraconfigs", "authenticationservices", "consoleservices"]
+          verbs: [ "get", "list", "watch" ]
+      clusterPermissions:
+      - serviceAccountName: standard-authservice
+        rules:
+        - apiGroups: [ "authentication.k8s.io" ]
+          resources: [ "tokenreviews" ]
+          verbs: [ "create" ]
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: [ "oauth.openshift.io" ]
+          resources: [ "oauthclients" ]
+          verbs: [ "create", "get", "update", "list", "watch" ]
+      - serviceAccountName: api-server
+        rules:
+        - apiGroups: [ "authentication.k8s.io" ]
+          resources: [ "tokenreviews" ]
+          verbs: [ "create" ]
+        - apiGroups: [ "authorization.k8s.io" ]
+          resources: [ "subjectaccessreviews" ]
+          verbs: [ "create" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          resourceNames: [ "extension-apiserver-authentication" ]
+          verbs: [ "get" ]
+      deployments:
+      - name: enmasse-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              name: enmasse-operator
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                name: enmasse-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              serviceAccountName: enmasse-operator
+              containers:
+              - name: controller
+                image: docker.io/enmasseproject/controller-manager:0.28.0
+                imagePullPolicy: IfNotPresent
+                env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_NAME
+                  value: "enmasse-operator"
+                - name: IMAGE_PULL_POLICY
+                  value: "IfNotPresent"
+                - name: CONTROLLER_DISABLE_ALL
+                  value: "true"
+                - name: CONTROLLER_ENABLE_IOT_CONFIG
+                  value: "true"
+                - name: CONTROLLER_ENABLE_AUTHENTICATION_SERVICE
+                  value: "true"
+                - name: IOT_AUTH_SERVICE_IMAGE
+                  value: docker.io/enmasseproject/iot-auth-service:0.28.0
+                - name: IOT_DEVICE_REGISTRY_FILE_IMAGE
+                  value: docker.io/enmasseproject/iot-device-registry-file:0.28.0
+                - name: IOT_GC_IMAGE
+                  value: docker.io/enmasseproject/iot-gc:0.28.0
+                - name: IOT_HTTP_ADAPTER_IMAGE
+                  value: docker.io/enmasseproject/iot-http-adapter:0.28.0
+                - name: IOT_MQTT_ADAPTER_IMAGE
+                  value: docker.io/enmasseproject/iot-mqtt-adapter:0.28.0
+                - name: IOT_TENANT_SERVICE_IMAGE
+                  value: docker.io/enmasseproject/iot-tenant-service:0.28.0
+                - name: IOT_PROXY_CONFIGURATOR_IMAGE
+                  value: docker.io/enmasseproject/iot-proxy-configurator:0.28.0
+                - name: QDROUTERD_BASE_IMAGE
+                  value: enmasseproject/qdrouterd-base:1.6.0-rc1
+                - name: NONE_AUTHSERVICE_IMAGE
+                  value: docker.io/enmasseproject/none-authservice:0.28.0
+                - name: KEYCLOAK_IMAGE
+                  value: jboss/keycloak-openshift:4.8.3.Final
+                - name: KEYCLOAK_PLUGIN_IMAGE
+                  value: docker.io/enmasseproject/keycloak-plugin:0.28.0
+                - name: CONTROLLER_ENABLE_CONSOLE_SERVICE
+                  value: "true"
+                - name: CONSOLE_INIT_IMAGE
+                  value: "docker.io/enmasseproject/console-init:0.28.0"
+                - name: CONSOLE_PROXY_OPENSHIFT_IMAGE
+                  value: "openshift/oauth-proxy:latest"
+                - name: CONSOLE_PROXY_KUBERNETES_IMAGE
+                  value: "quay.io/pusher/oauth2_proxy:latest"
+                - name: CONSOLE_HTTPD_IMAGE
+                  value: "docker.io/enmasseproject/console-httpd:0.28.0"
+                resources:
+                  limits:
+                    memory: 128Mi
+      - name: user-api-server
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              component: user-api-server
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                component: user-api-server
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc -Xlog:gc*
+                - name: CERT_DIR
+                  value: /api-server-cert
+                - name: ENABLE_RBAC
+                  value: "true"
+                - name: APISERVER_CLIENT_CA_CONFIG_NAME
+                  value: extension-apiserver-authentication
+                - name: APISERVER_CLIENT_CA_CONFIG_NAMESPACE
+                  value: kube-system
+                - name: APISERVER_ROUTE_NAME
+                  value: restapi
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                image: docker.io/enmasseproject/api-server:0.28.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                name: api-server
+                ports:
+                - containerPort: 8080
+                  name: http
+                - containerPort: 8443
+                  name: https
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /api-server-cert
+                  name: apiservice-cert
+                  readOnly: true
+              serviceAccountName: api-server
+
+      - name: api-server
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              component: api-server
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                component: api-server
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc -Xlog:gc*
+                - name: CERT_DIR
+                  value: /api-server-cert
+                - name: ENABLE_RBAC
+                  value: "true"
+                - name: APISERVER_CLIENT_CA_CONFIG_NAME
+                  value: extension-apiserver-authentication
+                - name: APISERVER_CLIENT_CA_CONFIG_NAMESPACE
+                  value: kube-system
+                - name: APISERVER_ROUTE_NAME
+                  value: restapi
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                image: docker.io/enmasseproject/api-server:0.28.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                name: api-server
+                ports:
+                - containerPort: 8080
+                  name: http
+                - containerPort: 8443
+                  name: https
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /api-server-cert
+                  name: apiservice-cert
+                  readOnly: true
+              serviceAccountName: api-server
+      - name: address-space-controller
+        spec:
+          replicas: 1
+          strategy:
+            type: RollingUpdate
+          selector:
+            matchLabels:
+              app: enmasse
+              name: address-space-controller
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                name: address-space-controller
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc
+                - name: ENABLE_EVENT_LOGGER
+                  value: "true"
+                - name: EXPOSE_ENDPOINTS_BY_DEFAULT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: exposeEndpointsByDefault
+                      name: address-space-controller-config
+                      optional: true
+                - name: ENVIRONMENT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: environment
+                      name: address-space-controller-config
+                      optional: true
+                - name: TEMPLATE_DIR
+                  value: /templates
+                - name: RESOURCES_DIR
+                  value: /
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                - name: WILDCARD_ENDPOINT_CERT_SECRET
+                  valueFrom:
+                    configMapKeyRef:
+                      key: wildcardEndpointCertSecret
+                      name: address-space-controller-config
+                      optional: true
+                - name: RESYNC_INTERVAL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: resyncInterval
+                      name: address-space-controller-config
+                      optional: true
+                - name: RECHECK_INTERVAL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: recheckInterval
+                      name: address-space-controller-config
+                      optional: true
+                - name: IMAGE_PULL_POLICY
+                  value: IfNotPresent
+                - name: ROUTER_IMAGE
+                  value: docker.io/enmasseproject/router:0.28.0
+                - name: STANDARD_CONTROLLER_IMAGE
+                  value: docker.io/enmasseproject/standard-controller:0.28.0
+                - name: AGENT_IMAGE
+                  value: docker.io/enmasseproject/agent:0.28.0
+                - name: BROKER_IMAGE
+                  value: docker.io/enmasseproject/artemis:0.28.0
+                - name: BROKER_PLUGIN_IMAGE
+                  value: docker.io/enmasseproject/broker-plugin:0.28.0
+                - name: TOPIC_FORWARDER_IMAGE
+                  value: docker.io/enmasseproject/topic-forwarder:0.28.0
+                - name: MQTT_GATEWAY_IMAGE
+                  value: docker.io/enmasseproject/mqtt-gateway:0.28.0
+                - name: MQTT_LWT_IMAGE
+                  value: docker.io/enmasseproject/mqtt-lwt:0.28.0
+                image: docker.io/enmasseproject/address-space-controller:0.28.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                name: address-space-controller
+                ports:
+                - containerPort: 8080
+                  name: http
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 256Mi
+              serviceAccountName: address-space-controller
+  apiservicedefinitions:
+    owned:
+    - group: enmasse.io
+      version: v1beta1
+      kind: AddressSpace 
+      name: addressspaces
+      displayName: Address Space
+      description: A group of messaging addresses that can be accessed via the same endpoint
+      deploymentName: api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The address space type.
+          displayName: Type
+          path: type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The address space plan.
+          displayName: Plan
+          path: plan
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+      statusDescriptors:
+        - description: Address space ready.
+          displayName: Ready
+          path: isReady
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+    - group: enmasse.io
+      version: v1beta1
+      kind: Address
+      name: addresses
+      displayName: Address
+      description: A messaging address that can be used to send/receive messages to/from
+      deploymentName: api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The address type.
+          displayName: Type
+          path: type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The address plan.
+          displayName: Plan
+          path: plan
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+      statusDescriptors:
+        - description: Address ready.
+          displayName: Ready
+          path: isReady
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+        - description: Address phase
+          displayName: Phase
+          path: phase
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+    - group: enmasse.io
+      version: v1beta1
+      kind: AddressSpaceSchema
+      name: addressspaceschemas
+      displayName: AddressSpaceSchema
+      description: A resource representing the available schema of plans and authentication services
+      deploymentName: api-server
+      containerPort: 8443
+    - group: user.enmasse.io
+      version: v1beta1
+      kind: MessagingUser
+      name: messagingusers
+      displayName: Messaging User
+      description: A messaging user that can connect to an Address Space
+      deploymentName: user-api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The user name.
+          displayName: Username
+          path: username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The authentication type
+          displayName: Authentication type
+          path: authentication.type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The password
+          displayName: Password
+          path: authentication.password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+  customresourcedefinitions:
+    owned:
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: StandardInfraConfig
+        name: standardinfraconfigs.admin.enmasse.io
+        displayName: Standard Infra Config
+        description: Infrastructure configuration template for the standard address space type
+        specDescriptors:
+          - description: The minimal number of AMQP router replicas to create.
+            displayName: Minimum Router Replicas
+            path: router.minReplicas
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+          - description: The link capacity of AMQP producer links attached to the routers.
+            displayName: Link capacity
+            path: router.linkCapacity
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for AMQP router pods.
+            displayName: Router Memory
+            path: router.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for message brokers.
+            displayName: Broker Memory
+            path: broker.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of storage to configure for message brokers.
+            displayName: Broker Storage
+            path: broker.resources.storage
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The storage class name to use for message broker persistent volumes.
+            displayName: Broker Storage Class
+            path: broker.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The policy to apply when message queues are full.
+            displayName: Broker Address Full Policy
+            path: broker.addressFullPolicy
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for the admin operator.
+            displayName: Admin Memory
+            path: admin.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: BrokeredInfraConfig
+        name: brokeredinfraconfigs.admin.enmasse.io
+        displayName: Brokered Infra Config
+        description: Infrastructure configuration template for the brokered address space type
+        specDescriptors:
+          - description: The amount of memory to configure for message brokers.
+            displayName: Broker Memory
+            path: broker.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of storage to configure for message brokers.
+            displayName: Broker Storage
+            path: broker.resources.storage
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The storage class name to use for message broker persistent volumes.
+            displayName: Broker Storage Class
+            path: broker.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The policy to apply when message queues are full.
+            displayName: Broker Address Full Policy
+            path: broker.addressFullPolicy
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for the admin operator.
+            displayName: Admin Memory
+            path: admin.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta2
+        kind: AddressPlan
+        name: addressplans.admin.enmasse.io
+        displayName: Address Plan
+        description: Plan describing the resource usage of a given address type
+        specDescriptors:
+          - description: The name to be displayed in the console UI.
+            displayName: Display Name
+            path: displayName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The description to be shown in the console UI.
+            displayName: Short Description
+            path: shortDescription
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The broker resource usage.
+            displayName: Broker Usage
+            path: resources.broker
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The router resource usage.
+            displayName: Router Usage
+            path: resources.router
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta2
+        kind: AddressSpacePlan
+        name: addressspaceplans.admin.enmasse.io
+        displayName: Address Space Plan
+        description: Plan describing the capabilities and resource limits of a given address space type
+        specDescriptors:
+          - description: The name to be displayed in the console UI.
+            displayName: Display Name
+            path: displayName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The reference to the infrastructure config used by this plan.
+            displayName: InfraConfig Reference
+            path: infraConfigRef
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The description to be shown in the console UI.
+            displayName: Short Description
+            path: shortDescription
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The quota for broker resources
+            displayName: Broker Quota
+            path: resourceLimits.broker
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The quota for router resources
+            displayName: Router Quota
+            path: resourceLimits.router
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The aggregate quota for all resources
+            displayName: Aggregate Quota
+            path: resourceLimits.aggregate
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: AuthenticationService
+        name: authenticationservices.admin.enmasse.io
+        displayName: Authentication Service
+        description: Authentication service configuration available to address spaces.
+        specDescriptors:
+          - description: The type of authentication service
+            displayName: Type
+            path: type
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: ConsoleService
+        name: consoleservices.admin.enmasse.io
+        displayName: Console Service
+        description: Console Service Singleton for deploying global console.
+        specDescriptors:
+          - description: The discovery Metadata URL
+            displayName: Discovery Metadata URL
+            path: discoveryMetadataUrl
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: Console certificate secret name
+            displayName: Console certificate secret name
+            path: certificateSecret.name
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: OAUTH Client Secret Name
+            displayName: OAUTH Client Secret Name
+            path: oauthClientSecret.name
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: Scope
+            displayName: Scope
+            path: scope
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: Host to use for ingress
+            displayName: Host
+            path: host
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: iot.enmasse.io
+        version: v1alpha1
+        kind: IoTConfig
+        name: iotconfigs.iot.enmasse.io
+        displayName: IoT Config
+        description: IoT Infrastructure Configuration Singleton

--- a/community-operators/enmasse/enmasse.package.yaml
+++ b/community-operators/enmasse/enmasse.package.yaml
@@ -1,0 +1,4 @@
+packageName: enmasse
+channels:
+- name: alpha
+  currentCSV: enmasse.0.28.0

--- a/community-operators/enmasse/iotconfigs.crd.yaml
+++ b/community-operators/enmasse/iotconfigs.crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: iotconfigs.iot.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: iot.enmasse.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: IoTConfig
+    plural: iotconfigs
+    singular: iotconfig
+    shortNames:
+    - icfg

--- a/community-operators/enmasse/standardinfraconfigs.crd.yaml
+++ b/community-operators/enmasse/standardinfraconfigs.crd.yaml
@@ -1,0 +1,165 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: standardinfraconfigs.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: StandardInfraConfig
+    listKind: StandardInfraConfigList
+    singular: standardinfraconfig
+    plural: standardinfraconfigs
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            version:
+              type: string
+            networkPolicy:
+              type: object
+              properties:
+                ingress:
+                  type: array
+                egress:
+                  type: array
+            admin:
+              type: object
+              properties:
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                        priorityClassName:
+                          type: string
+                        containers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              resources:
+                                type: object
+            broker:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                        priorityClassName:
+                          type: string
+                        resources:
+                          type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                    storage:
+                      type: string
+                addressFullPolicy:
+                  type: string
+                  enum:
+                  - PAGE
+                  - BLOCK
+                  - FAIL
+                  - DROP
+                storageClassName:
+                  type: string
+                updatePersistentVolumeClaim:
+                  type: boolean
+                connectorIdleTimeout:
+                  type: integer
+                connectorWorkerThreads:
+                  type: integer
+            router:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                        priorityClassName:
+                          type: string
+                        resources:
+                          type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                minReplicas:
+                  type: integer
+                linkCapacity:
+                  type: integer
+                idleTimeout:
+                  type: integer
+                workerThreads:
+                  type: integer
+                policy:
+                  type: object
+                  properties:
+                    maxConnections:
+                      type: integer
+                    maxConnectionsPerUser:
+                      type: integer
+                    maxConnectionsPerHost:
+                      type: integer
+                    maxSessionsPerConnection:
+                      type: integer
+                    maxSendersPerConnection:
+                      type: integer
+                    maxReceiversPerConnection:
+                      type: integer

--- a/scripts/ci/test-operator
+++ b/scripts/ci/test-operator
@@ -124,6 +124,12 @@ wait_on_deployment "$DEP_NAME" "$NAMESPACE"
 # Always print out operator logs after scorecard
 trap_add_exit "echo Printing operator logs; get_operator_logs "$CSV_NAME" "$NAMESPACE""
 
+trap_add_exit "kubectl get pods -n $NAMESPACE"
+
+trap_add_exit "kubectl get events --sort-by='.metadata.creationTimestamp' -n $NAMESPACE"
+
+sleep 180
+
 # Run scorecard tests on the operator.
 # TODO: run against multiple CR's. Right now the scorecard only works with one
 # CR.

--- a/upstream-community-operators/enmasse/addressplans.crd.yaml
+++ b/upstream-community-operators/enmasse/addressplans.crd.yaml
@@ -1,0 +1,77 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addressplans.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: AddressPlan
+    listKind: AddressPlanList
+    singular: addressplan
+    plural: addressplans
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          required:
+            - addressType
+            - resources
+          properties:
+            displayName:
+              type: string
+            displayOrder:
+              type: integer
+            shortDescription:
+              type: string
+            longDescription:
+              type: string
+            addressType:
+              type: string
+            partitions:
+              type: integer
+            resources:
+              type: object
+              properties:
+                router:
+                  type: number
+                broker:
+                  type: number
+        displayName:
+          type: string
+        displayOrder:
+          type: integer
+        shortDescription:
+          type: string
+        longDescription:
+          type: string
+        uuid:
+          type: string
+        addressType:
+          type: string
+        requiredResources:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - credit
+            properties:
+              name:
+                type: string
+              credit:
+                type: number

--- a/upstream-community-operators/enmasse/addressspaceplans.crd.yaml
+++ b/upstream-community-operators/enmasse/addressspaceplans.crd.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addressspaceplans.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: AddressSpacePlan
+    listKind: AddressSpacePlanList
+    singular: addressspaceplan
+    plural: addressspaceplans
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          required:
+            - addressSpaceType
+            - resourceLimits 
+            - addressPlans
+            - infraConfigRef
+          properties:
+            displayName:
+              type: string
+            displayOrder:
+              type: integer
+            shortDescription:
+              type: string
+            longDescription:
+              type: string
+            addressSpaceType:
+              type: string
+            infraConfigRef:
+              type: string
+            resourceLimits:
+              type: object
+              properties:
+                aggregate:
+                  type: number
+                router:
+                  type: number
+                broker:
+                  type: number
+            addressPlans:
+              type: array
+              items:
+                type: string
+        displayName:
+          type: string
+        displayOrder:
+          type: integer
+        shortDescription:
+          type: string
+        longDescription:
+          type: string
+        uuid:
+          type: string
+        addressSpaceType:
+          type: string
+        resources:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - max
+            properties:
+              name:
+                type: string
+              max:
+                type: number
+        addressPlans:
+          type: array
+          items:
+            type: string

--- a/upstream-community-operators/enmasse/authenticationservices.crd.yaml
+++ b/upstream-community-operators/enmasse/authenticationservices.crd.yaml
@@ -1,0 +1,190 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: authenticationservices.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: AuthenticationService
+    listKind: AuthenticationServiceList
+    singular: authenticationservice
+    plural: authenticationservices
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - none
+              - standard
+              - external
+            realm:
+              type: string
+            none:
+              type: object
+              properties:
+                certificateSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                image:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pullPolicy:
+                      type: string
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+            standard:
+              type: object
+              properties:
+                certificateSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                credentialsSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                initImage:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pullPolicy:
+                      type: string
+                jvmOptions:
+                  type: string
+                image:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pullPolicy:
+                      type: string
+                deploymentName:
+                  type: string
+                serviceName:
+                  type: string
+                routeName:
+                  type: string
+                storage:
+                  type: object
+                  required:
+                  - type
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                    class:
+                      type: string
+                    size:
+                      type: string
+                    claimName:
+                      type: string
+                    deleteClaim:
+                      type: boolean
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                datasource:
+                  type: object
+                  required:
+                  - type
+                  properties:
+                    type:
+                      type: string
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                    database:
+                      type: string
+                    credentialsSecret:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+            external:
+              type: object
+              required:
+              - host
+              - port
+              properties:
+                allowOverride:
+                  type: boolean
+                host:
+                  type: string
+                port:
+                  type: integer
+                caCertSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                clientCertSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+        status:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: integer

--- a/upstream-community-operators/enmasse/brokeredinfraconfigs.crd.yaml
+++ b/upstream-community-operators/enmasse/brokeredinfraconfigs.crd.yaml
@@ -1,0 +1,111 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: brokeredinfraconfigs.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: BrokeredInfraConfig
+    listKind: BrokeredInfraConfigList
+    singular: brokeredinfraconfig
+    plural: brokeredinfraconfigs
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            version:
+              type: string
+            networkPolicy:
+              type: object
+              properties:
+                ingress:
+                  type: array
+                egress:
+                  type: array
+            admin:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                        priorityClassName:
+                          type: string
+                        containers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              resources:
+                                type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+            broker:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                        priorityClassName:
+                          type: string
+                        resources:
+                          type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                    storage:
+                      type: string
+                addressFullPolicy:
+                  type: string
+                  enum:
+                  - PAGE
+                  - BLOCK
+                  - FAIL
+                  - DROP
+                storageClassName:
+                  type: string
+                updatePersistentVolumeClaim:
+                  type: boolean

--- a/upstream-community-operators/enmasse/consoleservices.crd.yaml
+++ b/upstream-community-operators/enmasse/consoleservices.crd.yaml
@@ -1,0 +1,63 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleservices.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: ConsoleService
+    listKind: ConsoleServiceList
+    singular: consoleservice
+    plural: consoleservices
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            discoveryMetadataURL:
+              type: string
+            certificateSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            oauthClientSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            ssoCookieSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            ssoCookieDomain:
+              type: string
+            scope:
+              type: string
+            host:
+              type: string
+        status:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: integer
+            caCertSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+

--- a/upstream-community-operators/enmasse/enmasse.0.27.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/enmasse/enmasse.0.27.2.clusterserviceversion.yaml
@@ -1,0 +1,729 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: enmasse.0.27.2
+  namespace: placeholder
+  annotations:
+    categories: "Streaming & Messaging"
+    certified: "false"
+    description: EnMasse provides a self-service messaging platform with a uniform interface to manage different messaging infrastructure.
+    containerImage: docker.io/enmasseproject/enmasse-controller-manager:0.27
+    createdAt: 2019-02-19T00:00:00Z
+    capabilities: Seamless Upgrades
+    repository: https://github.com/EnMasseProject/enmasse
+    support: EnMasse
+    alm-examples: '[{"apiVersion":"admin.enmasse.io/v1beta1","kind":"StandardInfraConfig","metadata":{"name":"my-standard-infra"},"spec":{"version":"0.27","broker":{"resources":{"memory":"1Gi","storage":"5Gi"},"addressFullPolicy":"BLOCK"},"router":{"linkCapacity":50,"resources":{"memory":"512Mi"}}}},{"apiVersion":"admin.enmasse.io/v1beta1","kind":"BrokeredInfraConfig","metadata":{"name":"my-brokered-infra"},"spec":{"version":"0.27","broker":{"resources":{"memory":"4Gi"}}}},{"apiVersion":"admin.enmasse.io/v1beta2","kind":"AddressPlan","metadata":{"name":"small-standard-queue"},"spec":{"addressType":"queue","shortDescription":"Small Queue","resources":{"router":0.01,"broker":0.1}}},{"apiVersion":"admin.enmasse.io/v1beta2","kind":"AddressSpacePlan","metadata":{"name":"standard-small"},"spec":{"addressSpaceType":"standard","infraConfigRef":"my-standard-infra","shortDescription":"Small Address Space Plan","resourceLimits":{"router":1,"broker":2,"aggregate":2},"addressPlans":["small-standard-queue"]}},{"apiVersion":"admin.enmasse.io/v1beta1","kind":"AuthenticationService","metadata":{"name":"none-authservice"},"spec":{"type":"none"}},{"apiVersion":"enmasse.io/v1beta1","kind":"AddressSpace","metadata":{"name":"myspace"},"spec":{"type":"standard","plan":"standard-small"}},{"apiVersion":"enmasse.io/v1beta1","kind":"Address","metadata":{"name":"myspace.myqueue"},"spec":{"address":"myqueue","type":"queue","plan":"small-standard-queue"}},{"apiVersion":"user.enmasse.io/v1beta1","kind":"MessagingUser","metadata":{"name":"myspace.user"},"spec":{"username":"user","authentication":{"type":"password","password":"ZW5tYXNzZQ=="},"authorization":[{"operations":["send","recv"],"addresses":["myqueue"]}]}},{"apiVersion":"iot.enmasse.io/v1alpha1","kind":"IoTConfig","metadata":{"name":"default"},"spec":{}}]'
+spec:
+  maturity: beta
+  displayName: EnMasse
+  description: >
+    EnMasse provides a self-service messaging platform on Kubernetes and OpenShift with a uniform interface to manage different messaging infrastructure.
+    See our [website](http://enmasse.io) for more details about the project.
+
+    ### Supported features
+
+    * **Built-in authentication and authorization** - Use the built-in or plug in your own authentication service for authentication and authorization of messaging clients.
+
+    * **Self-service messaging for applications** - The service admin deploys and manages the messaging infrastructure, while applications can request messaging resources without caring about the messaging infrastructure.
+
+    * **Supports a wide variety of messaging patterns** - Choose between JMS-style messaging with strict guarantees, or messaging that supports a larger number of connections and higher throughput.
+
+    ### Examples
+
+    The example resources provided this operator can be categorized into resources managed by the operator admin and resources managed by messaging tenants.
+
+    The `AddressSpacePlan`, `AddressPlan`, `StandardInfraConfig`, `BrokeredInfraConfig` and `AuthenticationService` resources should be created by the operator admin in the same namespace where the operator is running.
+
+    The `AddressSpace`, `Address` and `MessagingUser` resources should be created by the messaging tenant in the same namespace as the application that will use messaging.
+
+    ### Documentation
+    
+    Documentation for the latest releases can be found on our [website](http://enmasse.io)
+
+    ### Getting help
+
+    * [EnMasse mailing list](https://www.redhat.com/mailman/listinfo/enmasse)
+
+    * [#enmasse IRC channel on Freenode](https://webchat.freenode.net/?randomnick=1&channels=enmasse&uio=d4)
+
+    ### Contributing
+
+    If you've got some great ideas and use cases for EnMasse, we would love to hear them!
+
+    * Raise issues on [GitHub](https://github.com/EnMasseProject/enmasse/issues).
+
+    * Read the [Hacking guide](https://github.com/EnMasseProject/enmasse/blob/master/HACKING.md) for details on how to build EnMasse.
+
+    * Fix issues and open Pull Requests
+
+    ### License
+
+    EnMasse is licensed under the [Apache License, Version 2.0](https://github.com/EnMasseProject/enmasse/blob/master/LICENSE) license.
+  version: 0.27.2
+  keywords: ['messaging', 'amqp', 'iot', 'mqtt']
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNzlweCIgaGVpZ2h0PSI3OXB4IiB2aWV3Qm94PSIwIDAgNzkgNzkiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDQyICgzNjc4MSkgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+dmVyc2lvbnM8L3RpdGxlPgogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZGVmcz48L2RlZnM+CiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0idmVyc2lvbnMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0zMDguMDAwMDAwLCAtNzIuMDAwMDAwKSI+CiAgICAgICAgICAgIDxlbGxpcHNlIGlkPSJDb21iaW5lZC1TaGFwZS1Db3B5LTIiIGZpbGw9IiMwMDQ5OUUiIGN4PSIzNDcuNSIgY3k9IjExMS41IiByeD0iMjQuNSIgcnk9IjI0LjUiPjwvZWxsaXBzZT4KICAgICAgICAgICAgPHBhdGggZD0iTTMzOSwxMDIuNjkxMDE0IEMzMzksMTAyLjY5MTAxNCAzNDIuNjkwMjE1LDk0LjQxMDUzMjMgMzUwLjIwNTY1MSwxMDAuOTM1OTEyIEwzNTEuMDE1Njk5LDEwMS43NDU5NTkgQzM1MS4wMTU2OTksMTAxLjc0NTk1OSAzNTIuNzI1Nzk4LDEwMy41MDEwNjEgMzUzLjQ0NTg0LDEwMy41MDEwNjEgQzM1NC4xNjU4ODIsMTAzLjUwMTA2MSAzNTQuMjU1ODg3LDEwMy40MTEwNTYgMzU1Ljk2NTk4NiwxMDEuNzAwOTU2IEMzNTcuNjc2MDg2LDk5Ljk5MDg1NjggMzU3LjQwNjA3LDEwMC4wMzU4NTkgMzU5Ljg4MTIxNCw5Ny43ODU3Mjg2IEMzNjIuMzU2MzU4LDk1LjUzNTU5NzcgMzY1LjY3MTUyMSw5My45MzA1MzQ0IDM2NS42NzE1MjEsOTMuOTMwNTM0NCBDMzY1LjY3MTUyMSw5My45MzA1MzQ0IDM2Ny4yOTE2MTUsOTIuOTEwNDE1MSAzNzAuMjYxNzg4LDkyLjE2MDQwMTUgQzM3My4yMzE5Niw5MS40MTAzODc5IDM3Ny40MDk3MzMsOTAuNjUyODEzOSAzODIsOTEuMTcwMzQ0IEMzODIsOTEuMTcwMzQ0IDM4MC4xMzIzOTEsOTIuMjUwNDA2NyAzNzcuOTI3MjYzLDk4Ljk1NTc5NjYgQzM3NS43MjIxMzUsMTA1LjY2MTE4NiAzNzQuNTA3MDY0LDEwNy43MzEzMDcgMzc0LjUwNzA2NCwxMDcuNzMxMzA3IEMzNzQuNTA3MDY0LDEwNy43MzEzMDcgMzcxLjg1MTkxLDExMy4zNTY2MzQgMzY1LjQ2MTUzOCwxMTQuNTcxNzA0IEMzNjUuNDYxNTM4LDExNC41NzE3MDQgMzY4LjY1NjcyNCwxMTguMzk2OTI3IDM3OS45OTczODQsMTE3LjEzNjg1NCBDMzc5Ljk5NzM4NCwxMTcuMTM2ODU0IDM1OC4wODExMDksMTMxLjE3NzY3IDM0OC4yNzA1MzksMTE0Ljg0MTcyIEMzNDguMDQ4OTQ2LDExNC4zNDQyNjEgMzQ1Ljg0OTM5OCwxMTAuMDI1NDUgMzQ1LjMwMDM2NiwxMDguMjExMzA1IEMzNDQuNjEwMjk2LDEwNS45MzEyMDIgMzQ0LjMwOTEzOSwxMDUuMTI1Mzg1IDM0My4yOTAyNzksMTA0LjE2MTA2OSBDMzQwLjc3MDEzMywxMDEuNzc1OTMxIDMzOSwxMDIuNjkxMDE0IDMzOSwxMDIuNjkxMDE0IiBpZD0iRmlsbC0xLUNvcHktNyIgZmlsbD0iIzc1QTBEMyI+PC9wYXRoPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+
+      mediatype: image/svg+xml
+  maintainers:
+  - name: EnMasse
+    email: enmasse@redhat.com
+  provider:
+    name: EnMasse
+  labels:
+    app: enmasse
+  selector:
+    matchLabels:
+      app: enmasse
+  links:
+  - name: Documentation
+    url: https://enmasse.io/documentation
+  - name: GitHub
+    url: https://github.com/EnMasseProject/enmasse
+
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: [ "apps" ]
+          resources: [ "deployments" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps", "secrets", "persistentvolumeclaims", "services" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
+        - apiGroups: [ "", "route.openshift.io" ]
+          resources: [ "routes", "routes/custom-host", "routes/status"]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "authenticationservices", "authenticationservices/finalizers" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch" ]
+      - serviceAccountName: address-space-controller
+        rules:
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "pods" ]
+          verbs: [ "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "events" ]
+          verbs: [ "create", "update", "patch", "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "services", "secrets", "persistentvolumeclaims" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "networking.k8s.io", "extensions" ]
+          resources: [ "networkpolicies" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "route.openshift.io", "" ]
+          resources: [ "routes", "routes/custom-host", "routes/status" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "apps" ]
+          resources: [ "statefulsets", "deployments", "replicasets" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+      - serviceAccountName: address-space-admin
+        rules:
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "pods", "secrets" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "events" ]
+          verbs: [ "create", "update", "patch", "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "persistentvolumeclaims", "services" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "apps" ]
+          resources: [ "statefulsets", "deployments" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+      - serviceAccountName: api-server
+        rules:
+        - apiGroups: [ "" ]
+          resources: [ "services", "secrets" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressspaceplans", "addressplans", "standardinfraconfigs", "brokeredinfraconfigs", "authenticationservices" ]
+          verbs: [ "get", "list", "watch" ]
+      clusterPermissions:
+      - serviceAccountName: standard-authservice
+        rules:
+        - apiGroups: [ "authentication.k8s.io" ]
+          resources: [ "tokenreviews" ]
+          verbs: [ "create" ]
+      - serviceAccountName: address-space-controller
+        rules:
+        - apiGroups: [ "", "user.openshift.io" ]
+          resources: [ "users" ]
+          verbs: [ "get" ]
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: [ "oauth.openshift.io" ]
+          resources: [ "oauthclients" ]
+          verbs: [ "create", "get", "list", "watch" ]
+      - serviceAccountName: api-server
+        rules:
+        - apiGroups: [ "authentication.k8s.io" ]
+          resources: [ "tokenreviews" ]
+          verbs: [ "create" ]
+        - apiGroups: [ "authorization.k8s.io" ]
+          resources: [ "subjectaccessreviews" ]
+          verbs: [ "create" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          resourceNames: [ "extension-apiserver-authentication" ]
+          verbs: [ "get" ]
+      deployments:
+      - name: enmasse-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              name: enmasse-operator
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                name: enmasse-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              serviceAccountName: enmasse-operator
+              containers:
+              - name: controller
+                image: docker.io/enmasseproject/enmasse-controller-manager:0.27
+                imagePullPolicy: Always
+                env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_NAME
+                  value: "enmasse-operator"
+                - name: ENMASSE_DEFAULT_PULL_POLICY
+                  value: "Always"
+                - name: CONTROLLER_DISABLE_ALL
+                  value: "true"
+                - name: CONTROLLER_ENABLE_AUTHENTICATION_SERVICE
+                  value: "true"
+                resources:
+                  limits:
+                    memory: 128Mi
+      - name: user-api-server
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              component: user-api-server
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                component: user-api-server
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc -Xlog:gc*
+                - name: CERT_DIR
+                  value: /api-server-cert
+                - name: ENABLE_RBAC
+                  value: "true"
+                - name: APISERVER_CLIENT_CA_CONFIG_NAME
+                  value: extension-apiserver-authentication
+                - name: APISERVER_CLIENT_CA_CONFIG_NAMESPACE
+                  value: kube-system
+                - name: APISERVER_ROUTE_NAME
+                  value: restapi
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                image: docker.io/enmasseproject/api-server:0.27
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  failureThreshold: 5
+                name: api-server
+                ports:
+                - containerPort: 8080
+                  name: http
+                - containerPort: 8443
+                  name: https
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /api-server-cert
+                  name: apiservice-cert
+                  readOnly: true
+              serviceAccountName: api-server
+      - name: api-server
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              component: api-server
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                component: api-server
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc -Xlog:gc*
+                - name: CERT_DIR
+                  value: /api-server-cert
+                - name: ENABLE_RBAC
+                  value: "true"
+                - name: APISERVER_CLIENT_CA_CONFIG_NAME
+                  value: extension-apiserver-authentication
+                - name: APISERVER_CLIENT_CA_CONFIG_NAMESPACE
+                  value: kube-system
+                - name: APISERVER_ROUTE_NAME
+                  value: restapi
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                image: docker.io/enmasseproject/api-server:0.27
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  failureThreshold: 5
+                name: api-server
+                ports:
+                - containerPort: 8080
+                  name: http
+                - containerPort: 8443
+                  name: https
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /api-server-cert
+                  name: apiservice-cert
+                  readOnly: true
+              serviceAccountName: api-server
+      - name: address-space-controller
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              name: address-space-controller
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                name: address-space-controller
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc
+                - name: ENABLE_EVENT_LOGGER
+                  value: "true"
+                - name: EXPOSE_ENDPOINTS_BY_DEFAULT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: exposeEndpointsByDefault
+                      name: address-space-controller-config
+                      optional: true
+                - name: ENVIRONMENT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: environment
+                      name: address-space-controller-config
+                      optional: true
+                - name: TEMPLATE_DIR
+                  value: /templates
+                - name: RESOURCES_DIR
+                  value: /
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                - name: WILDCARD_ENDPOINT_CERT_SECRET
+                  valueFrom:
+                    configMapKeyRef:
+                      key: wildcardEndpointCertSecret
+                      name: address-space-controller-config
+                      optional: true
+                - name: RESYNC_INTERVAL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: resyncInterval
+                      name: address-space-controller-config
+                      optional: true
+                - name: RECHECK_INTERVAL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: recheckInterval
+                      name: address-space-controller-config
+                      optional: true
+                image: docker.io/enmasseproject/address-space-controller:0.27
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                name: address-space-controller
+                ports:
+                - containerPort: 8080
+                  name: http
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 256Mi
+              serviceAccountName: address-space-controller
+  apiservicedefinitions:
+    owned:
+    - group: enmasse.io
+      version: v1beta1
+      kind: AddressSpace 
+      name: addressspaces
+      displayName: Address Space
+      description: A group of messaging addresses that can be accessed via the same endpoint
+      deploymentName: api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The address space type.
+          displayName: Type
+          path: type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The address space plan.
+          displayName: Plan
+          path: plan
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+      statusDescriptors:
+        - description: Address space ready.
+          displayName: Ready
+          path: isReady
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+    - group: enmasse.io
+      version: v1beta1
+      kind: Address
+      name: addresses
+      displayName: Address
+      description: A messaging address that can be used to send/receive messages to/from
+      deploymentName: api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The address type.
+          displayName: Type
+          path: type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The address plan.
+          displayName: Plan
+          path: plan
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+      statusDescriptors:
+        - description: Address ready.
+          displayName: Ready
+          path: isReady
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+        - description: Address phase
+          displayName: Phase
+          path: phase
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+    - group: user.enmasse.io
+      version: v1beta1
+      kind: MessagingUser
+      name: messagingusers
+      displayName: Messaging User
+      description: A messaging user that can connect to an Address Space
+      deploymentName: user-api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The user name.
+          displayName: Username
+          path: username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The authentication type
+          displayName: Authentication type
+          path: authentication.type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The password
+          displayName: Password
+          path: authentication.password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+  customresourcedefinitions:
+    owned:
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: AuthenticationService
+        name: authenticationservices.admin.enmasse.io
+        displayName: Authentication Service
+        description: Authentication service configuration available to address spaces.
+        specDescriptors:
+          - description: The type of authentication service
+            displayName: Type
+            path: type
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: StandardInfraConfig
+        name: standardinfraconfigs.admin.enmasse.io
+        displayName: Standard Infra Config
+        description: Infrastructure configuration template for the standard address space type
+        specDescriptors:
+          - description: The minimal number of AMQP router replicas to create.
+            displayName: Minimum Router Replicas
+            path: router.minReplicas
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+          - description: The link capacity of AMQP producer links attached to the routers.
+            displayName: Link capacity
+            path: router.linkCapacity
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for AMQP router pods.
+            displayName: Router Memory
+            path: router.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for message brokers.
+            displayName: Broker Memory
+            path: broker.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of storage to configure for message brokers.
+            displayName: Broker Storage
+            path: broker.resources.storage
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The storage class name to use for message broker persistent volumes.
+            displayName: Broker Storage Class
+            path: broker.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The policy to apply when message queues are full.
+            displayName: Broker Address Full Policy
+            path: broker.addressFullPolicy
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for the admin operator.
+            displayName: Admin Memory
+            path: admin.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: BrokeredInfraConfig
+        name: brokeredinfraconfigs.admin.enmasse.io
+        displayName: Brokered Infra Config
+        description: Infrastructure configuration template for the brokered address space type
+        specDescriptors:
+          - description: The amount of memory to configure for message brokers.
+            displayName: Broker Memory
+            path: broker.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of storage to configure for message brokers.
+            displayName: Broker Storage
+            path: broker.resources.storage
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The storage class name to use for message broker persistent volumes.
+            displayName: Broker Storage Class
+            path: broker.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The policy to apply when message queues are full.
+            displayName: Broker Address Full Policy
+            path: broker.addressFullPolicy
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for the admin operator.
+            displayName: Admin Memory
+            path: admin.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta2
+        kind: AddressSpacePlan
+        name: addressspaceplans.admin.enmasse.io
+        displayName: Address Space Plan
+        description: Plan describing the capabilities and resource limits of a given address space type
+        specDescriptors:
+          - description: The name to be displayed in the console UI.
+            displayName: Display Name
+            path: displayName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The reference to the infrastructure config used by this plan.
+            displayName: InfraConfig Reference
+            path: infraConfigRef
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The description to be shown in the console UI.
+            displayName: Short Description
+            path: shortDescription
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The quota for broker resources
+            displayName: Broker Quota
+            path: resourceLimits.broker
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The quota for router resources
+            displayName: Router Quota
+            path: resourceLimits.router
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The aggregate quota for all resources
+            displayName: Aggregate Quota
+            path: resourceLimits.aggregate
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta2
+        kind: AddressPlan
+        name: addressplans.admin.enmasse.io
+        displayName: Address Plan
+        description: Plan describing the resource usage of a given address type
+        specDescriptors:
+          - description: The name to be displayed in the console UI.
+            displayName: Display Name
+            path: displayName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The description to be shown in the console UI.
+            displayName: Short Description
+            path: shortDescription
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The broker resource usage.
+            displayName: Broker Usage
+            path: resources.broker
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The router resource usage.
+            displayName: Router Usage
+            path: resources.router
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: iot.enmasse.io
+        version: v1alpha1
+        kind: IoTConfig
+        name: iotconfigs.iot.enmasse.io
+        displayName: IoT Config
+        description: IoT Infrastructure Configuration

--- a/upstream-community-operators/enmasse/enmasse.0.28.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/enmasse/enmasse.0.28.0.clusterserviceversion.yaml
@@ -1,0 +1,975 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: enmasse.0.28.0
+  namespace: placeholder
+  annotations:
+    categories: "Streaming & Messaging"
+    certified: "false"
+    description: EnMasse provides a self-service messaging platform with a uniform interface to manage different messaging infrastructure.
+    containerImage: docker.io/enmasseproject/controller-manager:0.28.0
+    createdAt: 2019-02-19T00:00:00Z
+    capabilities: Seamless Upgrades
+    repository: https://github.com/EnMasseProject/enmasse
+    support: EnMasse
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "StandardInfraConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "broker": {
+              "resources": {
+                "memory": "1Gi",
+                "storage": "5Gi"
+              },
+              "addressFullPolicy": "FAIL"
+            },
+            "router": {
+              "linkCapacity": 50,
+              "resources": {
+                "memory": "512Mi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "BrokeredInfraConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "broker": {
+              "resources": {
+                "memory": "4Gi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta2",
+          "kind": "AddressPlan",
+          "metadata": {
+            "name": "standard-small-queue"
+          },
+          "spec": {
+            "addressType": "queue",
+            "shortDescription": "Small Queue",
+            "resources": {
+              "router": 0.01,
+              "broker": 0.1
+            }
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta2",
+          "kind": "AddressSpacePlan",
+          "metadata": {
+            "name": "standard-small"
+          },
+          "spec": {
+            "addressSpaceType": "standard",
+            "infraConfigRef": "default",
+            "shortDescription": "Small Address Space Plan",
+            "resourceLimits": {
+              "router": 1.0,
+              "broker": 2.0,
+              "aggregate": 2.0
+            },
+            "addressPlans": [
+              "standard-small-queue"
+            ]
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "AuthenticationService",
+          "metadata": {
+            "name": "none-authservice"
+          },
+          "spec": {
+            "type": "none"
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "ConsoleService",
+          "metadata": {
+            "name": "console"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "iot.enmasse.io/v1alpha1",
+          "kind": "IoTConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "AddressSpace",
+          "metadata": {
+            "name": "myspace"
+          },
+          "spec": {
+            "plan": "standard-small",
+            "type": "standard"
+          }
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "Address",
+          "metadata": {
+            "name": "myspace.myqueue"
+          },
+          "spec": {
+            "address": "myqueue",
+            "plan": "standard-small-queue",
+            "type": "queue"
+          }
+        },
+        {
+          "apiVersion": "user.enmasse.io/v1beta1",
+          "kind": "MessagingUser",
+          "metadata": {
+            "name": "myspace.user"
+          },
+          "spec": {
+            "authentication": {
+              "password": "ZW5tYXNzZQ==",
+              "type": "password"
+            },
+            "authorization": [
+              {
+                "addresses": [
+                  "myqueue"
+                ],
+                "operations": [
+                  "send",
+                  "recv"
+                ]
+              }
+            ],
+            "username": "user"
+          }
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "AddressSpaceSchema",
+          "metadata": {
+            "name": "undefined"
+          },
+          "spec": {}
+        }
+      ]
+
+spec:
+  maturity: beta
+  displayName: EnMasse
+  description: >
+    EnMasse provides a self-service messaging platform on Kubernetes and OpenShift with a uniform interface to manage different messaging infrastructure.
+    See our [website](http://enmasse.io) for more details about the project.
+
+    ### Supported features
+
+    * **Built-in authentication and authorization** - Use the built-in or plug in your own authentication service for authentication and authorization of messaging clients.
+
+    * **Self-service messaging for applications** - The service admin deploys and manages the messaging infrastructure, while applications can request messaging resources without caring about the messaging infrastructure.
+
+    * **Supports a wide variety of messaging patterns** - Choose between JMS-style messaging with strict guarantees, or messaging that supports a larger number of connections and higher throughput.
+
+    ### Configuring
+
+    The example resources provided this operator can be categorized into resources managed by the operator admin to configure the infrastructure and resources managed by messaging tenants to provision messaging.
+
+    1. Create the `AddressSpacePlan`, `AddressPlan`, `StandardInfraConfig`, `BrokeredInfraConfig` and `AuthenticationService` resources in the namespace where the operator is installed. See the [minimal service configuration](https://enmasse.io/documentation/master/kubernetes/index.html#minimal-service-configuration-messaging) for examples.
+
+    2. Create the `AddressSpace`, `Address` and `MessagingUser` resources in the same namespace as the application that will use messaging. See the [minimal tenant configuration](https://enmasse.io/documentation/master/kubernetes/index.html#minimal-tenant-configuration-messaging) for examples.
+
+
+    ### Documentation
+    
+    Documentation for the latest releases can be found on our [website](http://enmasse.io)
+
+    ### Getting help
+
+    * [EnMasse mailing list](https://www.redhat.com/mailman/listinfo/enmasse)
+
+    * [#enmasse IRC channel on Freenode](https://webchat.freenode.net/?randomnick=1&channels=enmasse&uio=d4)
+
+    ### Contributing
+
+    If you've got some great ideas and use cases for EnMasse, we would love to hear them!
+
+    * Raise issues on [GitHub](https://github.com/EnMasseProject/enmasse/issues).
+
+    * Read the [Hacking guide](https://github.com/EnMasseProject/enmasse/blob/master/HACKING.md) for details on how to build EnMasse.
+
+    * Fix issues and open Pull Requests
+
+    ### License
+
+    EnMasse is licensed under the [Apache License, Version 2.0](https://github.com/EnMasseProject/enmasse/blob/master/LICENSE) license.
+  version: 0.28.0
+  keywords: ['messaging', 'amqp', 'iot', 'mqtt']
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNzlweCIgaGVpZ2h0PSI3OXB4IiB2aWV3Qm94PSIwIDAgNzkgNzkiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDQyICgzNjc4MSkgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+dmVyc2lvbnM8L3RpdGxlPgogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZGVmcz48L2RlZnM+CiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0idmVyc2lvbnMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0zMDguMDAwMDAwLCAtNzIuMDAwMDAwKSI+CiAgICAgICAgICAgIDxlbGxpcHNlIGlkPSJDb21iaW5lZC1TaGFwZS1Db3B5LTIiIGZpbGw9IiMwMDQ5OUUiIGN4PSIzNDcuNSIgY3k9IjExMS41IiByeD0iMjQuNSIgcnk9IjI0LjUiPjwvZWxsaXBzZT4KICAgICAgICAgICAgPHBhdGggZD0iTTMzOSwxMDIuNjkxMDE0IEMzMzksMTAyLjY5MTAxNCAzNDIuNjkwMjE1LDk0LjQxMDUzMjMgMzUwLjIwNTY1MSwxMDAuOTM1OTEyIEwzNTEuMDE1Njk5LDEwMS43NDU5NTkgQzM1MS4wMTU2OTksMTAxLjc0NTk1OSAzNTIuNzI1Nzk4LDEwMy41MDEwNjEgMzUzLjQ0NTg0LDEwMy41MDEwNjEgQzM1NC4xNjU4ODIsMTAzLjUwMTA2MSAzNTQuMjU1ODg3LDEwMy40MTEwNTYgMzU1Ljk2NTk4NiwxMDEuNzAwOTU2IEMzNTcuNjc2MDg2LDk5Ljk5MDg1NjggMzU3LjQwNjA3LDEwMC4wMzU4NTkgMzU5Ljg4MTIxNCw5Ny43ODU3Mjg2IEMzNjIuMzU2MzU4LDk1LjUzNTU5NzcgMzY1LjY3MTUyMSw5My45MzA1MzQ0IDM2NS42NzE1MjEsOTMuOTMwNTM0NCBDMzY1LjY3MTUyMSw5My45MzA1MzQ0IDM2Ny4yOTE2MTUsOTIuOTEwNDE1MSAzNzAuMjYxNzg4LDkyLjE2MDQwMTUgQzM3My4yMzE5Niw5MS40MTAzODc5IDM3Ny40MDk3MzMsOTAuNjUyODEzOSAzODIsOTEuMTcwMzQ0IEMzODIsOTEuMTcwMzQ0IDM4MC4xMzIzOTEsOTIuMjUwNDA2NyAzNzcuOTI3MjYzLDk4Ljk1NTc5NjYgQzM3NS43MjIxMzUsMTA1LjY2MTE4NiAzNzQuNTA3MDY0LDEwNy43MzEzMDcgMzc0LjUwNzA2NCwxMDcuNzMxMzA3IEMzNzQuNTA3MDY0LDEwNy43MzEzMDcgMzcxLjg1MTkxLDExMy4zNTY2MzQgMzY1LjQ2MTUzOCwxMTQuNTcxNzA0IEMzNjUuNDYxNTM4LDExNC41NzE3MDQgMzY4LjY1NjcyNCwxMTguMzk2OTI3IDM3OS45OTczODQsMTE3LjEzNjg1NCBDMzc5Ljk5NzM4NCwxMTcuMTM2ODU0IDM1OC4wODExMDksMTMxLjE3NzY3IDM0OC4yNzA1MzksMTE0Ljg0MTcyIEMzNDguMDQ4OTQ2LDExNC4zNDQyNjEgMzQ1Ljg0OTM5OCwxMTAuMDI1NDUgMzQ1LjMwMDM2NiwxMDguMjExMzA1IEMzNDQuNjEwMjk2LDEwNS45MzEyMDIgMzQ0LjMwOTEzOSwxMDUuMTI1Mzg1IDM0My4yOTAyNzksMTA0LjE2MTA2OSBDMzQwLjc3MDEzMywxMDEuNzc1OTMxIDMzOSwxMDIuNjkxMDE0IDMzOSwxMDIuNjkxMDE0IiBpZD0iRmlsbC0xLUNvcHktNyIgZmlsbD0iIzc1QTBEMyI+PC9wYXRoPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+
+      mediatype: image/svg+xml
+  maintainers:
+  - name: EnMasse
+    email: enmasse@redhat.com
+  provider:
+    name: EnMasse
+  labels:
+    app: enmasse
+  selector:
+    matchLabels:
+      app: enmasse
+  links:
+  - name: Documentation
+    url: https://enmasse.io/documentation
+  - name: GitHub
+    url: https://github.com/EnMasseProject/enmasse
+
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: [ "apps" ]
+          resources: [ "deployments" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps", "secrets", "persistentvolumeclaims", "services" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
+        - apiGroups: [ "", "route.openshift.io" ]
+          resources: [ "routes", "routes/custom-host", "routes/status"]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "authenticationservices", "authenticationservices/finalizers", "consoleservices", "consoleservices/finalizers" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch" ]
+        - apiGroups: [ "iot.enmasse.io" ]
+          resources: [ "iotconfigs", "iotconfigs/finalizers" ]
+          verbs: [ "get", "list", "watch", "update", "create", "patch" ]
+      - serviceAccountName: address-space-controller
+        rules:
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices", "consoleservices"]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "pods" ]
+          verbs: [ "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "events" ]
+          verbs: [ "create", "update", "patch", "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "services", "secrets", "persistentvolumeclaims" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "networking.k8s.io", "extensions" ]
+          resources: [ "networkpolicies" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "route.openshift.io", "" ]
+          resources: [ "routes", "routes/custom-host", "routes/status" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "apps", "extensions" ]
+          resources: [ "statefulsets", "deployments", "replicasets" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+      - serviceAccountName: address-space-admin
+        rules:
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices", "consoleservices"]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "pods", "secrets" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "" ]
+          resources: [ "events" ]
+          verbs: [ "create", "update", "patch", "get", "list" ]
+        - apiGroups: [ "" ]
+          resources: [ "persistentvolumeclaims", "services" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "apps" ]
+          resources: [ "statefulsets", "deployments" ]
+          verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+      - serviceAccountName: api-server
+        rules:
+        - apiGroups: [ "" ]
+          resources: [ "services", "secrets" ]
+          verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "admin.enmasse.io" ]
+          resources: [ "addressspaceplans", "addressplans", "standardinfraconfigs", "brokeredinfraconfigs", "authenticationservices", "consoleservices"]
+          verbs: [ "get", "list", "watch" ]
+      clusterPermissions:
+      - serviceAccountName: standard-authservice
+        rules:
+        - apiGroups: [ "authentication.k8s.io" ]
+          resources: [ "tokenreviews" ]
+          verbs: [ "create" ]
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: [ "oauth.openshift.io" ]
+          resources: [ "oauthclients" ]
+          verbs: [ "create", "get", "update", "list", "watch" ]
+      - serviceAccountName: api-server
+        rules:
+        - apiGroups: [ "authentication.k8s.io" ]
+          resources: [ "tokenreviews" ]
+          verbs: [ "create" ]
+        - apiGroups: [ "authorization.k8s.io" ]
+          resources: [ "subjectaccessreviews" ]
+          verbs: [ "create" ]
+        - apiGroups: [ "" ]
+          resources: [ "configmaps" ]
+          resourceNames: [ "extension-apiserver-authentication" ]
+          verbs: [ "get" ]
+      deployments:
+      - name: enmasse-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              name: enmasse-operator
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                name: enmasse-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              serviceAccountName: enmasse-operator
+              containers:
+              - name: controller
+                image: docker.io/enmasseproject/controller-manager:0.28.0
+                imagePullPolicy: IfNotPresent
+                env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_NAME
+                  value: "enmasse-operator"
+                - name: IMAGE_PULL_POLICY
+                  value: "IfNotPresent"
+                - name: CONTROLLER_DISABLE_ALL
+                  value: "true"
+                - name: CONTROLLER_ENABLE_IOT_CONFIG
+                  value: "true"
+                - name: CONTROLLER_ENABLE_AUTHENTICATION_SERVICE
+                  value: "true"
+                - name: IOT_AUTH_SERVICE_IMAGE
+                  value: docker.io/enmasseproject/iot-auth-service:0.28.0
+                - name: IOT_DEVICE_REGISTRY_FILE_IMAGE
+                  value: docker.io/enmasseproject/iot-device-registry-file:0.28.0
+                - name: IOT_GC_IMAGE
+                  value: docker.io/enmasseproject/iot-gc:0.28.0
+                - name: IOT_HTTP_ADAPTER_IMAGE
+                  value: docker.io/enmasseproject/iot-http-adapter:0.28.0
+                - name: IOT_MQTT_ADAPTER_IMAGE
+                  value: docker.io/enmasseproject/iot-mqtt-adapter:0.28.0
+                - name: IOT_TENANT_SERVICE_IMAGE
+                  value: docker.io/enmasseproject/iot-tenant-service:0.28.0
+                - name: IOT_PROXY_CONFIGURATOR_IMAGE
+                  value: docker.io/enmasseproject/iot-proxy-configurator:0.28.0
+                - name: QDROUTERD_BASE_IMAGE
+                  value: enmasseproject/qdrouterd-base:1.6.0-rc1
+                - name: NONE_AUTHSERVICE_IMAGE
+                  value: docker.io/enmasseproject/none-authservice:0.28.0
+                - name: KEYCLOAK_IMAGE
+                  value: jboss/keycloak-openshift:4.8.3.Final
+                - name: KEYCLOAK_PLUGIN_IMAGE
+                  value: docker.io/enmasseproject/keycloak-plugin:0.28.0
+                - name: CONTROLLER_ENABLE_CONSOLE_SERVICE
+                  value: "true"
+                - name: CONSOLE_INIT_IMAGE
+                  value: "docker.io/enmasseproject/console-init:0.28.0"
+                - name: CONSOLE_PROXY_OPENSHIFT_IMAGE
+                  value: "openshift/oauth-proxy:latest"
+                - name: CONSOLE_PROXY_KUBERNETES_IMAGE
+                  value: "quay.io/pusher/oauth2_proxy:latest"
+                - name: CONSOLE_HTTPD_IMAGE
+                  value: "docker.io/enmasseproject/console-httpd:0.28.0"
+                resources:
+                  limits:
+                    memory: 128Mi
+      - name: user-api-server
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              component: user-api-server
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                component: user-api-server
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc -Xlog:gc*
+                - name: CERT_DIR
+                  value: /api-server-cert
+                - name: ENABLE_RBAC
+                  value: "true"
+                - name: APISERVER_CLIENT_CA_CONFIG_NAME
+                  value: extension-apiserver-authentication
+                - name: APISERVER_CLIENT_CA_CONFIG_NAMESPACE
+                  value: kube-system
+                - name: APISERVER_ROUTE_NAME
+                  value: restapi
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                image: docker.io/enmasseproject/api-server:0.28.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                name: api-server
+                ports:
+                - containerPort: 8080
+                  name: http
+                - containerPort: 8443
+                  name: https
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /api-server-cert
+                  name: apiservice-cert
+                  readOnly: true
+              serviceAccountName: api-server
+
+      - name: api-server
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              component: api-server
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                component: api-server
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc -Xlog:gc*
+                - name: CERT_DIR
+                  value: /api-server-cert
+                - name: ENABLE_RBAC
+                  value: "true"
+                - name: APISERVER_CLIENT_CA_CONFIG_NAME
+                  value: extension-apiserver-authentication
+                - name: APISERVER_CLIENT_CA_CONFIG_NAMESPACE
+                  value: kube-system
+                - name: APISERVER_ROUTE_NAME
+                  value: restapi
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                image: docker.io/enmasseproject/api-server:0.28.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                name: api-server
+                ports:
+                - containerPort: 8080
+                  name: http
+                - containerPort: 8443
+                  name: https
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
+                volumeMounts:
+                - mountPath: /api-server-cert
+                  name: apiservice-cert
+                  readOnly: true
+              serviceAccountName: api-server
+      - name: address-space-controller
+        spec:
+          replicas: 1
+          strategy:
+            type: RollingUpdate
+          selector:
+            matchLabels:
+              app: enmasse
+              name: address-space-controller
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                name: address-space-controller
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                          - key: node-role.enmasse.io/operator-infra
+                            operator: In
+                            values:
+                              - "true"
+              containers:
+              - env:
+                - name: JAVA_OPTS
+                  value: -verbose:gc
+                - name: ENABLE_EVENT_LOGGER
+                  value: "true"
+                - name: EXPOSE_ENDPOINTS_BY_DEFAULT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: exposeEndpointsByDefault
+                      name: address-space-controller-config
+                      optional: true
+                - name: ENVIRONMENT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: environment
+                      name: address-space-controller-config
+                      optional: true
+                - name: TEMPLATE_DIR
+                  value: /templates
+                - name: RESOURCES_DIR
+                  value: /
+                - name: STANDARD_AUTHSERVICE_CONFIG_NAME
+                  value: keycloak-config
+                - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME
+                  value: keycloak-credentials
+                - name: STANDARD_AUTHSERVICE_CERT_SECRET_NAME
+                  value: standard-authservice-cert
+                - name: WILDCARD_ENDPOINT_CERT_SECRET
+                  valueFrom:
+                    configMapKeyRef:
+                      key: wildcardEndpointCertSecret
+                      name: address-space-controller-config
+                      optional: true
+                - name: RESYNC_INTERVAL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: resyncInterval
+                      name: address-space-controller-config
+                      optional: true
+                - name: RECHECK_INTERVAL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: recheckInterval
+                      name: address-space-controller-config
+                      optional: true
+                - name: IMAGE_PULL_POLICY
+                  value: IfNotPresent
+                - name: ROUTER_IMAGE
+                  value: docker.io/enmasseproject/router:0.28.0
+                - name: STANDARD_CONTROLLER_IMAGE
+                  value: docker.io/enmasseproject/standard-controller:0.28.0
+                - name: AGENT_IMAGE
+                  value: docker.io/enmasseproject/agent:0.28.0
+                - name: BROKER_IMAGE
+                  value: docker.io/enmasseproject/artemis:0.28.0
+                - name: BROKER_PLUGIN_IMAGE
+                  value: docker.io/enmasseproject/broker-plugin:0.28.0
+                - name: TOPIC_FORWARDER_IMAGE
+                  value: docker.io/enmasseproject/topic-forwarder:0.28.0
+                - name: MQTT_GATEWAY_IMAGE
+                  value: docker.io/enmasseproject/mqtt-gateway:0.28.0
+                - name: MQTT_LWT_IMAGE
+                  value: docker.io/enmasseproject/mqtt-lwt:0.28.0
+                image: docker.io/enmasseproject/address-space-controller:0.28.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                name: address-space-controller
+                ports:
+                - containerPort: 8080
+                  name: http
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: http
+                    scheme: HTTP
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 256Mi
+              serviceAccountName: address-space-controller
+  apiservicedefinitions:
+    owned:
+    - group: enmasse.io
+      version: v1beta1
+      kind: AddressSpace 
+      name: addressspaces
+      displayName: Address Space
+      description: A group of messaging addresses that can be accessed via the same endpoint
+      deploymentName: api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The address space type.
+          displayName: Type
+          path: type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The address space plan.
+          displayName: Plan
+          path: plan
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+      statusDescriptors:
+        - description: Address space ready.
+          displayName: Ready
+          path: isReady
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+    - group: enmasse.io
+      version: v1beta1
+      kind: Address
+      name: addresses
+      displayName: Address
+      description: A messaging address that can be used to send/receive messages to/from
+      deploymentName: api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The address type.
+          displayName: Type
+          path: type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The address plan.
+          displayName: Plan
+          path: plan
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+      statusDescriptors:
+        - description: Address ready.
+          displayName: Ready
+          path: isReady
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+        - description: Address phase
+          displayName: Phase
+          path: phase
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+    - group: enmasse.io
+      version: v1beta1
+      kind: AddressSpaceSchema
+      name: addressspaceschemas
+      displayName: AddressSpaceSchema
+      description: A resource representing the available schema of plans and authentication services
+      deploymentName: api-server
+      containerPort: 8443
+    - group: user.enmasse.io
+      version: v1beta1
+      kind: MessagingUser
+      name: messagingusers
+      displayName: Messaging User
+      description: A messaging user that can connect to an Address Space
+      deploymentName: user-api-server
+      containerPort: 8443
+      specDescriptors:
+        - description: The user name.
+          displayName: Username
+          path: username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The authentication type
+          displayName: Authentication type
+          path: authentication.type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+        - description: The password
+          displayName: Password
+          path: authentication.password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:label'
+  customresourcedefinitions:
+    owned:
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: StandardInfraConfig
+        name: standardinfraconfigs.admin.enmasse.io
+        displayName: Standard Infra Config
+        description: Infrastructure configuration template for the standard address space type
+        specDescriptors:
+          - description: The minimal number of AMQP router replicas to create.
+            displayName: Minimum Router Replicas
+            path: router.minReplicas
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+          - description: The link capacity of AMQP producer links attached to the routers.
+            displayName: Link capacity
+            path: router.linkCapacity
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for AMQP router pods.
+            displayName: Router Memory
+            path: router.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for message brokers.
+            displayName: Broker Memory
+            path: broker.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of storage to configure for message brokers.
+            displayName: Broker Storage
+            path: broker.resources.storage
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The storage class name to use for message broker persistent volumes.
+            displayName: Broker Storage Class
+            path: broker.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The policy to apply when message queues are full.
+            displayName: Broker Address Full Policy
+            path: broker.addressFullPolicy
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for the admin operator.
+            displayName: Admin Memory
+            path: admin.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: BrokeredInfraConfig
+        name: brokeredinfraconfigs.admin.enmasse.io
+        displayName: Brokered Infra Config
+        description: Infrastructure configuration template for the brokered address space type
+        specDescriptors:
+          - description: The amount of memory to configure for message brokers.
+            displayName: Broker Memory
+            path: broker.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of storage to configure for message brokers.
+            displayName: Broker Storage
+            path: broker.resources.storage
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The storage class name to use for message broker persistent volumes.
+            displayName: Broker Storage Class
+            path: broker.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The policy to apply when message queues are full.
+            displayName: Broker Address Full Policy
+            path: broker.addressFullPolicy
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The amount of memory to configure for the admin operator.
+            displayName: Admin Memory
+            path: admin.resources.memory
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta2
+        kind: AddressPlan
+        name: addressplans.admin.enmasse.io
+        displayName: Address Plan
+        description: Plan describing the resource usage of a given address type
+        specDescriptors:
+          - description: The name to be displayed in the console UI.
+            displayName: Display Name
+            path: displayName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The description to be shown in the console UI.
+            displayName: Short Description
+            path: shortDescription
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The broker resource usage.
+            displayName: Broker Usage
+            path: resources.broker
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The router resource usage.
+            displayName: Router Usage
+            path: resources.router
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta2
+        kind: AddressSpacePlan
+        name: addressspaceplans.admin.enmasse.io
+        displayName: Address Space Plan
+        description: Plan describing the capabilities and resource limits of a given address space type
+        specDescriptors:
+          - description: The name to be displayed in the console UI.
+            displayName: Display Name
+            path: displayName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The reference to the infrastructure config used by this plan.
+            displayName: InfraConfig Reference
+            path: infraConfigRef
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The description to be shown in the console UI.
+            displayName: Short Description
+            path: shortDescription
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The quota for broker resources
+            displayName: Broker Quota
+            path: resourceLimits.broker
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The quota for router resources
+            displayName: Router Quota
+            path: resourceLimits.router
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: The aggregate quota for all resources
+            displayName: Aggregate Quota
+            path: resourceLimits.aggregate
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: AuthenticationService
+        name: authenticationservices.admin.enmasse.io
+        displayName: Authentication Service
+        description: Authentication service configuration available to address spaces.
+        specDescriptors:
+          - description: The type of authentication service
+            displayName: Type
+            path: type
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: admin.enmasse.io
+        version: v1beta1
+        kind: ConsoleService
+        name: consoleservices.admin.enmasse.io
+        displayName: Console Service
+        description: Console Service Singleton for deploying global console.
+        specDescriptors:
+          - description: The discovery Metadata URL
+            displayName: Discovery Metadata URL
+            path: discoveryMetadataUrl
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: Console certificate secret name
+            displayName: Console certificate secret name
+            path: certificateSecret.name
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: OAUTH Client Secret Name
+            displayName: OAUTH Client Secret Name
+            path: oauthClientSecret.name
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: Scope
+            displayName: Scope
+            path: scope
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: Host to use for ingress
+            displayName: Host
+            path: host
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - group: iot.enmasse.io
+        version: v1alpha1
+        kind: IoTConfig
+        name: iotconfigs.iot.enmasse.io
+        displayName: IoT Config
+        description: IoT Infrastructure Configuration Singleton

--- a/upstream-community-operators/enmasse/enmasse.package.yaml
+++ b/upstream-community-operators/enmasse/enmasse.package.yaml
@@ -1,0 +1,4 @@
+packageName: enmasse
+channels:
+- name: alpha
+  currentCSV: enmasse.0.28.0

--- a/upstream-community-operators/enmasse/iotconfigs.crd.yaml
+++ b/upstream-community-operators/enmasse/iotconfigs.crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: iotconfigs.iot.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: iot.enmasse.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: IoTConfig
+    plural: iotconfigs
+    singular: iotconfig
+    shortNames:
+    - icfg

--- a/upstream-community-operators/enmasse/standardinfraconfigs.crd.yaml
+++ b/upstream-community-operators/enmasse/standardinfraconfigs.crd.yaml
@@ -1,0 +1,165 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: standardinfraconfigs.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: StandardInfraConfig
+    listKind: StandardInfraConfigList
+    singular: standardinfraconfig
+    plural: standardinfraconfigs
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            version:
+              type: string
+            networkPolicy:
+              type: object
+              properties:
+                ingress:
+                  type: array
+                egress:
+                  type: array
+            admin:
+              type: object
+              properties:
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                        priorityClassName:
+                          type: string
+                        containers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              resources:
+                                type: object
+            broker:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                        priorityClassName:
+                          type: string
+                        resources:
+                          type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                    storage:
+                      type: string
+                addressFullPolicy:
+                  type: string
+                  enum:
+                  - PAGE
+                  - BLOCK
+                  - FAIL
+                  - DROP
+                storageClassName:
+                  type: string
+                updatePersistentVolumeClaim:
+                  type: boolean
+                connectorIdleTimeout:
+                  type: integer
+                connectorWorkerThreads:
+                  type: integer
+            router:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                        priorityClassName:
+                          type: string
+                        resources:
+                          type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                minReplicas:
+                  type: integer
+                linkCapacity:
+                  type: integer
+                idleTimeout:
+                  type: integer
+                workerThreads:
+                  type: integer
+                policy:
+                  type: object
+                  properties:
+                    maxConnections:
+                      type: integer
+                    maxConnectionsPerUser:
+                      type: integer
+                    maxConnectionsPerHost:
+                      type: integer
+                    maxSessionsPerConnection:
+                      type: integer
+                    maxSendersPerConnection:
+                      type: integer
+                    maxReceiversPerConnection:
+                      type: integer


### PR DESCRIPTION
This adds a bundle for EnMasse. EnMasse is an open source project for managed, self-service messaging on Kubernetes, and provides a uniform interface to manage different underlying messaging technologies. 