### PR TITLE
WIP: updating to cockroachdb chart 2.1.1

### DIFF
--- a/upstream-community-operators/cockroachdb/cockroachdb.package.yaml
+++ b/upstream-community-operators/cockroachdb/cockroachdb.package.yaml
@@ -1,4 +1,4 @@
 packageName: cockroachdb
 channels:
 - name: stable
-  currentCSV: cockroachdb.v2.0.9
+  currentCSV: cockroachdb.v2.1.1

--- a/upstream-community-operators/cockroachdb/cockroachdb.v2.1.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/cockroachdb/cockroachdb.v2.1.1.clusterserviceversion.yaml
@@ -1,0 +1,176 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Cockroachdb","metadata":{"name":"example-cockroachdb"},"spec":{"CacheSize":"25%","ClusterDomain":"cluster.local","Component":"cockroachdb","ExternalGrpcName":"grpc","ExternalGrpcPort":26257,"ExternalHttpPort":8080,"HttpName":"http","Image":"cockroachdb/cockroach","ImagePullPolicy":"Always","ImageTag":"v2.1.5","InternalGrpcName":"grpc","InternalGrpcPort":26257,"InternalHttpPort":8080,"JoinExisting":[],"Locality":"","MaxSQLMemory":"25%","MaxUnavailable":1,"Name":"cockroachdb","NetworkPolicy":{"AllowExternal":true,"Enabled":false},"NodeSelector":{},"PodManagementPolicy":"Parallel","Replicas":3,"Resources":{},"Secure":{"Enabled":false,"RequestCertsImage":"cockroachdb/cockroach-k8s-request-cert","RequestCertsImageTag":"0.4","ServiceAccount":{"Create":true,"Name":null}},"Service":{"annotations":{},"type":"ClusterIP"},"Storage":"100Gi","StorageClass":null,"Tolerations":{},"UpdateStrategy":{"type":"RollingUpdate"}}}]'
+    capabilities: Basic Install
+    categories: Database
+    containerImage: quay.io/helmoperators/cockroachdb:2.1.1
+    createdAt: 2019-01-24T15-33-43Z
+    description: CockroachDB Operator based on the CockroachDB helm chart
+    repository: https://github.com/cockroachdb/cockroach
+    support: a-robinson
+  name: cockroachdb.v2.1.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: CockroachDB
+      displayName: cockroachdb
+      kind: Cockroachdb
+      name: cockroachdbs.charts.helm.k8s.io
+      version: v1alpha1
+  description: |
+    CockroachDB is a scalable, survivable, strongly-consistent SQL database.
+
+    ## Core capabilities
+    * **StatefulSet** - Sets up a dynamically scalable CockroachDB cluster using a Kubernetes StatefulSet
+    * **Expand Replicas** - Supports expanding the set of replicas by simply editing your object
+    * **Dashboard** - Installs the CockroachDB user interface to administer your cluster. Easily expose it via an Ingress rule.
+
+    Review all of the [confiuguration options](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to best run your database instance.
+
+    ## Before you start
+
+    This Operator requires a cluster with PV support in order to run correctly.
+
+    ## About this Operator
+
+    This Operator is based on a Helm chart for CockroachDB. It supports reconfiguration for some parameters, but notably does not handle scale down of the replica count in a seamless manner. Scale up works great.
+  displayName: CockroachDB
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMS44MiAzMiIgd2lkdGg9IjI0ODYiIGhlaWdodD0iMjUwMCI+PHRpdGxlPkNMPC90aXRsZT48cGF0aCBkPSJNMTkuNDIgOS4xN2ExNS4zOSAxNS4zOSAwIDAgMS0zLjUxLjQgMTUuNDYgMTUuNDYgMCAwIDEtMy41MS0uNCAxNS42MyAxNS42MyAwIDAgMSAzLjUxLTMuOTEgMTUuNzEgMTUuNzEgMCAwIDEgMy41MSAzLjkxek0zMCAuNTdBMTcuMjIgMTcuMjIgMCAwIDAgMjUuNTkgMGExNy40IDE3LjQgMCAwIDAtOS42OCAyLjkzQTE3LjM4IDE3LjM4IDAgMCAwIDYuMjMgMGExNy4yMiAxNy4yMiAwIDAgMC00LjQ0LjU3QTE2LjIyIDE2LjIyIDAgMCAwIDAgMS4xM2EuMDcuMDcgMCAwIDAgMCAuMDkgMTcuMzIgMTcuMzIgMCAwIDAgLjgzIDEuNTcuMDcuMDcgMCAwIDAgLjA4IDAgMTYuMzkgMTYuMzkgMCAwIDEgMS44MS0uNTQgMTUuNjUgMTUuNjUgMCAwIDEgMTEuNTkgMS44OCAxNy41MiAxNy41MiAwIDAgMC0zLjc4IDQuNDhjLS4yLjMyLS4zNy42NS0uNTUgMXMtLjIyLjQ1LS4zMy42OS0uMzEuNzItLjQ0IDEuMDhhMTcuNDYgMTcuNDYgMCAwIDAgNC4yOSAxOC43Yy4yNi4yNS41My40OS44MS43M3MuNDQuMzcuNjcuNTQuNTkuNDQuODkuNjRhLjA3LjA3IDAgMCAwIC4wOCAwYy4zLS4yMS42LS40Mi44OS0uNjRzLjQ1LS4zNS42Ny0uNTQuNTUtLjQ4LjgxLS43M2ExNy40NSAxNy40NSAwIDAgMCA1LjM4LTEyLjYxIDE3LjM5IDE3LjM5IDAgMCAwLTEuMDktNi4wOWMtLjE0LS4zNy0uMjktLjczLS40NS0xLjA5cy0uMjItLjQ3LS4zMy0uNjktLjM1LS42Ni0uNTUtMWExNy42MSAxNy42MSAwIDAgMC0zLjc4LTQuNDggMTUuNjUgMTUuNjUgMCAwIDEgMTEuNi0xLjg0IDE2LjEzIDE2LjEzIDAgMCAxIDEuODEuNTQuMDcuMDcgMCAwIDAgLjA4IDBxLjQ0LS43Ni44Mi0xLjU2YS4wNy4wNyAwIDAgMCAwLS4wOUExNi44OSAxNi44OSAwIDAgMCAzMCAuNTd6IiBmaWxsPSIjMTUxZjM0Ii8+PHBhdGggZD0iTTIxLjgyIDE3LjQ3YTE1LjUxIDE1LjUxIDAgMCAxLTQuMjUgMTAuNjkgMTUuNjYgMTUuNjYgMCAwIDEtLjcyLTQuNjggMTUuNSAxNS41IDAgMCAxIDQuMjUtMTAuNjkgMTUuNjIgMTUuNjIgMCAwIDEgLjcyIDQuNjgiIGZpbGw9IiMzNDg1NDAiLz48cGF0aCBkPSJNMTUgMjMuNDhhMTUuNTUgMTUuNTUgMCAwIDEtLjcyIDQuNjggMTUuNTQgMTUuNTQgMCAwIDEtMy41My0xNS4zN0ExNS41IDE1LjUgMCAwIDEgMTUgMjMuNDgiIGZpbGw9IiM3ZGJjNDIiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - verbs:
+          - use
+          apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          resourceNames:
+          - privileged
+        serviceAccountName: cockroachdb-operator
+      deployments:
+      - name: cockroachdb
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cockroachdb
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: cockroachdb
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: cockroachdb
+                image: quay.io/helmoperators/cockroachdb:v2.1.1
+                imagePullPolicy: Always
+                name: cockroachdb
+                resources: {}
+              serviceAccountName: cockroachdb-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - charts.helm.k8s.io
+          resources:
+          - cockroachdbs
+          - cockroachdbs/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          - ingresses/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - '*'
+        serviceAccountName: cockroachdb-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - cockroach
+  - cockroachdb
+  - postgres
+  labels:
+    alm-owner-etcd: couchbaseoperator
+    operated-by: couchbaseoperator
+  links:
+  - name: Helm Chart Source
+    url: https://github.com/helm/charts/tree/master/stable/cockroachdb
+  - name: Configuration Options
+    url: https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration
+  maintainers:
+  - email: alex@cockroachlabs.com
+    name: a-robinson
+  maturity: stable
+  minKubeVersion: 1.8.0
+  provider:
+    name: Helm Community
+  replaces: cockroachdb.v2.0.9
+  selector:
+    matchLabels:
+      alm-owner-etcd: couchbaseoperator
+      operated-by: couchbaseoperator
+  version: 2.1.1


### PR DESCRIPTION
This regenerates the CockroachDB Operator from a newer version of the helm chart (2.1.1)