### PR TITLE
[scripts] Fix: Access correct installPlan for subscription

### DIFF
--- a/scripts/lib/cluster
+++ b/scripts/lib/cluster
@@ -42,8 +42,8 @@ function check_subscription_passes() {
       if [[ $retries == 0 ]]; then
         echo "FAIL: Failed to reach "AtLatestKnown" subscription status for \"$sub\""
         kubectl get "subscription/${sub}" --namespace=${namespace} -o yaml
-        installplan="`kubectl get subscription/packageserver -n olm -o json | jq .status.installplan.name`"
-        echo "  installplan status for \"$installplan\":"
+        installplan="`kubectl get subscription/${sub} --namespace=${namespace} -o json | jq .status.installplan.name`"
+        echo "installplan status for \"$installplan\":"
         kubectl get "installplan/${installplan}" --namespace=${namespace} -o yaml
         exit 1
       fi


### PR DESCRIPTION
This allows CI to print the logs of the correct installPlan when
a subscription with a status fails