### PR TITLE
[scripts] Log output to file in addition to stdout

### DIFF
--- a/scripts/ci/check-pr
+++ b/scripts/ci/check-pr
@@ -2,6 +2,9 @@
 
 set -e
 
+[[ -z "$ARTIFACTS" ]] && ARTIFACTS="/tmp/artifacts"
+exec |& tee -a "$ARTIFACTS/check-pr.txt"
+
 DIRS=()
 GIT_INFO=""
 

--- a/scripts/ci/test-operator
+++ b/scripts/ci/test-operator
@@ -8,6 +8,9 @@
 
 set -e
 
+[[ -z "$ARTIFACTS" ]] && ARTIFACTS="/tmp/artifacts"
+exec |& tee -a "$ARTIFACTS/test-operator.txt"
+
 for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
   . "$f"
 done

--- a/scripts/ci/test-pr
+++ b/scripts/ci/test-pr
@@ -2,6 +2,9 @@
 
 set -e
 
+[[ -z "$ARTIFACTS" ]] && ARTIFACTS="/tmp/artifacts"
+exec |& tee -a "$ARTIFACTS/test-pr.txt"
+
 # Runs scripts/ci/test-operator on each operator with changes in a PR.
 
 DISTRO_TYPE_UPSTREAM="upstream"

--- a/scripts/ci/verify-operator
+++ b/scripts/ci/verify-operator
@@ -2,6 +2,9 @@
 
 set -e
 
+[[ -z "$ARTIFACTS" ]] && ARTIFACTS="/tmp/artifacts"
+exec |& tee -a "$ARTIFACTS/verify-operator.txt"
+
 # Verifies each operator with changes in a PR with operator-courier.
 if [[ -n $OPERATORS_OPENSHIFT ]]; then
   for path_ver in ${OPERATORS_OPENSHIFT}; do


### PR DESCRIPTION
- Tee output to file for check-pr, test-pr, test-operator
- Tee output to file for verify-operator

This change is needed to persist logs when running tests with prow