### PR TITLE
set defaultChannel for etcd

### DIFF
--- a/community-operators/etcd/etcd.package.yaml
+++ b/community-operators/etcd/etcd.package.yaml
@@ -4,3 +4,4 @@ channels:
   currentCSV: etcdoperator.v0.9.4
 - name: clusterwide-alpha
   currentCSV: etcdoperator.v0.9.4-clusterwide
+defaultChannel: singlenamespace-alpha

--- a/upstream-community-operators/etcd/etcd.package.yaml
+++ b/upstream-community-operators/etcd/etcd.package.yaml
@@ -4,3 +4,4 @@ channels:
   currentCSV: etcdoperator.v0.9.4
 - name: clusterwide-alpha
   currentCSV: etcdoperator.v0.9.4-clusterwide
+defaultChannel: singlenamespace-alpha


### PR DESCRIPTION
A defaultChannel is required for OLM to perform dependency resolution. We want to start validating that a defaultChannel is set in the registry https://github.com/operator-framework/operator-registry/pull/46 but can't because etcd doesn't have a default.

It would be better to have one CSV for both installmodes for etcd, but for now this will unblock the operator-registry PR. Any context for why there are two channels here?