### PR TITLE
Bug fix for federation v2 controller manager can not start.

### DIFF
--- a/community-operators/federation/federation.v0.0.8.clusterserviceversion.yaml
+++ b/community-operators/federation/federation.v0.0.8.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ spec:
     Before you use federation, you should ensure that you're using the binary
     for this version. You can get it from the releases on GitHub.
 
-        curl -Ls https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.8/kubefed2.tar.gz | tar xz
+        curl -Ls https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.8/kubefed2.tgz | tar xz
 
     ### Joining Clusters
 

--- a/community-operators/federation/federation.v0.0.8.clusterserviceversion.yaml
+++ b/community-operators/federation/federation.v0.0.8.clusterserviceversion.yaml
@@ -361,7 +361,6 @@ spec:
                     - /root/controller-manager
                   args:
                     - --federation-namespace=$(FEDERATION_NAMESPACE)
-                    - --install-crds=false
                     - --limited-scope=true
                     - --registry-namespace=$(CLUSTER_REGISTRY_NAMESPACE)
                     - -v=5

--- a/upstream-community-operators/federation/federation.v0.0.8.clusterserviceversion.yaml
+++ b/upstream-community-operators/federation/federation.v0.0.8.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ spec:
     Before you use federation, you should ensure that you're using the binary
     for this version. You can get it from the releases on GitHub.
 
-        curl -Ls https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.8/kubefed2.tar.gz | tar xz
+        curl -Ls https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.8/kubefed2.tgz | tar xz
 
     ### Joining Clusters
 

--- a/upstream-community-operators/federation/federation.v0.0.8.clusterserviceversion.yaml
+++ b/upstream-community-operators/federation/federation.v0.0.8.clusterserviceversion.yaml
@@ -361,7 +361,6 @@ spec:
                     - /root/controller-manager
                   args:
                     - --federation-namespace=$(FEDERATION_NAMESPACE)
-                    - --install-crds=false
                     - --limited-scope=true
                     - --registry-namespace=$(CLUSTER_REGISTRY_NAMESPACE)
                     - -v=5


### PR DESCRIPTION
From v0.0.8 controller-manager does not support --install-crds=false parameter.
With this cmd args, we will get the following errors:
Error: unknown flag: --install-crds