### PR TITLE
Add operator for FederatorAI 0.0.1

### DIFF
--- a/community-operators/federatorai/federatorai-AlamedaService.crd.yaml
+++ b/community-operators/federatorai/federatorai-AlamedaService.crd.yaml
@@ -11,3 +11,4 @@ spec:
     singular: alamedaservice
   scope: Namespaced
   version: v1alpha1
+

--- a/community-operators/federatorai/federatorai-AlamedaService.crd.yaml
+++ b/community-operators/federatorai/federatorai-AlamedaService.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: alamedaservices.federatorai.containers.ai
+spec:
+  group: federatorai.containers.ai
+  names:
+    kind: AlamedaService
+    listKind: AlamedaServiceList
+    plural: alamedaservices
+    singular: alamedaservice
+  scope: Namespaced
+  version: v1alpha1

--- a/community-operators/federatorai/federatorai.package.yaml
+++ b/community-operators/federatorai/federatorai.package.yaml
@@ -1,0 +1,4 @@
+packageName: federatorai
+channels:
+- name: alpha
+  currentCSV: federatorai.v0.0.1

--- a/community-operators/federatorai/federatorai.package.yaml
+++ b/community-operators/federatorai/federatorai.package.yaml
@@ -2,3 +2,4 @@ packageName: federatorai
 channels:
 - name: alpha
   currentCSV: federatorai.v0.0.1
+

--- a/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -1,0 +1,484 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: federatorai.v0.0.1
+  namespace: placeholder
+  annotations:
+    capabilities: Basic Install
+    categories: OpenShift Optional
+    certified: "false"
+    repository: https://github.com/containers-ai/federatorai-operator
+    containerImage: prophetstor/federatorai-operator:0.0.1
+    createdAt: 2019-03-19T00:59:59Z
+    description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
+    support: ProphetStor Data Services, Inc.
+    alm-examples: >-
+      [{"apiVersion":"federatorai.containers.ai/v1alpha1","kind":"AlamedaService","metadata":{"name":"my-alamedaservice"},"spec":{"enableexecution":true,"enablegui":true,"version":"v0.3.7","prometheusservice":"https://prometheus-k8s.openshift-monitoring:9091","persistentvolumeclaim":""}},{"apiVersion":"autoscaling.containers.ai/v1alpha1","kind":"AlamedaScaler","metadata":{"name":"alameda","namespace":"webapp"},"spec":{"policy":"stable","selector":{"matchLabels":{"app":"nginx"}}}}]
+spec: 
+  version: 0.0.1
+  maturity: alpha
+  displayName: FederatorAI
+  description: |
+    **FederatorAI** is the brain of resource orchestration for kubernetes. It foresees future resource usage of your Kubernetes cluster from the cloud layer down to the pod level. We use machine learning technology to provide intelligence that enables dynamic scaling and scheduling of your containers - effectively making us the “brain” of Kubernetes resource orchestration. By providing full foresight of resource availability, demand, health, impact and SLA, we enable cloud strategies that involve changing provisioned resources in real time. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+
+    **FederatorAI Operator** provides easy configuration and management of AI-based Kubernetes resource orchestrator. Once installed, the FederatoAI Operator provides the following features:
+    - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
+    - **Easy Configuration**: Easily config source of Prometheus and enable/disable addon components such as GUI, and execition.
+    - **Autoscaling Pod**: Use provided CRD to setup target pods for autoscaling.
+
+    ### Prerequisite
+    **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
+
+    ### Common Configurations
+        apiVersion: federatorai.containers.ai/v1alpha1
+        kind: Alamedaservice
+        metadata:
+          name: my-alamedaservice
+        spec:
+          enableexecution: true
+          enablegui: true
+          version: v0.3.7
+          prometheusservice: https://prometheus-k8s.openshift-monitoring:9091
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAACWCAMAAACsAjcrAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAC91BMVEUAAAD9/v3r78n09PTx8fHu7u719fX29vba2tpiZWLc3Nzf39/b4p/DxMPHx8fLy8zO13zExcTIyMjMzM3G0WjH0mrr78rIx8js8M3a29r19PXd3N329+X5+fn4+Pj6+/L5+vDs8M7s78v4+u3H0Wj///65x0T///25x0X+/f66x0b9/vy3xT7I0mvI0mrI02vU3Ir9/v3K1HHr78nCzlzM1nXM1nbX3pPL1XP09+L19fXz8/Px8fHx8fHx8fHx8fHv8O/t7e3s7Ozs7Ozy8vL9/f3+/v/r6+zm5ubm5ubm5ubw8PD+/v3f39/W1tbQ0NDf4N/x8fHKysrT09P9/f+8vL3MzM34+Pje5ajQ2YHE0GPF0GXF0GTd5KTMzcy9vr3b3Nv////x8fG5ubnu7+6UlJaurrD09PTS24i/y1S+v766urrv7++WlpiwsLH09PXL1XW1wzrM1ne2xT22xD3v8O+6ubqVlZevr7HL1XT19+TMzszc3Nzv7u/X35T19+Tg4ODW19bh4eHy8fLMzMzU09T19PW9vb7Ozs75+fj3+On19+T19+X29+X6+vr4+Pj29vb29vb29vb29vb29vb19fXz9PPz8/P09PT39/f8/Pz9/f3z8/Pw8PDw8PDw8PD29vb+/v76+/Hu8tPq7sXq7sbP2H62xD35+u/s8Mzm67zn673n7L7g5q61wzns8Mzq7sfr78n4+ezDzl22xDy3xD23xT+1wzeltg6mtxCmtxK0wzmltw+mtxGnuBOmuBOnuBXPz8/P0M++vr6/vr+/v7+qqqupqaqys7K1trWzs7OXlpeYl5iZmJl3d3l2dnivvyuwwC2wwCzR2oSztLO2t7a1tLWamZqbmpt5eXt4eHqktQultg2ktg3K1HHL1XO0wziltg+0tLS1wzjR2oPH0mnH0mrR0dHAv8DAwMCrq62rq6zBzVmtvSSuvieuviWouRa7yEi9yk+ouRepuhqpuhnN13jn7MDg5qvh5q3h5qzt8M////9HTZ/9AAAAs3RSTlMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7ArsCuwK7Av7r5+upAfIxCQsLCPEnBWZ9e3cWA2F9e2EDAVp+e31mBQvT/nxD6cgCu9MLFoaOjo6OC9O7AnXIBbvTCyfx08gFu9MLJ/En8fEFyLvT8ScLuwXDFgvThkvtyAW70wuOjpBBBnWPjogaA2+QjpBvAwFokI6PdQYCBQUFK/JY3tvb2+H9ZmZmZjqy/PcAAAABYktHRGGysEyGAAAACXBIWXMAAAGQAAABkABW8NvoAAACuklEQVR42u3cVVQUURzH8RUUA1tssVHADgxs7EbEVhQLC2ywu7s7UbC7WGRRUbAQOxCMtVuxxRefFnc8d/+Mc9T5z/H3fb73nv/nzOudqztw8JDSDhd10PHpSIheaaHFiqs9vVlHwwxKC3d0Unt6QAABBBBA1A4QQAABBBBAAAEEEEAA+Z8gx1hDQsNld9y5hNrTW4boS5YqLbcyZcupPT0BKV+hoovMKlVOofb0BKRKVSu1RwIEEFYBwi1AuAUItwDhFiDcAoRbgHCLgFi7Vqteg6hmrZSiE1PVruNWl8itXn0b0b4GDRs1JmrStFlqhZA0zVuciCBq6Z5WdKJ1K4+Tp4giW7umE+3zbBN1miiqbTtb09L07Tt07GRe5y4UJINX1zNUZ7t5CyHdz52PJrrQo2dGIaRXzEWimN4+mUxLM/fpe+myeVeuUpAsXv2uUV23BLkRfZPoVv8BWYUQ39jbRLF+A7OZltoNGhwXb96du9qEZB8yNEQytuGeViHDpBA9IIAAAggggAACCCCAAAIIIIAAAggggAACCCCAAAIIIIAAAggggAACCCCAaBsy/G9A7hslj38Z/wTkAQ3xt/BFAmjICBryUPriWdjIUTmSIKOTgYxR9kX8x+YU7XNIBuLnQ0IePX4iadz4XKbluSdMpK40RjydJJpHl2fylMhnRM+nTssrhEx/8ZJqxkxbCjJrtqQ5c/MlnWw/b/6ChUSLFguvfdosWbpsOdGKlavyi/atXrN2HdH6DRvtKYgmA4RbgHALEG4Bwi1AuAUItwDhFiDcAuRfVCBw0+YgmXkHb+ELKbh12/YdMtu5a7eRLaTQnlev38jt7TsDW4jV3oRf/i38jQABBBBAAAEEEEAAAQQQQAABBBBAAAFEixADI0jhfe8/fFTap89qj/+zIvu/fP2msMTE7z8AofGIUB1IPooAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDMtMTRUMTc6MDA6NTIrMDE6MDCjbINkAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAzLTE0VDE3OjAwOjUyKzAxOjAw0jE72AAAACB0RVh0cGRmOkhpUmVzQm91bmRpbmdCb3gANDA4eDI2NiswKzDr8x6EAAAAHXRFWHRwZGY6U3BvdENvbG9yLTAAUEFOVE9ORSA0MjEgQx6zNCoAAAAldEVYdHBkZjpTcG90Q29sb3ItMQBQQU5UT05FIENvb2wgR3JheSA3IEOzNDMdAAAAJXRFWHRwZGY6U3BvdENvbG9yLTIAUEFOVE9ORSBDb29sIEdyYXkgOSBDz08nKgAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNQ1Ag1dMAAAAAElFTkSuQmCC
+    mediatype: image/png
+  keywords: ['AI', 'Resource Orchestration', 'NoOps']
+  maintainers:
+  - email: info@prophetstor.com
+    name: ProphetStor Data Services, Inc.
+  provider:
+    name: ProphetStor Data Services, Inc.
+  links:
+  - name: FederatorAI
+    url: https://github.com/containers-ai/alameda
+  - name: FederatorAI Operator
+    url: https://github.com/containers-ai/federatorai-operator
+  labels:
+    alm-owner-federatorai: federatorai-operator
+    alm-status-descriptors: federatorai-operator.v0.0.1
+  selector:
+    matchLabels:
+      alm-owner-federatorai: federatorai-operator
+  customresourcedefinitions:
+    owned:
+    - name: alamedaservices.federatorai.containers.ai
+      version: v1alpha1
+      kind: AlamedaService
+      displayName: AlamedaService
+      description: An instance of Alameda.
+      resources:
+      - kind: Deployment
+        version: v1
+      - kind: ReplicaSet
+        version: v1
+      - kind: Pod
+        version: v1
+      specDescriptors:
+      - description: Enable Execution
+        displayName: Enable Execution
+        path: enableexecution
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Enable dashboard
+        displayName: Enable GUI
+        path: enablegui
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - "*"
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - federatorai.containers.ai
+          resources:
+          - alamedaservices
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - list
+          - watch
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - services
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - federatorai.containers.ai
+          resources:
+          - alamedaservices/finalizers
+          verbs:
+          - '*'
+      - serviceAccountName: alameda-operator
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - nodes
+          - replicationcontrollers
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - alamedascalers
+          - alamedarecommendations
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - update
+      - serviceAccountName: admission-controller
+        rules:
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - create
+          - update
+      - serviceAccountName: alameda-datahub
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+      permissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - federatorai.containers.ai
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - federatorai-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+      - serviceAccountName: alameda-operator
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - nodes
+          - pods
+          - replicationcontrollers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - alamedascalers
+          - alamedarecommendations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - alamedascalers/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - secrets
+          verbs:
+          - create
+          - watch
+          - list
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - watch
+          - create
+          - update
+          - list
+        - apiGroups:
+          - ''
+          resources:
+          - services
+          verbs:
+          - watch
+          - create
+          - update
+          - list
+      - serviceAccountName: alameda-datahub
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - alamedarecommendations
+          verbs:
+          - get
+          - update
+      - serviceAccountName: alameda-evictioner
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          verbs:
+          - get
+          - delete
+      - serviceAccountName: admission-controller
+        rules:
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ''
+          resources:
+          - replicationcontrollers
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+      - serviceAccountName: alameda-ai
+        rules: []
+      deployments:
+      - name: federatorai-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: federatorai-operator
+            strategy:
+              type: Recreate
+          template:
+            metadata:
+              labels:
+                name: federatorai-operator
+            spec:
+              serviceAccountName: federatorai-operator
+              containers:
+              - command:
+                - federatorai-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: federatorai-operator
+                image: quay.io/prophetstor/federatorai-operator:v0.0.1
+                imagePullPolicy: IfNotPresent
+                name: federatorai-operator
+                resources: {}

--- a/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -100,181 +100,117 @@ spec:
       - serviceAccountName: federatorai-operator
         rules:
         - apiGroups:
+          - federatorai.containers.ai
+          resources:
           - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
           resources:
           - nodes
+          - replicationcontrollers
+          - pods
+          - persistentvolumeclaims
+          - serviceaccounts
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
-          - federatorai.containers.ai
+          - ""
           resources:
-          - alamedaservices
+          - serviceaccounts
           verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - services
+          verbs:
+          - create
           - list
-          - update
           - watch
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterroles
-          verbs:
-          - create
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
           - clusterrolebindings
           verbs:
+          - create
           - list
           - watch
-          - create
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumeclaims
-          - services
-          - configmaps
-          - serviceaccounts
-          verbs:
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          verbs:
-          - create
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - create
         - apiGroups:
           - apps
           resources:
           - deployments
           verbs:
+          - create
           - list
           - watch
-          - create
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - list
+          - watch
         - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
           verbs:
-          - get
           - create
-          - update
           - delete
+          - get
+          - update
         - apiGroups:
-          - federatorai.containers.ai
+          - admissionregistration.k8s.io
           resources:
-          - alamedaservices/finalizers
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
           verbs:
-          - '*'
-      - serviceAccountName: alameda-operator
-        rules:
-        - apiGroups:
-          - ''
-          resources:
-          - nodes
-          - replicationcontrollers
-          verbs:
+          - create
+          - get
           - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - services
-          verbs:
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - replicasets
-          verbs:
-          - list
+          - update
           - watch
         - apiGroups:
           - apps.openshift.io
           resources:
           - deploymentconfigs
           verbs:
-          - list
-          - watch
-        - apiGroups:
-          - autoscaling.containers.ai
-          resources:
-          - alamedascalers
-          - alamedarecommendations
-          verbs:
-          - list
-          - watch
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - validatingwebhookconfigurations
-          verbs:
-          - create
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - create
-          - update
-      - serviceAccountName: admission-controller
-        rules:
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - mutatingwebhookconfigurations
-          verbs:
           - get
-          - create
-          - update
-      - serviceAccountName: alameda-datahub
-        rules:
-        - apiGroups:
-          - ''
-          resources:
-          - namespaces
-          verbs:
-          - get
+          - list
+          - watch
       permissions:
       - serviceAccountName: federatorai-operator
         rules:
         - apiGroups:
-          - federatorai.containers.ai
-          resources:
-          - '*'
-          verbs:
-          - '*'
-        - apiGroups:
           - ""
           resources:
-          - pods
-          - services
+          - configmaps
+          - events
           - endpoints
           - persistentvolumeclaims
-          - events
-          - configmaps
+          - pods
           - secrets
+          - services
           verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - get
+          - "*"
         - apiGroups:
           - apps
           resources:
@@ -283,167 +219,20 @@ spec:
           - replicasets
           - statefulsets
           verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
-          - create
+          - "*"
         - apiGroups:
           - apps
-          resourceNames:
-          - federatorai-operator
           resources:
           - deployments/finalizers
           verbs:
           - update
         - apiGroups:
-          - ""
+          - monitoring.coreos.com
           resources:
-          - serviceaccounts
+          - servicemonitors
           verbs:
           - create
-      - serviceAccountName: alameda-operator
-        rules:
-        - apiGroups:
-          - ''
-          resources:
-          - nodes
-          - pods
-          - replicationcontrollers
-          verbs:
           - get
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          - deployments
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - autoscaling.containers.ai
-          resources:
-          - alamedascalers
-          - alamedarecommendations
-          verbs:
-          - get
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - autoscaling.containers.ai
-          resources:
-          - alamedascalers/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - ''
-          resources:
-          - namespaces
-          verbs:
-          - get
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - get
-        - apiGroups:
-          - ''
-          resources:
-          - secrets
-          verbs:
-          - create
-          - watch
-          - list
-        - apiGroups:
-          - ''
-          resources:
-          - services
-          verbs:
-          - watch
-          - create
-          - update
-          - list
-      - serviceAccountName: alameda-datahub
-        rules:
-        - apiGroups:
-          - autoscaling.containers.ai
-          resources:
-          - alamedarecommendations
-          verbs:
-          - get
-          - update
-      - serviceAccountName: alameda-evictioner
-        rules:
-        - apiGroups:
-          - ''
-          resources:
-          - pods
-          verbs:
-          - get
-          - delete
-      - serviceAccountName: admission-controller
-        rules:
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - mutatingwebhookconfigurations
-          verbs:
-          - get
-          - create
-          - update
-        - apiGroups:
-          - ''
-          resources:
-          - pods
-          verbs:
-          - get
-          - list
-          - patch
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          - deployments
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - ''
-          resources:
-          - replicationcontrollers
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - get
-          - list
-      - serviceAccountName: alameda-ai
-        rules: []
       deployments:
       - name: federatorai-operator
         spec:
@@ -477,3 +266,4 @@ spec:
                 imagePullPolicy: IfNotPresent
                 name: federatorai-operator
                 resources: {}
+

--- a/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -4,11 +4,11 @@ metadata:
   name: federatorai.v0.0.1
   namespace: placeholder
   annotations:
-    capabilities: Basic Install
-    categories: OpenShift Optional
+    capabilities: Seamless Upgrades
+    categories: "AI/Machine Learning, OpenShift Optional"
     certified: "false"
-    repository: https://github.com/containers-ai/federatorai-operator
-    containerImage: prophetstor/federatorai-operator:0.0.1
+    repository: https://quay.io/repository/prophetstor/federatorai-operator
+    containerImage: quay.io/prophetstor/federatorai-operator:v0.0.1
     createdAt: 2019-03-19T00:59:59Z
     description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
     support: ProphetStor Data Services, Inc.
@@ -92,7 +92,7 @@ spec:
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
-    supported: false
+    supported: true
   install:
     strategy: deployment
     spec:
@@ -112,6 +112,7 @@ spec:
           - alamedaservices
           verbs:
           - list
+          - update
           - watch
         - apiGroups:
           - rbac.authorization.k8s.io
@@ -138,12 +139,25 @@ spec:
           - list
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+        - apiGroups:
           - apps
           resources:
           - deployments
           verbs:
           - list
           - watch
+          - create
         - apiGroups:
           - apiextensions.k8s.io
           resources:
@@ -331,8 +345,6 @@ spec:
           - alamedarecommendations
           verbs:
           - get
-          - list
-          - watch
           - create
           - update
           - patch
@@ -355,8 +367,6 @@ spec:
           - customresourcedefinitions
           verbs:
           - get
-          - create
-          - update
         - apiGroups:
           - ''
           resources:
@@ -364,15 +374,6 @@ spec:
           verbs:
           - create
           - watch
-          - list
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - validatingwebhookconfigurations
-          verbs:
-          - watch
-          - create
-          - update
           - list
         - apiGroups:
           - ''
@@ -385,12 +386,6 @@ spec:
           - list
       - serviceAccountName: alameda-datahub
         rules:
-        - apiGroups:
-          - ''
-          resources:
-          - namespaces
-          verbs:
-          - get
         - apiGroups:
           - autoscaling.containers.ai
           resources:
@@ -471,7 +466,7 @@ spec:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
-                      fieldPath: metadata.namespace
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: POD_NAME
                   valueFrom:
                     fieldRef:

--- a/upstream-community-operators/federatorai/federatorai-AlamedaService.crd.yaml
+++ b/upstream-community-operators/federatorai/federatorai-AlamedaService.crd.yaml
@@ -11,3 +11,4 @@ spec:
     singular: alamedaservice
   scope: Namespaced
   version: v1alpha1
+

--- a/upstream-community-operators/federatorai/federatorai-AlamedaService.crd.yaml
+++ b/upstream-community-operators/federatorai/federatorai-AlamedaService.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: alamedaservices.federatorai.containers.ai
+spec:
+  group: federatorai.containers.ai
+  names:
+    kind: AlamedaService
+    listKind: AlamedaServiceList
+    plural: alamedaservices
+    singular: alamedaservice
+  scope: Namespaced
+  version: v1alpha1

--- a/upstream-community-operators/federatorai/federatorai.package.yaml
+++ b/upstream-community-operators/federatorai/federatorai.package.yaml
@@ -1,0 +1,4 @@
+packageName: federatorai
+channels:
+- name: alpha
+  currentCSV: federatorai.v0.0.1

--- a/upstream-community-operators/federatorai/federatorai.package.yaml
+++ b/upstream-community-operators/federatorai/federatorai.package.yaml
@@ -2,3 +2,4 @@ packageName: federatorai
 channels:
 - name: alpha
   currentCSV: federatorai.v0.0.1
+

--- a/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -1,0 +1,484 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: federatorai.v0.0.1
+  namespace: placeholder
+  annotations:
+    capabilities: Basic Install
+    categories: OpenShift Optional
+    certified: "false"
+    repository: https://github.com/containers-ai/federatorai-operator
+    containerImage: prophetstor/federatorai-operator:0.0.1
+    createdAt: 2019-03-19T00:59:59Z
+    description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
+    support: ProphetStor Data Services, Inc.
+    alm-examples: >-
+      [{"apiVersion":"federatorai.containers.ai/v1alpha1","kind":"AlamedaService","metadata":{"name":"my-alamedaservice"},"spec":{"enableexecution":true,"enablegui":true,"version":"v0.3.7","prometheusservice":"https://prometheus-k8s.openshift-monitoring:9091","persistentvolumeclaim":""}},{"apiVersion":"autoscaling.containers.ai/v1alpha1","kind":"AlamedaScaler","metadata":{"name":"alameda","namespace":"webapp"},"spec":{"policy":"stable","selector":{"matchLabels":{"app":"nginx"}}}}]
+spec: 
+  version: 0.0.1
+  maturity: alpha
+  displayName: FederatorAI
+  description: |
+    **FederatorAI** is the brain of resource orchestration for kubernetes. It foresees future resource usage of your Kubernetes cluster from the cloud layer down to the pod level. We use machine learning technology to provide intelligence that enables dynamic scaling and scheduling of your containers - effectively making us the “brain” of Kubernetes resource orchestration. By providing full foresight of resource availability, demand, health, impact and SLA, we enable cloud strategies that involve changing provisioned resources in real time. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+
+    **FederatorAI Operator** provides easy configuration and management of AI-based Kubernetes resource orchestrator. Once installed, the FederatoAI Operator provides the following features:
+    - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
+    - **Easy Configuration**: Easily config source of Prometheus and enable/disable addon components such as GUI, and execition.
+    - **Autoscaling Pod**: Use provided CRD to setup target pods for autoscaling.
+
+    ### Prerequisite
+    **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
+
+    ### Common Configurations
+        apiVersion: federatorai.containers.ai/v1alpha1
+        kind: Alamedaservice
+        metadata:
+          name: my-alamedaservice
+        spec:
+          enableexecution: true
+          enablegui: true
+          version: v0.3.7
+          prometheusservice: https://prometheus-k8s.openshift-monitoring:9091
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAACWCAMAAACsAjcrAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAC91BMVEUAAAD9/v3r78n09PTx8fHu7u719fX29vba2tpiZWLc3Nzf39/b4p/DxMPHx8fLy8zO13zExcTIyMjMzM3G0WjH0mrr78rIx8js8M3a29r19PXd3N329+X5+fn4+Pj6+/L5+vDs8M7s78v4+u3H0Wj///65x0T///25x0X+/f66x0b9/vy3xT7I0mvI0mrI02vU3Ir9/v3K1HHr78nCzlzM1nXM1nbX3pPL1XP09+L19fXz8/Px8fHx8fHx8fHx8fHv8O/t7e3s7Ozs7Ozy8vL9/f3+/v/r6+zm5ubm5ubm5ubw8PD+/v3f39/W1tbQ0NDf4N/x8fHKysrT09P9/f+8vL3MzM34+Pje5ajQ2YHE0GPF0GXF0GTd5KTMzcy9vr3b3Nv////x8fG5ubnu7+6UlJaurrD09PTS24i/y1S+v766urrv7++WlpiwsLH09PXL1XW1wzrM1ne2xT22xD3v8O+6ubqVlZevr7HL1XT19+TMzszc3Nzv7u/X35T19+Tg4ODW19bh4eHy8fLMzMzU09T19PW9vb7Ozs75+fj3+On19+T19+X29+X6+vr4+Pj29vb29vb29vb29vb29vb19fXz9PPz8/P09PT39/f8/Pz9/f3z8/Pw8PDw8PDw8PD29vb+/v76+/Hu8tPq7sXq7sbP2H62xD35+u/s8Mzm67zn673n7L7g5q61wzns8Mzq7sfr78n4+ezDzl22xDy3xD23xT+1wzeltg6mtxCmtxK0wzmltw+mtxGnuBOmuBOnuBXPz8/P0M++vr6/vr+/v7+qqqupqaqys7K1trWzs7OXlpeYl5iZmJl3d3l2dnivvyuwwC2wwCzR2oSztLO2t7a1tLWamZqbmpt5eXt4eHqktQultg2ktg3K1HHL1XO0wziltg+0tLS1wzjR2oPH0mnH0mrR0dHAv8DAwMCrq62rq6zBzVmtvSSuvieuviWouRa7yEi9yk+ouRepuhqpuhnN13jn7MDg5qvh5q3h5qzt8M////9HTZ/9AAAAs3RSTlMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7ArsCuwK7Av7r5+upAfIxCQsLCPEnBWZ9e3cWA2F9e2EDAVp+e31mBQvT/nxD6cgCu9MLFoaOjo6OC9O7AnXIBbvTCyfx08gFu9MLJ/En8fEFyLvT8ScLuwXDFgvThkvtyAW70wuOjpBBBnWPjogaA2+QjpBvAwFokI6PdQYCBQUFK/JY3tvb2+H9ZmZmZjqy/PcAAAABYktHRGGysEyGAAAACXBIWXMAAAGQAAABkABW8NvoAAACuklEQVR42u3cVVQUURzH8RUUA1tssVHADgxs7EbEVhQLC2ywu7s7UbC7WGRRUbAQOxCMtVuxxRefFnc8d/+Mc9T5z/H3fb73nv/nzOudqztw8JDSDhd10PHpSIheaaHFiqs9vVlHwwxKC3d0Unt6QAABBBBA1A4QQAABBBBAAAEEEEAA+Z8gx1hDQsNld9y5hNrTW4boS5YqLbcyZcupPT0BKV+hoovMKlVOofb0BKRKVSu1RwIEEFYBwi1AuAUItwDhFiDcAoRbgHCLgFi7Vqteg6hmrZSiE1PVruNWl8itXn0b0b4GDRs1JmrStFlqhZA0zVuciCBq6Z5WdKJ1K4+Tp4giW7umE+3zbBN1miiqbTtb09L07Tt07GRe5y4UJINX1zNUZ7t5CyHdz52PJrrQo2dGIaRXzEWimN4+mUxLM/fpe+myeVeuUpAsXv2uUV23BLkRfZPoVv8BWYUQ39jbRLF+A7OZltoNGhwXb96du9qEZB8yNEQytuGeViHDpBA9IIAAAggggAACCCCAAAIIIIAAAggggAACCCCAAAIIIIAAAggggAACCCCAaBsy/G9A7hslj38Z/wTkAQ3xt/BFAmjICBryUPriWdjIUTmSIKOTgYxR9kX8x+YU7XNIBuLnQ0IePX4iadz4XKbluSdMpK40RjydJJpHl2fylMhnRM+nTssrhEx/8ZJqxkxbCjJrtqQ5c/MlnWw/b/6ChUSLFguvfdosWbpsOdGKlavyi/atXrN2HdH6DRvtKYgmA4RbgHALEG4Bwi1AuAUItwDhFiDcAuRfVCBw0+YgmXkHb+ELKbh12/YdMtu5a7eRLaTQnlev38jt7TsDW4jV3oRf/i38jQABBBBAAAEEEEAAAQQQQAABBBBAAAFEixADI0jhfe8/fFTap89qj/+zIvu/fP2msMTE7z8AofGIUB1IPooAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDMtMTRUMTc6MDA6NTIrMDE6MDCjbINkAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAzLTE0VDE3OjAwOjUyKzAxOjAw0jE72AAAACB0RVh0cGRmOkhpUmVzQm91bmRpbmdCb3gANDA4eDI2NiswKzDr8x6EAAAAHXRFWHRwZGY6U3BvdENvbG9yLTAAUEFOVE9ORSA0MjEgQx6zNCoAAAAldEVYdHBkZjpTcG90Q29sb3ItMQBQQU5UT05FIENvb2wgR3JheSA3IEOzNDMdAAAAJXRFWHRwZGY6U3BvdENvbG9yLTIAUEFOVE9ORSBDb29sIEdyYXkgOSBDz08nKgAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNQ1Ag1dMAAAAAElFTkSuQmCC
+    mediatype: image/png
+  keywords: ['AI', 'Resource Orchestration', 'NoOps']
+  maintainers:
+  - email: info@prophetstor.com
+    name: ProphetStor Data Services, Inc.
+  provider:
+    name: ProphetStor Data Services, Inc.
+  links:
+  - name: FederatorAI
+    url: https://github.com/containers-ai/alameda
+  - name: FederatorAI Operator
+    url: https://github.com/containers-ai/federatorai-operator
+  labels:
+    alm-owner-federatorai: federatorai-operator
+    alm-status-descriptors: federatorai-operator.v0.0.1
+  selector:
+    matchLabels:
+      alm-owner-federatorai: federatorai-operator
+  customresourcedefinitions:
+    owned:
+    - name: alamedaservices.federatorai.containers.ai
+      version: v1alpha1
+      kind: AlamedaService
+      displayName: AlamedaService
+      description: An instance of Alameda.
+      resources:
+      - kind: Deployment
+        version: v1
+      - kind: ReplicaSet
+        version: v1
+      - kind: Pod
+        version: v1
+      specDescriptors:
+      - description: Enable Execution
+        displayName: Enable Execution
+        path: enableexecution
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Enable dashboard
+        displayName: Enable GUI
+        path: enablegui
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - "*"
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - federatorai.containers.ai
+          resources:
+          - alamedaservices
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - list
+          - watch
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - services
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - federatorai.containers.ai
+          resources:
+          - alamedaservices/finalizers
+          verbs:
+          - '*'
+      - serviceAccountName: alameda-operator
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - nodes
+          - replicationcontrollers
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - alamedascalers
+          - alamedarecommendations
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - update
+      - serviceAccountName: admission-controller
+        rules:
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - create
+          - update
+      - serviceAccountName: alameda-datahub
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+      permissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - federatorai.containers.ai
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - federatorai-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+      - serviceAccountName: alameda-operator
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - nodes
+          - pods
+          - replicationcontrollers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - alamedascalers
+          - alamedarecommendations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - alamedascalers/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - secrets
+          verbs:
+          - create
+          - watch
+          - list
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - watch
+          - create
+          - update
+          - list
+        - apiGroups:
+          - ''
+          resources:
+          - services
+          verbs:
+          - watch
+          - create
+          - update
+          - list
+      - serviceAccountName: alameda-datahub
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - alamedarecommendations
+          verbs:
+          - get
+          - update
+      - serviceAccountName: alameda-evictioner
+        rules:
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          verbs:
+          - get
+          - delete
+      - serviceAccountName: admission-controller
+        rules:
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ''
+          resources:
+          - replicationcontrollers
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+      - serviceAccountName: alameda-ai
+        rules: []
+      deployments:
+      - name: federatorai-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: federatorai-operator
+            strategy:
+              type: Recreate
+          template:
+            metadata:
+              labels:
+                name: federatorai-operator
+            spec:
+              serviceAccountName: federatorai-operator
+              containers:
+              - command:
+                - federatorai-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: federatorai-operator
+                image: quay.io/prophetstor/federatorai-operator:v0.0.1
+                imagePullPolicy: IfNotPresent
+                name: federatorai-operator
+                resources: {}

--- a/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -100,181 +100,117 @@ spec:
       - serviceAccountName: federatorai-operator
         rules:
         - apiGroups:
+          - federatorai.containers.ai
+          resources:
           - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
           resources:
           - nodes
+          - replicationcontrollers
+          - pods
+          - persistentvolumeclaims
+          - serviceaccounts
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
-          - federatorai.containers.ai
+          - ""
           resources:
-          - alamedaservices
+          - serviceaccounts
           verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - services
+          verbs:
+          - create
           - list
-          - update
           - watch
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterroles
-          verbs:
-          - create
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
           - clusterrolebindings
           verbs:
+          - create
           - list
           - watch
-          - create
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumeclaims
-          - services
-          - configmaps
-          - serviceaccounts
-          verbs:
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          verbs:
-          - create
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - create
         - apiGroups:
           - apps
           resources:
           - deployments
           verbs:
+          - create
           - list
           - watch
-          - create
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - list
+          - watch
         - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
           verbs:
-          - get
           - create
-          - update
           - delete
+          - get
+          - update
         - apiGroups:
-          - federatorai.containers.ai
+          - admissionregistration.k8s.io
           resources:
-          - alamedaservices/finalizers
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
           verbs:
-          - '*'
-      - serviceAccountName: alameda-operator
-        rules:
-        - apiGroups:
-          - ''
-          resources:
-          - nodes
-          - replicationcontrollers
-          verbs:
+          - create
+          - get
           - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - services
-          verbs:
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - replicasets
-          verbs:
-          - list
+          - update
           - watch
         - apiGroups:
           - apps.openshift.io
           resources:
           - deploymentconfigs
           verbs:
-          - list
-          - watch
-        - apiGroups:
-          - autoscaling.containers.ai
-          resources:
-          - alamedascalers
-          - alamedarecommendations
-          verbs:
-          - list
-          - watch
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - validatingwebhookconfigurations
-          verbs:
-          - create
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - create
-          - update
-      - serviceAccountName: admission-controller
-        rules:
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - mutatingwebhookconfigurations
-          verbs:
           - get
-          - create
-          - update
-      - serviceAccountName: alameda-datahub
-        rules:
-        - apiGroups:
-          - ''
-          resources:
-          - namespaces
-          verbs:
-          - get
+          - list
+          - watch
       permissions:
       - serviceAccountName: federatorai-operator
         rules:
         - apiGroups:
-          - federatorai.containers.ai
-          resources:
-          - '*'
-          verbs:
-          - '*'
-        - apiGroups:
           - ""
           resources:
-          - pods
-          - services
+          - configmaps
+          - events
           - endpoints
           - persistentvolumeclaims
-          - events
-          - configmaps
+          - pods
           - secrets
+          - services
           verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - get
+          - "*"
         - apiGroups:
           - apps
           resources:
@@ -283,167 +219,20 @@ spec:
           - replicasets
           - statefulsets
           verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
-          - create
+          - "*"
         - apiGroups:
           - apps
-          resourceNames:
-          - federatorai-operator
           resources:
           - deployments/finalizers
           verbs:
           - update
         - apiGroups:
-          - ""
+          - monitoring.coreos.com
           resources:
-          - serviceaccounts
+          - servicemonitors
           verbs:
           - create
-      - serviceAccountName: alameda-operator
-        rules:
-        - apiGroups:
-          - ''
-          resources:
-          - nodes
-          - pods
-          - replicationcontrollers
-          verbs:
           - get
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          - deployments
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - autoscaling.containers.ai
-          resources:
-          - alamedascalers
-          - alamedarecommendations
-          verbs:
-          - get
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - autoscaling.containers.ai
-          resources:
-          - alamedascalers/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - ''
-          resources:
-          - namespaces
-          verbs:
-          - get
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - get
-        - apiGroups:
-          - ''
-          resources:
-          - secrets
-          verbs:
-          - create
-          - watch
-          - list
-        - apiGroups:
-          - ''
-          resources:
-          - services
-          verbs:
-          - watch
-          - create
-          - update
-          - list
-      - serviceAccountName: alameda-datahub
-        rules:
-        - apiGroups:
-          - autoscaling.containers.ai
-          resources:
-          - alamedarecommendations
-          verbs:
-          - get
-          - update
-      - serviceAccountName: alameda-evictioner
-        rules:
-        - apiGroups:
-          - ''
-          resources:
-          - pods
-          verbs:
-          - get
-          - delete
-      - serviceAccountName: admission-controller
-        rules:
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - mutatingwebhookconfigurations
-          verbs:
-          - get
-          - create
-          - update
-        - apiGroups:
-          - ''
-          resources:
-          - pods
-          verbs:
-          - get
-          - list
-          - patch
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          - deployments
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - ''
-          resources:
-          - replicationcontrollers
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - get
-          - list
-      - serviceAccountName: alameda-ai
-        rules: []
       deployments:
       - name: federatorai-operator
         spec:
@@ -477,3 +266,4 @@ spec:
                 imagePullPolicy: IfNotPresent
                 name: federatorai-operator
                 resources: {}
+

--- a/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -4,11 +4,11 @@ metadata:
   name: federatorai.v0.0.1
   namespace: placeholder
   annotations:
-    capabilities: Basic Install
-    categories: OpenShift Optional
+    capabilities: Seamless Upgrades
+    categories: "AI/Machine Learning, OpenShift Optional"
     certified: "false"
-    repository: https://github.com/containers-ai/federatorai-operator
-    containerImage: prophetstor/federatorai-operator:0.0.1
+    repository: https://quay.io/repository/prophetstor/federatorai-operator
+    containerImage: quay.io/prophetstor/federatorai-operator:v0.0.1
     createdAt: 2019-03-19T00:59:59Z
     description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
     support: ProphetStor Data Services, Inc.
@@ -92,7 +92,7 @@ spec:
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
-    supported: false
+    supported: true
   install:
     strategy: deployment
     spec:
@@ -112,6 +112,7 @@ spec:
           - alamedaservices
           verbs:
           - list
+          - update
           - watch
         - apiGroups:
           - rbac.authorization.k8s.io
@@ -138,12 +139,25 @@ spec:
           - list
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+        - apiGroups:
           - apps
           resources:
           - deployments
           verbs:
           - list
           - watch
+          - create
         - apiGroups:
           - apiextensions.k8s.io
           resources:
@@ -331,8 +345,6 @@ spec:
           - alamedarecommendations
           verbs:
           - get
-          - list
-          - watch
           - create
           - update
           - patch
@@ -355,8 +367,6 @@ spec:
           - customresourcedefinitions
           verbs:
           - get
-          - create
-          - update
         - apiGroups:
           - ''
           resources:
@@ -364,15 +374,6 @@ spec:
           verbs:
           - create
           - watch
-          - list
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - validatingwebhookconfigurations
-          verbs:
-          - watch
-          - create
-          - update
           - list
         - apiGroups:
           - ''
@@ -385,12 +386,6 @@ spec:
           - list
       - serviceAccountName: alameda-datahub
         rules:
-        - apiGroups:
-          - ''
-          resources:
-          - namespaces
-          verbs:
-          - get
         - apiGroups:
           - autoscaling.containers.ai
           resources:
@@ -471,7 +466,7 @@ spec:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
-                      fieldPath: metadata.namespace
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: POD_NAME
                   valueFrom:
                     fieldRef:


### PR DESCRIPTION
This adds a bundle for **FederatorAI Operator**. FederatorAI is the brain of resource orchestration for kubernetes. It foresees future resource usage of your Kubernetes cluster from the cloud layer down to the pod level. We use machine learning technology to provide intelligence that enables dynamic scaling and scheduling of your containers - effectively making us the “brain” of Kubernetes resource orchestration. By providing full foresight of resource availability, demand, health, impact and SLA, we enable cloud strategies that involve changing provisioned resources in real time.

For more information, please visit https://github.com/containers-ai/federatorai-operator