### PR TITLE
Update metering-operator image tag to 4.1

### DIFF
--- a/community-operators/metering/meteringoperator.v4.1.0.clusterserviceversion.yaml
+++ b/community-operators/metering/meteringoperator.v4.1.0.clusterserviceversion.yaml
@@ -445,7 +445,7 @@ spec:
                     value: "30"
                   - name: RELEASE_HISTORY_LIMIT
                     value: "3"
-                  image: quay.io/openshift/origin-metering-helm-operator:v4.0
+                  image: quay.io/openshift/origin-metering-helm-operator:4.1
                   imagePullPolicy: Always
                   name: metering-operator
                   resources:
@@ -464,7 +464,7 @@ spec:
                         fieldPath: metadata.namespace
                   - name: TILLER_HISTORY_MAX
                     value: "3"
-                  image: quay.io/openshift/origin-metering-helm-operator:v4.0
+                  image: quay.io/openshift/origin-metering-helm-operator:4.1
                   imagePullPolicy: Always
                   livenessProbe:
                     failureThreshold: 3


### PR DESCRIPTION
OCP branching has switched to 4.1 so use 4.1 for images.