### PR TITLE
Let descheduler run in a single namespace

### DIFF
--- a/community-operators/descheduler/descheduler.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/descheduler/descheduler.v0.0.1.clusterserviceversion.yaml
@@ -94,7 +94,7 @@ spec:
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
-    supported: true
+    supported: false
   install:
     spec:
       clusterPermissions:


### PR DESCRIPTION
EDIT: I have a single commit in this PR instead of 2(after the discussions here https://github.com/operator-framework/community-operators/pull/248#discussion_r271419699)

- ~~First commit which reverts watching multiple namespaces~~
- Second commit which removes support for installing in multiple namespaces

/cc @SamiSousa @aravindhp @tkashem @kevinrizza 