### PR TITLE
add federatorai.v0.1.0

### DIFF
--- a/community-operators/federatorai/federatorai.package.yaml
+++ b/community-operators/federatorai/federatorai.package.yaml
@@ -1,5 +1,5 @@
 packageName: federatorai
 channels:
 - name: alpha
-  currentCSV: federatorai.v0.0.1
+  currentCSV: federatorai.v0.1.0
 

--- a/community-operators/federatorai/federatorai.v0.1.0.clusterserviceversion.yaml
+++ b/community-operators/federatorai/federatorai.v0.1.0.clusterserviceversion.yaml
@@ -1,0 +1,320 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: federatorai.v0.1.0
+  namespace: placeholder
+  annotations:
+    capabilities: Full Lifecycle
+    categories: "AI/Machine Learning, OpenShift Optional"
+    certified: "false"
+    repository: https://quay.io/repository/prophetstor/federatorai-operator
+    containerImage: quay.io/prophetstor/federatorai-operator:v0.1.0
+    createdAt: 2019-04-29T10:00:00Z
+    description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
+    support: ProphetStor Data Services, Inc.
+    alm-examples: >-
+        [{"apiVersion":"federatorai.containers.ai/v1alpha1","kind":"AlamedaService","metadata":{"name":"my-alamedaservice"},"spec":{"enableexecution":false,"enablegui":true,"version":"v0.3.8","prometheusservice":"https://prometheus-k8s.openshift-monitoring:9091","storages":[{"usage":"log","type":"ephemeral"},{"usage":"data","type":"ephemeral"}]}}]
+spec: 
+  replaces: federatorai.v0.0.1
+  version: 0.1.0
+  maturity: alpha
+  displayName: FederatorAI
+  description: |
+    **FederatorAI** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **FederatorAI** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+
+    **FederatorAI Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
+    - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
+    - **Easy Configuration**: Easily configure data source of Prometheus and enable/disable add-on components, such as GUI, and predictive autoscaling.
+    - **Pod Scaling Recommendation/Autoscaling**: Use provided CRD to setup target pods and desired policies for scaling recommendation and autoscaling.
+
+    ### Prerequisite
+    **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
+
+    ### Common Configurations
+        apiVersion: federatorai.containers.ai/v1alpha1
+        kind: AlamedaService
+        metadata:
+          name: my-alamedaservice
+        spec:
+          # experimental feature, set true to enable
+          enableexecution: false
+          enablegui: true
+          version: v0.3.8
+          prometheusservice: https://prometheus-k8s.openshift-monitoring:9091
+          # storages is optional. Omit this field if not needed.
+          storages:
+            - usage: log       # the supported usages are log and data
+              type: ephemeral  # the supported types are ephemeral and pvc
+            - usage: data
+              type: ephemeral 
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAACWCAMAAACsAjcrAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAC91BMVEUAAAD9/v3r78n09PTx8fHu7u719fX29vba2tpiZWLc3Nzf39/b4p/DxMPHx8fLy8zO13zExcTIyMjMzM3G0WjH0mrr78rIx8js8M3a29r19PXd3N329+X5+fn4+Pj6+/L5+vDs8M7s78v4+u3H0Wj///65x0T///25x0X+/f66x0b9/vy3xT7I0mvI0mrI02vU3Ir9/v3K1HHr78nCzlzM1nXM1nbX3pPL1XP09+L19fXz8/Px8fHx8fHx8fHx8fHv8O/t7e3s7Ozs7Ozy8vL9/f3+/v/r6+zm5ubm5ubm5ubw8PD+/v3f39/W1tbQ0NDf4N/x8fHKysrT09P9/f+8vL3MzM34+Pje5ajQ2YHE0GPF0GXF0GTd5KTMzcy9vr3b3Nv////x8fG5ubnu7+6UlJaurrD09PTS24i/y1S+v766urrv7++WlpiwsLH09PXL1XW1wzrM1ne2xT22xD3v8O+6ubqVlZevr7HL1XT19+TMzszc3Nzv7u/X35T19+Tg4ODW19bh4eHy8fLMzMzU09T19PW9vb7Ozs75+fj3+On19+T19+X29+X6+vr4+Pj29vb29vb29vb29vb29vb19fXz9PPz8/P09PT39/f8/Pz9/f3z8/Pw8PDw8PDw8PD29vb+/v76+/Hu8tPq7sXq7sbP2H62xD35+u/s8Mzm67zn673n7L7g5q61wzns8Mzq7sfr78n4+ezDzl22xDy3xD23xT+1wzeltg6mtxCmtxK0wzmltw+mtxGnuBOmuBOnuBXPz8/P0M++vr6/vr+/v7+qqqupqaqys7K1trWzs7OXlpeYl5iZmJl3d3l2dnivvyuwwC2wwCzR2oSztLO2t7a1tLWamZqbmpt5eXt4eHqktQultg2ktg3K1HHL1XO0wziltg+0tLS1wzjR2oPH0mnH0mrR0dHAv8DAwMCrq62rq6zBzVmtvSSuvieuviWouRa7yEi9yk+ouRepuhqpuhnN13jn7MDg5qvh5q3h5qzt8M////9HTZ/9AAAAs3RSTlMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7ArsCuwK7Av7r5+upAfIxCQsLCPEnBWZ9e3cWA2F9e2EDAVp+e31mBQvT/nxD6cgCu9MLFoaOjo6OC9O7AnXIBbvTCyfx08gFu9MLJ/En8fEFyLvT8ScLuwXDFgvThkvtyAW70wuOjpBBBnWPjogaA2+QjpBvAwFokI6PdQYCBQUFK/JY3tvb2+H9ZmZmZjqy/PcAAAABYktHRGGysEyGAAAACXBIWXMAAAGQAAABkABW8NvoAAACuklEQVR42u3cVVQUURzH8RUUA1tssVHADgxs7EbEVhQLC2ywu7s7UbC7WGRRUbAQOxCMtVuxxRefFnc8d/+Mc9T5z/H3fb73nv/nzOudqztw8JDSDhd10PHpSIheaaHFiqs9vVlHwwxKC3d0Unt6QAABBBBA1A4QQAABBBBAAAEEEEAA+Z8gx1hDQsNld9y5hNrTW4boS5YqLbcyZcupPT0BKV+hoovMKlVOofb0BKRKVSu1RwIEEFYBwi1AuAUItwDhFiDcAoRbgHCLgFi7Vqteg6hmrZSiE1PVruNWl8itXn0b0b4GDRs1JmrStFlqhZA0zVuciCBq6Z5WdKJ1K4+Tp4giW7umE+3zbBN1miiqbTtb09L07Tt07GRe5y4UJINX1zNUZ7t5CyHdz52PJrrQo2dGIaRXzEWimN4+mUxLM/fpe+myeVeuUpAsXv2uUV23BLkRfZPoVv8BWYUQ39jbRLF+A7OZltoNGhwXb96du9qEZB8yNEQytuGeViHDpBA9IIAAAggggAACCCCAAAIIIIAAAggggAACCCCAAAIIIIAAAggggAACCCCAaBsy/G9A7hslj38Z/wTkAQ3xt/BFAmjICBryUPriWdjIUTmSIKOTgYxR9kX8x+YU7XNIBuLnQ0IePX4iadz4XKbluSdMpK40RjydJJpHl2fylMhnRM+nTssrhEx/8ZJqxkxbCjJrtqQ5c/MlnWw/b/6ChUSLFguvfdosWbpsOdGKlavyi/atXrN2HdH6DRvtKYgmA4RbgHALEG4Bwi1AuAUItwDhFiDcAuRfVCBw0+YgmXkHb+ELKbh12/YdMtu5a7eRLaTQnlev38jt7TsDW4jV3oRf/i38jQABBBBAAAEEEEAAAQQQQAABBBBAAAFEixADI0jhfe8/fFTap89qj/+zIvu/fP2msMTE7z8AofGIUB1IPooAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDMtMTRUMTc6MDA6NTIrMDE6MDCjbINkAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAzLTE0VDE3OjAwOjUyKzAxOjAw0jE72AAAACB0RVh0cGRmOkhpUmVzQm91bmRpbmdCb3gANDA4eDI2NiswKzDr8x6EAAAAHXRFWHRwZGY6U3BvdENvbG9yLTAAUEFOVE9ORSA0MjEgQx6zNCoAAAAldEVYdHBkZjpTcG90Q29sb3ItMQBQQU5UT05FIENvb2wgR3JheSA3IEOzNDMdAAAAJXRFWHRwZGY6U3BvdENvbG9yLTIAUEFOVE9ORSBDb29sIEdyYXkgOSBDz08nKgAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNQ1Ag1dMAAAAAElFTkSuQmCC
+    mediatype: image/png
+  keywords: ['AI', 'Resource Orchestration', 'NoOps']
+  maintainers:
+  - email: support@prophetstor.com
+    name: ProphetStor Data Services, Inc.
+  provider:
+    name: ProphetStor Data Services, Inc.
+  links:
+  - name: FederatorAI
+    url: https://github.com/containers-ai/alameda
+  - name: FederatorAI Operator
+    url: https://github.com/containers-ai/federatorai-operator
+  labels:
+    alm-owner-federatorai: federatorai-operator
+    alm-status-descriptors: federatorai-operator.v0.1.0
+  selector:
+    matchLabels:
+      alm-owner-federatorai: federatorai-operator
+  customresourcedefinitions:
+    owned:
+    - name: alamedaservices.federatorai.containers.ai
+      version: v1alpha1
+      kind: AlamedaService
+      displayName: AlamedaService
+      description: An instance of Alameda.
+      resources:
+      - kind: Deployment
+        version: v1
+      - kind: ReplicaSet
+        version: v1
+      - kind: Pod
+        version: v1
+      specDescriptors:
+      - description: Deploy components to automatically execute Alameda recommendation
+        displayName: Enable Execution
+        path: enableexecution
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Deploy Grafana to visualize Alameda prediction and recommendation
+        displayName: Enable Dashboard
+        path: enablegui
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Alameda core component image version tag
+        displayName: Alameda Version
+        path: version
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      - description: Prometheus database connection settings for metrics retrieval
+        displayName: Prometheus Service
+        path: prometheusservice
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      statusDescriptors:
+        - description: Alameda service condictions
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - 'urn:alm:descriptor:io.kubernetes.conditions'
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - federatorai.containers.ai
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          - persistentvolumeclaims
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - replicationcontrollers
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - services
+          verbs:
+          - create
+          - list
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - delete
+          - patch
+      permissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - events
+          - endpoints
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - services
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - statefulsets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+      deployments:
+      - name: federatorai-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: federatorai-operator
+            strategy:
+              type: Recreate
+          template:
+            metadata:
+              labels:
+                name: federatorai-operator
+            spec:
+              serviceAccountName: federatorai-operator
+              containers:
+              - command:
+                - federatorai-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: federatorai-operator
+                image: quay.io/prophetstor/federatorai-operator:v0.1.0
+                imagePullPolicy: IfNotPresent
+                name: federatorai-operator
+                resources: {}
+

--- a/upstream-community-operators/federatorai/federatorai.package.yaml
+++ b/upstream-community-operators/federatorai/federatorai.package.yaml
@@ -1,5 +1,5 @@
 packageName: federatorai
 channels:
 - name: alpha
-  currentCSV: federatorai.v0.0.1
+  currentCSV: federatorai.v0.1.0
 

--- a/upstream-community-operators/federatorai/federatorai.v0.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/federatorai/federatorai.v0.1.0.clusterserviceversion.yaml
@@ -1,0 +1,320 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: federatorai.v0.1.0
+  namespace: placeholder
+  annotations:
+    capabilities: Full Lifecycle
+    categories: "AI/Machine Learning, OpenShift Optional"
+    certified: "false"
+    repository: https://quay.io/repository/prophetstor/federatorai-operator
+    containerImage: quay.io/prophetstor/federatorai-operator:v0.1.0
+    createdAt: 2019-04-29T10:00:00Z
+    description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
+    support: ProphetStor Data Services, Inc.
+    alm-examples: >-
+        [{"apiVersion":"federatorai.containers.ai/v1alpha1","kind":"AlamedaService","metadata":{"name":"my-alamedaservice"},"spec":{"enableexecution":false,"enablegui":true,"version":"v0.3.8","prometheusservice":"https://prometheus-k8s.openshift-monitoring:9091","storages":[{"usage":"log","type":"ephemeral"},{"usage":"data","type":"ephemeral"}]}}]
+spec: 
+  replaces: federatorai.v0.0.1
+  version: 0.1.0
+  maturity: alpha
+  displayName: FederatorAI
+  description: |
+    **FederatorAI** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **FederatorAI** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+
+    **FederatorAI Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
+    - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
+    - **Easy Configuration**: Easily configure data source of Prometheus and enable/disable add-on components, such as GUI, and predictive autoscaling.
+    - **Pod Scaling Recommendation/Autoscaling**: Use provided CRD to setup target pods and desired policies for scaling recommendation and autoscaling.
+
+    ### Prerequisite
+    **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
+
+    ### Common Configurations
+        apiVersion: federatorai.containers.ai/v1alpha1
+        kind: AlamedaService
+        metadata:
+          name: my-alamedaservice
+        spec:
+          # experimental feature, set true to enable
+          enableexecution: false
+          enablegui: true
+          version: v0.3.8
+          prometheusservice: https://prometheus-k8s.openshift-monitoring:9091
+          # storages is optional. Omit this field if not needed.
+          storages:
+            - usage: log       # the supported usages are log and data
+              type: ephemeral  # the supported types are ephemeral and pvc
+            - usage: data
+              type: ephemeral 
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAACWCAMAAACsAjcrAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAC91BMVEUAAAD9/v3r78n09PTx8fHu7u719fX29vba2tpiZWLc3Nzf39/b4p/DxMPHx8fLy8zO13zExcTIyMjMzM3G0WjH0mrr78rIx8js8M3a29r19PXd3N329+X5+fn4+Pj6+/L5+vDs8M7s78v4+u3H0Wj///65x0T///25x0X+/f66x0b9/vy3xT7I0mvI0mrI02vU3Ir9/v3K1HHr78nCzlzM1nXM1nbX3pPL1XP09+L19fXz8/Px8fHx8fHx8fHx8fHv8O/t7e3s7Ozs7Ozy8vL9/f3+/v/r6+zm5ubm5ubm5ubw8PD+/v3f39/W1tbQ0NDf4N/x8fHKysrT09P9/f+8vL3MzM34+Pje5ajQ2YHE0GPF0GXF0GTd5KTMzcy9vr3b3Nv////x8fG5ubnu7+6UlJaurrD09PTS24i/y1S+v766urrv7++WlpiwsLH09PXL1XW1wzrM1ne2xT22xD3v8O+6ubqVlZevr7HL1XT19+TMzszc3Nzv7u/X35T19+Tg4ODW19bh4eHy8fLMzMzU09T19PW9vb7Ozs75+fj3+On19+T19+X29+X6+vr4+Pj29vb29vb29vb29vb29vb19fXz9PPz8/P09PT39/f8/Pz9/f3z8/Pw8PDw8PDw8PD29vb+/v76+/Hu8tPq7sXq7sbP2H62xD35+u/s8Mzm67zn673n7L7g5q61wzns8Mzq7sfr78n4+ezDzl22xDy3xD23xT+1wzeltg6mtxCmtxK0wzmltw+mtxGnuBOmuBOnuBXPz8/P0M++vr6/vr+/v7+qqqupqaqys7K1trWzs7OXlpeYl5iZmJl3d3l2dnivvyuwwC2wwCzR2oSztLO2t7a1tLWamZqbmpt5eXt4eHqktQultg2ktg3K1HHL1XO0wziltg+0tLS1wzjR2oPH0mnH0mrR0dHAv8DAwMCrq62rq6zBzVmtvSSuvieuviWouRa7yEi9yk+ouRepuhqpuhnN13jn7MDg5qvh5q3h5qzt8M////9HTZ/9AAAAs3RSTlMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7ArsCuwK7Av7r5+upAfIxCQsLCPEnBWZ9e3cWA2F9e2EDAVp+e31mBQvT/nxD6cgCu9MLFoaOjo6OC9O7AnXIBbvTCyfx08gFu9MLJ/En8fEFyLvT8ScLuwXDFgvThkvtyAW70wuOjpBBBnWPjogaA2+QjpBvAwFokI6PdQYCBQUFK/JY3tvb2+H9ZmZmZjqy/PcAAAABYktHRGGysEyGAAAACXBIWXMAAAGQAAABkABW8NvoAAACuklEQVR42u3cVVQUURzH8RUUA1tssVHADgxs7EbEVhQLC2ywu7s7UbC7WGRRUbAQOxCMtVuxxRefFnc8d/+Mc9T5z/H3fb73nv/nzOudqztw8JDSDhd10PHpSIheaaHFiqs9vVlHwwxKC3d0Unt6QAABBBBA1A4QQAABBBBAAAEEEEAA+Z8gx1hDQsNld9y5hNrTW4boS5YqLbcyZcupPT0BKV+hoovMKlVOofb0BKRKVSu1RwIEEFYBwi1AuAUItwDhFiDcAoRbgHCLgFi7Vqteg6hmrZSiE1PVruNWl8itXn0b0b4GDRs1JmrStFlqhZA0zVuciCBq6Z5WdKJ1K4+Tp4giW7umE+3zbBN1miiqbTtb09L07Tt07GRe5y4UJINX1zNUZ7t5CyHdz52PJrrQo2dGIaRXzEWimN4+mUxLM/fpe+myeVeuUpAsXv2uUV23BLkRfZPoVv8BWYUQ39jbRLF+A7OZltoNGhwXb96du9qEZB8yNEQytuGeViHDpBA9IIAAAggggAACCCCAAAIIIIAAAggggAACCCCAAAIIIIAAAggggAACCCCAaBsy/G9A7hslj38Z/wTkAQ3xt/BFAmjICBryUPriWdjIUTmSIKOTgYxR9kX8x+YU7XNIBuLnQ0IePX4iadz4XKbluSdMpK40RjydJJpHl2fylMhnRM+nTssrhEx/8ZJqxkxbCjJrtqQ5c/MlnWw/b/6ChUSLFguvfdosWbpsOdGKlavyi/atXrN2HdH6DRvtKYgmA4RbgHALEG4Bwi1AuAUItwDhFiDcAuRfVCBw0+YgmXkHb+ELKbh12/YdMtu5a7eRLaTQnlev38jt7TsDW4jV3oRf/i38jQABBBBAAAEEEEAAAQQQQAABBBBAAAFEixADI0jhfe8/fFTap89qj/+zIvu/fP2msMTE7z8AofGIUB1IPooAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDMtMTRUMTc6MDA6NTIrMDE6MDCjbINkAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAzLTE0VDE3OjAwOjUyKzAxOjAw0jE72AAAACB0RVh0cGRmOkhpUmVzQm91bmRpbmdCb3gANDA4eDI2NiswKzDr8x6EAAAAHXRFWHRwZGY6U3BvdENvbG9yLTAAUEFOVE9ORSA0MjEgQx6zNCoAAAAldEVYdHBkZjpTcG90Q29sb3ItMQBQQU5UT05FIENvb2wgR3JheSA3IEOzNDMdAAAAJXRFWHRwZGY6U3BvdENvbG9yLTIAUEFOVE9ORSBDb29sIEdyYXkgOSBDz08nKgAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNQ1Ag1dMAAAAAElFTkSuQmCC
+    mediatype: image/png
+  keywords: ['AI', 'Resource Orchestration', 'NoOps']
+  maintainers:
+  - email: support@prophetstor.com
+    name: ProphetStor Data Services, Inc.
+  provider:
+    name: ProphetStor Data Services, Inc.
+  links:
+  - name: FederatorAI
+    url: https://github.com/containers-ai/alameda
+  - name: FederatorAI Operator
+    url: https://github.com/containers-ai/federatorai-operator
+  labels:
+    alm-owner-federatorai: federatorai-operator
+    alm-status-descriptors: federatorai-operator.v0.1.0
+  selector:
+    matchLabels:
+      alm-owner-federatorai: federatorai-operator
+  customresourcedefinitions:
+    owned:
+    - name: alamedaservices.federatorai.containers.ai
+      version: v1alpha1
+      kind: AlamedaService
+      displayName: AlamedaService
+      description: An instance of Alameda.
+      resources:
+      - kind: Deployment
+        version: v1
+      - kind: ReplicaSet
+        version: v1
+      - kind: Pod
+        version: v1
+      specDescriptors:
+      - description: Deploy components to automatically execute Alameda recommendation
+        displayName: Enable Execution
+        path: enableexecution
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Deploy Grafana to visualize Alameda prediction and recommendation
+        displayName: Enable Dashboard
+        path: enablegui
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Alameda core component image version tag
+        displayName: Alameda Version
+        path: version
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      - description: Prometheus database connection settings for metrics retrieval
+        displayName: Prometheus Service
+        path: prometheusservice
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      statusDescriptors:
+        - description: Alameda service condictions
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - 'urn:alm:descriptor:io.kubernetes.conditions'
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - federatorai.containers.ai
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          - persistentvolumeclaims
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - replicationcontrollers
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - services
+          verbs:
+          - create
+          - list
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - delete
+          - patch
+      permissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - events
+          - endpoints
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - services
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - statefulsets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+      deployments:
+      - name: federatorai-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: federatorai-operator
+            strategy:
+              type: Recreate
+          template:
+            metadata:
+              labels:
+                name: federatorai-operator
+            spec:
+              serviceAccountName: federatorai-operator
+              containers:
+              - command:
+                - federatorai-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: federatorai-operator
+                image: quay.io/prophetstor/federatorai-operator:v0.1.0
+                imagePullPolicy: IfNotPresent
+                name: federatorai-operator
+                resources: {}
+


### PR DESCRIPTION
Hi Operator community,
This federatorai.v0.1.0 csv replaces version 0.0.1 and moves forward to capability Full Lifecycle management.
This CSV is committed for community-operators and upstream-community-operators, and the e2e deployment tests on vanilla K8s and OKD 3.11+ v4.0 console GUI have passed.

Signed-off-by: matt.wu <matt.wu@prophetstor.com>