### PR TITLE
[scripts] Move ci test conditional to test-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,6 @@ jobs:
   include:
   - name: Scorecard on minikube
     script:
-    # Since travis conditionals can't operate on bash scripts, the first script
-    # line will check whether only scripts have been updated, and if so use
-    # the jaeger operator as an operator to test script correctness.
-    - |-
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -q '\.yaml'; then \
-        OPERATORS_UPSTREAM="upstream-community-operators/jaeger:$(yq r --tojson upstream-community-operators/jaeger/jaeger.package.yaml "channels" \
-        | jq ".[] | .currentCSV" | sort -V | tail -1 | sed -E 's/"[a-zA-Z\-]+\.?v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?)"/\1/')" \
-        scripts/ci/test-pr $DISTRO_TYPE && exit 0
-      fi
+    - scripts/ci/test-ci $DISTRO_TYPE
     # operators-env exports variables containing all operators to be tested.
     - eval $(scripts/ci/operators-env) && scripts/ci/test-pr $DISTRO_TYPE

--- a/scripts/ci/test-ci
+++ b/scripts/ci/test-ci
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Check whether only scripts have been updated, and if so use
+# the jaeger operator as an operator to test script correctness.
+
+DISTRO_TYPE_UPSTREAM="upstream"
+DISTRO_TYPE_OPENSHIFT="openshift"
+DISTRO_TYPE="${1:-$DISTRO_TYPE_UPSTREAM}"
+if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -q '\.yaml'; then
+  echo "No operator manifest changes detected, assuming script updates."
+  echo "Running CI with jaeger operator to test scripts"
+  OPERATORS_UPSTREAM="upstream-community-operators/jaeger:$(yq r --tojson upstream-community-operators/jaeger/jaeger.package.yaml "channels" \
+  | jq ".[] | .currentCSV" | sort -V | tail -1 | sed -E 's/"[a-zA-Z\-]+\.?v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?)"/\1/')" \
+  scripts/ci/test-pr $DISTRO_TYPE && exit 0
+fi


### PR DESCRIPTION
- Moved travis conditional from travis.yml to script/ci/test-ci
- Added logs to indicate that test-ci is being run

This is mainly to clean up CI output logs.
/cc @estroz @dmesser 