### PR TITLE
scripts/ci/test-operator: set PKG_FILE again with nested path

### DIFF
--- a/scripts/ci/test-operator
+++ b/scripts/ci/test-operator
@@ -55,6 +55,8 @@ mkdir -p "$CR_DIR"
 # Organize expected dir structure for the registry image build.
 operator-courier nest "${OP_PATH}" "${DEPLOY_DIR}/${PKG_NAME}"
 pushd "$DEPLOY_DIR"
+# Set PKG_FILE again with the nested path.
+PKG_FILE="$(find "$DEPLOY_DIR" -name "*.package.yaml" -print -quit)"
 CATALOGSOURCE_FILE="${PKG_NAME}.catalogsource.yaml"
 SUBSCRIPTION_FILE="${PKG_NAME}.subscription.yaml"
 OPERATOR_GROUP_FILE="${PKG_NAME}.operatorgroup.yaml"


### PR DESCRIPTION
So `$PKG_FILE` can be used in any directory.

/cc @SamiSousa 