### PR TITLE
Adding additional properties to the CRD

### DIFF
--- a/upstream-community-operators/robin-operator/robin_v1alpha1_robincluster_crd.yaml
+++ b/upstream-community-operators/robin-operator/robin_v1alpha1_robincluster_crd.yaml
@@ -35,6 +35,14 @@ spec:
               type: string
             node_selector:
               type: string
+            source:
+              type: string
+            image_provisioner:
+              type: string
+            storage_disks:
+              type: string
+            options:
+              type: object
         status:
           type: object
           properties:


### PR DESCRIPTION
Adding few missing fields from crd spec.properties section which was causing a failure when deploying from operatorhub