### PR TITLE
Spark: remove title in description markdown

### DIFF
--- a/upstream-community-operators/spark-gcp/sparkoperator.2.4.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/spark-gcp/sparkoperator.2.4.0.clusterserviceversion.yaml
@@ -95,7 +95,6 @@ metadata:
 spec:
   displayName: Spark Operator
   description: |-
-    # Spark Operator
     Apache Spark is a fast and general-purpose cluster computing system.
     It provides high-level APIs in Java, Scala, Python and R, and an optimized engine that supports general execution graphs. 
     It also supports a rich set of higher-level tools including Spark SQL for SQL and structured data processing, MLlib for 


### PR DESCRIPTION
I removed the title in the description since we already give a title in the UI.

See https://operatorhub.io/operator/alpha/sparkoperator.v2.4.0 for reference.

/cc  @hasbro17 @dmesser @SamiSousa