### PR TITLE
change display name of FederatorAI to Federator.ai

### DIFF
--- a/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -10,24 +10,24 @@ metadata:
     repository: https://quay.io/repository/prophetstor/federatorai-operator
     containerImage: quay.io/prophetstor/federatorai-operator:v0.0.1
     createdAt: 2019-04-09T13:00:00Z
-    description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
+    description: Federator.ai Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
     support: ProphetStor Data Services, Inc.
     alm-examples: >-
       [{"apiVersion":"federatorai.containers.ai/v1alpha1","kind":"AlamedaService","metadata":{"name":"my-alamedaservice"},"spec":{"enableexecution":false,"enablegui":true,"version":"v0.3.7","prometheusservice":"https://prometheus-k8s.openshift-monitoring:9091","persistentvolumeclaim":""}}]
 spec: 
   version: 0.0.1
   maturity: alpha
-  displayName: FederatorAI
+  displayName: Federator.ai
   description: |
-    **FederatorAI** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **FederatorAI** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+    **Federator.ai** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **Federator.ai** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
 
-    **FederatorAI Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
-    - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
+    **Federator.ai Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
+    - **Create/Clean up**: Launch **Federator.ai** components using the Operator.
     - **Easy Configuration**: Easily configure data source of Prometheus and enable/disable add-on components, such as GUI, and predictive autoscaling.
     - **Pod Scaling Recommendation/Autoscaling**: Use provided CRD to setup target pods and desired policies for scaling recommendation and autoscaling.
 
     ### Prerequisite
-    **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
+    **Federator.ai** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **Federator.ai** components, Prometheus connection settings need to be provided.
 
     ### Common Configurations
         apiVersion: federatorai.containers.ai/v1alpha1
@@ -45,14 +45,14 @@ spec:
     mediatype: image/png
   keywords: ['AI', 'Resource Orchestration', 'NoOps']
   maintainers:
-  - email: info@prophetstor.com
+  - email: support@prophetstor.com
     name: ProphetStor Data Services, Inc.
   provider:
     name: ProphetStor Data Services, Inc.
   links:
-  - name: FederatorAI
+  - name: Federator.ai
     url: https://github.com/containers-ai/alameda
-  - name: FederatorAI Operator
+  - name: Federator.ai Operator
     url: https://github.com/containers-ai/federatorai-operator
   labels:
     alm-owner-federatorai: federatorai-operator

--- a/community-operators/federatorai/federatorai.v0.1.0.clusterserviceversion.yaml
+++ b/community-operators/federatorai/federatorai.v0.1.0.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     repository: https://quay.io/repository/prophetstor/federatorai-operator
     containerImage: quay.io/prophetstor/federatorai-operator:v0.1.0
     createdAt: 2019-04-29T10:00:00Z
-    description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
+    description: Federator.ai Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
     support: ProphetStor Data Services, Inc.
     alm-examples: >-
         [{"apiVersion":"federatorai.containers.ai/v1alpha1","kind":"AlamedaService","metadata":{"name":"my-alamedaservice"},"spec":{"enableexecution":false,"enablegui":true,"version":"v0.3.8","prometheusservice":"https://prometheus-k8s.openshift-monitoring:9091","storages":[{"usage":"log","type":"ephemeral"},{"usage":"data","type":"ephemeral"}]}}]
@@ -18,17 +18,17 @@ spec:
   replaces: federatorai.v0.0.1
   version: 0.1.0
   maturity: alpha
-  displayName: FederatorAI
+  displayName: Federator.ai
   description: |
-    **FederatorAI** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **FederatorAI** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+    **Federator.ai** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **Federator.ai** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
 
-    **FederatorAI Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
-    - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
+    **Federator.ai Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
+    - **Create/Clean up**: Launch **Federator.ai** components using the Operator.
     - **Easy Configuration**: Easily configure data source of Prometheus and enable/disable add-on components, such as GUI, and predictive autoscaling.
     - **Pod Scaling Recommendation/Autoscaling**: Use provided CRD to setup target pods and desired policies for scaling recommendation and autoscaling.
 
     ### Prerequisite
-    **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
+    **Federator.ai** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **Federator.ai** components, Prometheus connection settings need to be provided.
 
     ### Common Configurations
         apiVersion: federatorai.containers.ai/v1alpha1
@@ -57,9 +57,9 @@ spec:
   provider:
     name: ProphetStor Data Services, Inc.
   links:
-  - name: FederatorAI
+  - name: Federator.ai
     url: https://github.com/containers-ai/alameda
-  - name: FederatorAI Operator
+  - name: Federator.ai Operator
     url: https://github.com/containers-ai/federatorai-operator
   labels:
     alm-owner-federatorai: federatorai-operator

--- a/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/federatorai/federatorai.v0.0.1.clusterserviceversion.yaml
@@ -10,24 +10,24 @@ metadata:
     repository: https://quay.io/repository/prophetstor/federatorai-operator
     containerImage: quay.io/prophetstor/federatorai-operator:v0.0.1
     createdAt: 2019-04-09T13:00:00Z
-    description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
+    description: Federator.ai Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
     support: ProphetStor Data Services, Inc.
     alm-examples: >-
       [{"apiVersion":"federatorai.containers.ai/v1alpha1","kind":"AlamedaService","metadata":{"name":"my-alamedaservice"},"spec":{"enableexecution":false,"enablegui":true,"version":"v0.3.7","prometheusservice":"https://prometheus-k8s.openshift-monitoring:9091","persistentvolumeclaim":""}}]
 spec: 
   version: 0.0.1
   maturity: alpha
-  displayName: FederatorAI
+  displayName: Federator.ai
   description: |
-    **FederatorAI** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **FederatorAI** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+    **Federator.ai** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **Federator.ai** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
 
-    **FederatorAI Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
-    - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
+    **Federator.ai Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
+    - **Create/Clean up**: Launch **Federator.ai** components using the Operator.
     - **Easy Configuration**: Easily configure data source of Prometheus and enable/disable add-on components, such as GUI, and predictive autoscaling.
     - **Pod Scaling Recommendation/Autoscaling**: Use provided CRD to setup target pods and desired policies for scaling recommendation and autoscaling.
 
     ### Prerequisite
-    **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
+    **Federator.ai** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **Federator.ai** components, Prometheus connection settings need to be provided.
 
     ### Common Configurations
         apiVersion: federatorai.containers.ai/v1alpha1
@@ -45,14 +45,14 @@ spec:
     mediatype: image/png
   keywords: ['AI', 'Resource Orchestration', 'NoOps']
   maintainers:
-  - email: info@prophetstor.com
+  - email: support@prophetstor.com
     name: ProphetStor Data Services, Inc.
   provider:
     name: ProphetStor Data Services, Inc.
   links:
-  - name: FederatorAI
+  - name: Federator.ai
     url: https://github.com/containers-ai/alameda
-  - name: FederatorAI Operator
+  - name: Federator.ai Operator
     url: https://github.com/containers-ai/federatorai-operator
   labels:
     alm-owner-federatorai: federatorai-operator

--- a/upstream-community-operators/federatorai/federatorai.v0.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/federatorai/federatorai.v0.1.0.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     repository: https://quay.io/repository/prophetstor/federatorai-operator
     containerImage: quay.io/prophetstor/federatorai-operator:v0.1.0
     createdAt: 2019-04-29T10:00:00Z
-    description: FederatorAI Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
+    description: Federator.ai Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
     support: ProphetStor Data Services, Inc.
     alm-examples: >-
         [{"apiVersion":"federatorai.containers.ai/v1alpha1","kind":"AlamedaService","metadata":{"name":"my-alamedaservice"},"spec":{"enableexecution":false,"enablegui":true,"version":"v0.3.8","prometheusservice":"https://prometheus-k8s.openshift-monitoring:9091","storages":[{"usage":"log","type":"ephemeral"},{"usage":"data","type":"ephemeral"}]}}]
@@ -18,17 +18,17 @@ spec:
   replaces: federatorai.v0.0.1
   version: 0.1.0
   maturity: alpha
-  displayName: FederatorAI
+  displayName: Federator.ai
   description: |
-    **FederatorAI** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **FederatorAI** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
+    **Federator.ai** is the brain of resource orchestration for kubernetes. We use machine learning technology to provide intelligence that foresees future resource usage of your Kubernetes cluster across multiple layers. **Federator.ai** recommends the right sizes of containers and the right number of replications. It also elastically manages pod scaling and scheduling of your containerized applications. The overall benefit is cost reduction up to 50% and higher service quality, such as fewer OOM issues. For more information, visit [github.com/containers-ai/alameda](https://github.com/containers-ai/alameda)
 
-    **FederatorAI Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
-    - **Create/Clean up**: Launch **FederatorAI** components using the Operator.
+    **Federator.ai Operator** provides easy configuration and operation of AI-enabled Kubernetes resource orchestrator. Once installed, the Federator.ai Operator provides the following features:
+    - **Create/Clean up**: Launch **Federator.ai** components using the Operator.
     - **Easy Configuration**: Easily configure data source of Prometheus and enable/disable add-on components, such as GUI, and predictive autoscaling.
     - **Pod Scaling Recommendation/Autoscaling**: Use provided CRD to setup target pods and desired policies for scaling recommendation and autoscaling.
 
     ### Prerequisite
-    **FederatorAI** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **FederatorAI** components, Prometheus connection settings need to be provided.
+    **Federator.ai** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **Federator.ai** components, Prometheus connection settings need to be provided.
 
     ### Common Configurations
         apiVersion: federatorai.containers.ai/v1alpha1
@@ -57,9 +57,9 @@ spec:
   provider:
     name: ProphetStor Data Services, Inc.
   links:
-  - name: FederatorAI
+  - name: Federator.ai
     url: https://github.com/containers-ai/alameda
-  - name: FederatorAI Operator
+  - name: Federator.ai Operator
     url: https://github.com/containers-ai/federatorai-operator
   labels:
     alm-owner-federatorai: federatorai-operator


### PR DESCRIPTION
Change the displayed name from FederatorAI to Federator.ai

Signed-off-by: matt.wu <matt.wu@prophetstor.com>