### PR TITLE
Revert "[community] Fix descheduler to work with AllNamespaces"

### DIFF
--- a/community-operators/descheduler/descheduler.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/descheduler/descheduler.v0.0.1.clusterserviceversion.yaml
@@ -4,38 +4,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: |-
-      [
-        {
-          "apiVersion": "descheduler.io/v1alpha1",
-          "kind": "Descheduler",
-          "metadata": {
-            "name": "example-descheduler-1"
-          },
-          "spec": {
-            "schedule": "*/1 * * * ?",
-            "strategies": [
-              {
-                "name": "lownodeutilization",
-                "params": [
-                  {
-                    "name": "cputhreshold",
-                    "value": "10"
-                  },
-                  {
-                    "name": "memorythreshold",
-                    "value": "20"
-                  },
-                  {
-                    "name": "memorytargetthreshold",
-                    "value": "30"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      ]
     capabilities: Seamless Upgrades
     categories: "OpenShift Optional"
     certifiedLevel: Primed
@@ -159,7 +127,7 @@ spec:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                      fieldPath: metadata.namespace
                 - name: OPERATOR_NAME
                   value: descheduler-operator
                 image: registry.svc.ci.openshift.org/openshift/origin-v4.0:descheduler-operator


### PR DESCRIPTION
Reverts operator-framework/community-operators#127

I am reverting this change as descheduler is not capable of watching all namespaces.

