### PR TITLE
modify federatorai-operator description and fix rbac

### DIFF
--- a/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -19,12 +19,12 @@ spec:
   maturity: alpha
   displayName: FederatorAI
   description: |
-    **FederatorAI** is the brain of resource orchestration for kubernetes. It foresees future resource usage of your Kubernetes cluster from the cloud layer down to the pod level. We use machine learning technology to provide intelligence that enables dynamic scaling and scheduling of your containers - effectively making us the “brain” of Kubernetes resource orchestration. By providing full foresight of resource availability, demand, health, impact and SLA, we enable cloud strategies that involve changing provisioned resources in real time. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+    **FederatorAI** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **FederatorAI** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
 
-    **FederatorAI Operator** provides easy configuration and management of AI-based Kubernetes resource orchestrator. Once installed, the FederatoAI Operator provides the following features:
+    **FederatorAI Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
     - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
-    - **Easy Configuration**: Easily config source of Prometheus and enable/disable addon components such as GUI, and execition.
-    - **Autoscaling Pod**: Use provided CRD to setup target pods for autoscaling.
+    - **Easy Configuration**: Easily configure data source of Prometheus and enable/disable add-on components, such as GUI, and predictive autoscaling.
+    - **Pod Scaling Recommendation/Autoscaling**: Use provided CRD to setup target pods and desired policies for scaling recommendation and autoscaling.
 
     ### Prerequisite
     **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
@@ -143,13 +143,22 @@ spec:
           - ""
           resources:
           - nodes
-          - pods
           - persistentvolumeclaims
           - serviceaccounts
           verbs:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - patch
         - apiGroups:
           - ""
           resources:

--- a/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -19,12 +19,12 @@ spec:
   maturity: alpha
   displayName: FederatorAI
   description: |
-    **FederatorAI** is the brain of resource orchestration for kubernetes. It foresees future resource usage of your Kubernetes cluster from the cloud layer down to the pod level. We use machine learning technology to provide intelligence that enables dynamic scaling and scheduling of your containers - effectively making us the “brain” of Kubernetes resource orchestration. By providing full foresight of resource availability, demand, health, impact and SLA, we enable cloud strategies that involve changing provisioned resources in real time. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+    **FederatorAI** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **FederatorAI** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
 
-    **FederatorAI Operator** provides easy configuration and management of AI-based Kubernetes resource orchestrator. Once installed, the FederatoAI Operator provides the following features:
+    **FederatorAI Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
     - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
-    - **Easy Configuration**: Easily config source of Prometheus and enable/disable addon components such as GUI, and execition.
-    - **Autoscaling Pod**: Use provided CRD to setup target pods for autoscaling.
+    - **Easy Configuration**: Easily configure data source of Prometheus and enable/disable add-on components, such as GUI, and predictive autoscaling.
+    - **Pod Scaling Recommendation/Autoscaling**: Use provided CRD to setup target pods and desired policies for scaling recommendation and autoscaling.
 
     ### Prerequisite
     **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
@@ -143,13 +143,22 @@ spec:
           - ""
           resources:
           - nodes
-          - pods
           - persistentvolumeclaims
           - serviceaccounts
           verbs:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - patch
         - apiGroups:
           - ""
           resources:


### PR DESCRIPTION
@SamiSousa 
Sorry to send an PR again to patch FederatorAI-operator 0.01.
This PR mainly patches the description in this CSV and also one rbac fix.

The e2e test procedure in our internal process is as follows and passed. 
---
1. prepare an OKD 3.11/K8s 1.13 environment
2. deploy resource operatorsource, catalogconfig, operatorgroup and subscription to bring up FederatorAI operator
3. deploy our defined alamedaservice CR to spawn operands
---

Signed-off-by: matt.wu <matt.wu@prophetstor.com>