### PR TITLE
[scripts] Clean up CI logs

### DIFF
--- a/scripts/ci/install-deps
+++ b/scripts/ci/install-deps
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 # Don't use sudo when running in a container.
 SUDO=sudo
@@ -18,6 +18,7 @@ if [[ "$DISTRO_TYPE" != "$DISTRO_TYPE_UPSTREAM" && "$DISTRO_TYPE" != "$DISTRO_TY
 fi
 
 # jq, yq
+echo "Installing jq and yq"
 curl -Lo jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
 chmod +x jq
 $SUDO mv jq /usr/local/bin/
@@ -25,16 +26,19 @@ curl -Lo yq https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd
 chmod +x yq
 $SUDO mv yq /usr/local/bin/
 # operator-courier
-# export PATH="${HOME}/.local/bin:${PATH}"
+echo "Installing operator-courier"
 python3 -m pip install operator-courier
 # SDK
+echo "Installing operator-sdk"
 SDK_VER="v0.6.0"
 curl -Lo operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VER}/operator-sdk-${SDK_VER}-x86_64-linux-gnu"
 chmod +x operator-sdk
 $SUDO mv operator-sdk /usr/local/bin/
 # helm
+echo "Installing helm"
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
 # kubectl
+echo "Installing kubectl"
 KUBE_VER="v1.13.0"
 curl -Lo kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBE_VER}/bin/linux/amd64/kubectl"
 chmod +x kubectl
@@ -42,6 +46,7 @@ $SUDO mv kubectl /usr/local/bin/
 
 if [[ "$DISTRO_TYPE" == "$DISTRO_TYPE_UPSTREAM" ]]; then
   # minikube and crictl dependency
+  echo "Installing minikube and crictl"
   curl -Lo crictl.tar.gz "https://github.com/kubernetes-sigs/cri-tools/releases/download/${KUBE_VER}/crictl-${KUBE_VER}-linux-amd64.tar.gz"
   tar -zxvf crictl.tar.gz
   chmod +x crictl

--- a/scripts/ci/test-operator
+++ b/scripts/ci/test-operator
@@ -6,7 +6,7 @@
 # into a CSV, creates CR's from CSV metadata, deploys the operator with the
 # OLM in a local cluster, and runs the SDK scorecard against the operator.
 
-set -ex
+set -e
 
 for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
   . "$f"
@@ -86,7 +86,7 @@ insert_kubeconfig_secret_mount "$CSV_FILE"
 insert_proxy_container "$CSV_FILE" "$SC_PROXY_IMAGE"
 
 # Build a registry container containing operator manifests.
-docker build -t "$OP_REGISTRY_IMAGE" .
+docker build -t "$OP_REGISTRY_IMAGE" . > /dev/null
 
 # Define names for resource types.
 DEP_NAME="$(yq r "$CSV_FILE" "spec.install.spec.deployments[0].name")"
@@ -111,9 +111,12 @@ apply_objects_incluster "$DEPLOY_DIR"
 trap_add_exit "delete_objects_incluster $DEPLOY_DIR $NAMESPACE"
 trap_add_exit "delete_objects_incluster $ABS_BUNDLE_PATH $NAMESPACE"
 
-# Create logs for operator debugging.
-LOG_FILE="${TMP}/info.log"
-trap_add_exit "log_operator_state $LOG_FILE OBJECTS $NAMESPACE; cat $LOG_FILE"
+# Check that subscription is picked up
+check_subscription_passes "${PKG_NAME}-sub" "$NAMESPACE"
+
+# Wait for csv, then check that clusterserviceversion has Succeeded
+sleep 6
+check_csv_passes "$CSV_NAME" "$NAMESPACE"
 
 # Wait for the deployment specified in the CSV to rollout successfully.
 wait_on_deployment "$DEP_NAME" "$NAMESPACE"
@@ -122,6 +125,7 @@ wait_on_deployment "$DEP_NAME" "$NAMESPACE"
 # TODO: run against multiple CR's. Right now the scorecard only works with one
 # CR.
 for cr_file in $(find "$CR_DIR" -name "*.cr.yaml" -print -quit); do
+  echo "\n\nRunning operator-sdk scorecard against "$CSV_FILE" with "$cr_file""
   operator-sdk scorecard \
     --cr-manifest "$cr_file" \
     --crds-dir "$ABS_BUNDLE_PATH" \
@@ -132,4 +136,14 @@ for cr_file in $(find "$CR_DIR" -name "*.cr.yaml" -print -quit); do
     --proxy-image "$SC_PROXY_IMAGE" \
     --kubeconfig "$KUBECONFIG" \
     --verbose
+
+  # If scorecard errors out, print out operator logs
+  if [[ $? != 0 ]]; then
+    echo "\nFAIL: Scorecard test errored out. Printing operator state:"
+    LOG_FILE="${TMP}/info.log"
+    log_operator_state $LOG_FILE OBJECTS $NAMESPACE
+    cat $LOG_FILE
+  else
+    echo "\nPASS: Scorecard test passed"
+  fi
 done

--- a/scripts/ci/verify-operator
+++ b/scripts/ci/verify-operator
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 # Verifies each operator with changes in a PR with operator-courier.
 if [[ -n $OPERATORS_OPENSHIFT ]]; then

--- a/scripts/lib/cluster
+++ b/scripts/lib/cluster
@@ -9,11 +9,69 @@ function wait_on_deployment() {
       sleep 6
       retries=$((retries - 1))
       if [[ $retries == 0 ]]; then
-        echo "failed to rollout deployloyment \"$dep\""
+        echo "FAIL: Failed to rollout deployloyment \"$dep\""
         exit 1
       fi
       echo "retrying check rollout status for deployment \"$dep\"..."
   done
+
+  echo "Successfully rolled out deployment \"$dep\" in namespace \"$namespace\""
+}
+
+function check_subscription_passes() {
+  local sub="$1"
+  local namespace="$2"
+  local retries=10 # 1 minute timeout
+
+  echo "Checking subscription \"$sub\" reaches \"AtLatestKnown\" state"
+  while ! kubectl get "subscription/${sub}" --namespace=${namespace} -o json | jq .status -e &> /dev/null; do
+      sleep 6
+      retries=$((retries - 1))
+      if [[ $retries == 0 ]]; then
+        echo "FAIL: Failed to pick up subscription \"$sub\""
+        kubectl get "subscription/${sub}" --namespace=${namespace} -o yaml
+        exit 1
+      fi
+      echo "retrying check of subscription status for \"$sub\"..."
+  done
+
+  # Check that subscription status is set to "AtLatestKnown"
+  while ! [[ `kubectl get "subscription/${sub}" --namespace=${namespace} -o json | jq .status.state` == \"AtLatestKnown\" ]]; do
+      sleep 6
+      retries=$((retries - 1))
+      if [[ $retries == 0 ]]; then
+        echo "FAIL: Failed to reach "AtLatestKnown" subscription status for \"$sub\""
+        kubectl get "subscription/${sub}" --namespace=${namespace} -o yaml
+        installplan="`kubectl get subscription/packageserver -n olm -o json | jq .status.installplan.name`"
+        echo "  installplan status for \"$installplan\":"
+        kubectl get "installplan/${installplan}" --namespace=${installplan} -o yaml
+        exit 1
+      fi
+      echo "subscription status for \"$sub\": `kubectl get "subscription/${sub}" --namespace=${namespace} -o json | jq .status.state`"
+  done
+
+  echo "Successfully installed subscription \"$sub\" in namespace \"$namespace\""
+}
+
+function check_csv_passes() {
+  local csv="$1"
+  local namespace="$2"
+  local retries=10 # 1 minute timeout
+
+  echo "Check that clusterserviceversion \"$csv\" status is set to \"Succeeded\""
+  while ! [[ `kubectl get "clusterserviceversion/${csv}" --namespace=${namespace} -o json | jq .status.phase` == \"Succeeded\" ]]; do
+      sleep 6
+      retries=$((retries - 1))
+      if [[ $retries == 0 ]]; then
+        echo "failed to reach "Succeeded" clusterserviceversion status for \"$csv\""
+        # Print out CSV on error
+        kubectl get "clusterserviceversion/${csv}" --namespace=${namespace} -o yaml
+        exit 1
+      fi
+      echo "clusterserviceversion phase for \"$csv\": `kubectl get "clusterserviceversion/${csv}" --namespace=${namespace} -o json | jq .status.phase`"
+  done
+
+  echo "Successfully installed clusterserviceversion \"$csv\" in namespace \"$namespace\""
 }
 
 function check_cluster_available() {


### PR DESCRIPTION
- Check for subscription object to reach "AtLatestKnown" state
- Check for csv to reach "Succeeded" phase
- Print operator state logs on scorecard failure
- Remove 'set -x' from CI scripts, add descriptions for CI steps

This adds intermediate installation checks that more closely
follows a manual debug.