### PR TITLE
Add Developer Tools category

### DIFF
--- a/docs/required-fields.md
+++ b/docs/required-fields.md
@@ -54,6 +54,7 @@ For the best user experience, choose from the following categories:
 | Integration & Delivery |
 | Database |
 | Cloud Provider |
+| Developer Tools |
 | Logging & Tracing |
 | Streaming & Messaging |
 | Monitoring |


### PR DESCRIPTION
This PR adds **Developer Tools** category for marketplace. This category is required for CRW https://github.com/operator-framework/community-operators/pull/193 and Eclipse Che https://github.com/operator-framework/community-operators/pull/280  operators. Also new operators that bring k8s developer tooling can use this category.