### PR TITLE
Add openshift-pipelines-operator to community-operators

### DIFF
--- a/community-operators/openshift-pipelines-operator/openshift-pipelines-operator-tekton_v1alpha1_install_crd.yaml
+++ b/community-operators/openshift-pipelines-operator/openshift-pipelines-operator-tekton_v1alpha1_install_crd.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installs.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Install
+    listKind: InstallList
+    plural: installs
+    singular: install
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          properties:
+            resources:
+              description: The resources applied
+              items:
+                type: string
+              type: array
+            version:
+              type: string
+          required:
+          - resources
+          - version
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/openshift-pipelines-operator/openshift-pipelines-operator.package.yaml
+++ b/community-operators/openshift-pipelines-operator/openshift-pipelines-operator.package.yaml
@@ -1,0 +1,4 @@
+packageName: openshift-pipelines-operator
+channels:
+- name: alpha
+  currentCSV: openshift-pipelines-operator.v0.3.1

--- a/community-operators/openshift-pipelines-operator/openshift-pipelines-operator.v0.3.1.clusterserviceversion.yaml
+++ b/community-operators/openshift-pipelines-operator/openshift-pipelines-operator.v0.3.1.clusterserviceversion.yaml
@@ -1,0 +1,294 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Basic Install
+    categories: "Developer Tools, Integration & Delivery"
+    description: OpenShift Pipelines is a cloud-native CI/CD solution for building pipelines using Tekton concepts which run natively on OpenShift and Kubernetes.
+    containerImage: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-1
+    createdAt: 2019-03-15T19:44:21Z
+    certified: "false"
+    support: Red Hat, Inc.
+    repository: https://github.com/openshift/tektoncd-pipeline-operator
+    alm-examples: |
+      [
+        {
+          "apiVersion": "tekton.dev/v1alpha1",
+          "kind": "Install",
+          "metadata": {
+            "name": "pipelines-install"
+          },
+          "spec": {}
+        }
+      ]
+  name: openshift-pipelines-operator.v0.3.1
+  namespace: placeholder
+spec:
+  version: 0.3.1
+  maturity: alpha
+  provider:
+    name: Red Hat, Inc.
+  maintainers:
+  - name: Red Hat, Inc.
+    email: customerservice@redhat.com
+  links:
+  - name: Openshift Tektoncd Pipeline GitHub Repository
+    url: https://github.com/openshift/tektoncd-pipeline
+  - name: OpenShift Pipelines Operator GitHub Repository
+    url: https://github.com/openshift/tektoncd-pipeline-operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAPQAAAD0CAYAAACsLwv+AAAgAElEQVR4Xu2dDbiVVZn3f2s/GwQ5CKiolMqhYtIYA8zUsRQQLLU3gTRsROEAOjbNW6LWTM07JdT19jGTiVbjTKWgNVPTO47gNJpxDgfQnPwEchgqLCCdQPk6yKeHs/d6r3ufs/GcvZ9nPx/7+dxnres6F5c+6+Ne91r/fX+se91LYUqmONAGozWcmcM6RaNHAieDOgUYqeFkhRoKDNHo4xUcr+F4hTpBJqnRrys4BBzUqNK/Cn1I9/y/3t8UxT0atc2isBXYOgV2ZIpR/ZRY1U/nneppr4JxYI0ros8C9XaFGg16NKjm5AjXR0Bt0+iXFPoXityzBbp+cRnsS44mM3IlBwygE9oTz8GADhirsMaBGgf6XRo1TqHHghqQEFm+h9WwGfQzCv20ovjMqbBuHHT67sg0CIUDBtChsNG9k0fhuEEwoUjuAlDny5+Cse4ts1VDozsVap2Gp0WSawpPT4PfZWsW2aXWADrCtXsKBh/GmgZ8WMP/UqhREQ6X2q41/Eah2xS0DqKw+iLYk1piM06YAXTIC9gKpyqsqwTEwDRQg0MeItPdaXRRodZraAVaLbqemAJHMj2pFBFvAB3CYrTDOzS5mZrcdI3+E4XKhdBtw3fRDW5Ecv9gIIWH3w/7G37SEU/QADoAgzXkVsGFmvx0BdOBdwboxjTpwwHxovMI8IPTKDxuHGvBtocBtE++tcLFCuvjGq5WqON8NjfVPXBAo19TqB/m6PreFPgvD01MlR4OGEB72AorYZhFbr4md7ORxh4YFm6VDZrigxbFfzbBLe6MNYCuwaMnYEQnuU+A+iSoU93ZaWpExwH9Cug7uyh+94NwMLpxst2zAbTN+nWHV+ZvA71AoYZke4kbi3qN3q1Q3xpM1z3m+Kt6bQ2ge/FkLYw6ivXXGv5MoQY2FhQaazYafVCh7tV0fX0avNpYsws+GwNooB2GF8n/H9B/Yc6Ng2+mZFqWvOPfy1H42hR4JRka0jNqvwZ0OzQVyH1KoT4Danh6lsVQ4pcD3SGnPKgofP1S+LXf9o1Sv18CeiMM3FHyWKvPg5IriKY0DAf0YY26axBdX+2PgSr9CtAaVBvWbAVfSvYqYsOgJ7UTkbNs0F8cRfG7/SlIpd8AupW8XJL4ioLzUrsLDWFRcODXiq65l8LTUXSetj4bHtCPwxCL/BdBLzQx1mnbfvHQIzHjoO606PpCo18EaWhA94Rpfp9Sxg9TDAdoeGndkIAWqZzH+jogjq+GnKMBZzAONLq0brjNvgou0Fg/Mk6vYBu+v7TSsE7TteAyWNdIc24YQLfDoAL5xaBvVyirkRbJzCUqDuijoBfvpvjVWVCIapQ4+20IQHdL5fwD5iZUnFunocZ6StN1QyPkPss8oNuwbtTwbRN73VAAi30yGr1HwfVTKTwW++AhDphZQHdHe1nfBnVjiPwwXfVrDmiJPfrybrruyKoKnklAt8JJkP+Jggv79f4zk4+KA2tydH0siwkVMgfoVTBeY60wZ8tR7WXTbzcH9P8oCtMvheezxJFMAXoV1vQi/LNCHZ8lJhtas8kBjT6UQ33kUroez8oMMgPoVeQ+p1H/1wSKJLu18sOH0zT+3YyYPMmWkAPrN7B/wy85slXeuMt+0eiCQi+cSvFbWZhN6gEtzq/tWPcr1OwsMLQRaRzU3MzI6R/mtJa5DJ0w3tMUj2zdxs7lK9jxwIPsX7/BU5t0V9Lf2k1hYdqdZakGtDi/FHnJ1XxRuhe7MakTII+54/OMaplT1wT3rl7D1sVfQv7NdtGPDaNwzXndz++msqQW0JIWqED+MePJjn/fiFp9xi2fZMyiL4Q6uEjszbd+OtPquIbnBtJ15SWwM1TmhNRZKgH9OJySJ78SeHdI8zTdeOSAqNRnLb3Ps2rtsdtj1bo6Otg078aSOp7don+bozA5jTnMUgfolXCmIt/aiE+tpn0DC5gntrciErpWObJtW8kuFgdY7zKoeTRDJ0woOc3cioB6+zKJ1s1q0a8oCpdfChvTNINUAXoNjD2K1apQZ6aJSf2BFjcwd+3bx/ZlD/LykntcVWb5QRC7+4yFn2LQaOer6FkHtUb/AQoXpykGPDWAlpzYnVg/V6gx/QFAaZqjG5i3LP5SCciiLvsto1rmMnbJneSHDbNt2gCg/l2RwsUfgD/45U0U9VMB6G4w5+VZ0bOjmKTp05kDIk3PX/ccoi5XFlGtX5xxdd3HTjLGu5c/xPBJl9gS8uzE8+oeI+E13lig6wNpAHXigH4KTjxE/kkD5mS25Ngl3yh5tCvLgQ2/5IXJUwNJZaeZnL3sPkbNrT4CkzPrZyaeF+pYCXBzo6Zr0jTYncDYx4ZMFNCS6L5IfjXwniSZ0F/HlmgvcYLFAebyGE6gFrV+y6IvZn0pnsnRNSnJRISJAbr70XTrp6Auy/oqZpV+AXNlCKc4v9ZNnhqpCnz++uerPOFinz81ZmzWpbRc6njkUgozFRST2BeJAbqN/BLgliQmbcakBGQ76bz51ttLDrAoizjh3rvuuaohGkRKo9DfvpTC/46Sh059JwLoNnILIXdXEhM2Y3ZzwE71FSfYU83viIVFtuNv3cZTY+IZP4ZJLp5K16IYxukzROyAbiV/GeifmqT3cS913/Eu2buzKoAkziMkiRO/aMvmKiasmzKtAWK+u6el0LMvpfDPca50rIBuLYVyWk8o1AlxTrIRxxK1VYI2miaMLwFT/pUyuLnZ9gjKjQdiO68dfrJbtVC/n7P8IUZOv6pPny/f/U02L7wt1HGS6kzuU3dSuPJKiO1WSmyAXgnDcuTlfaF3JsXgrI4r57cC4CYJq5wwPpI46+0PPMimlgWxskiCTs5e+r0+Y3asWVs6LmuEsp8ieygWj4Mps2FtHHOKBdA9Hu2fgLoijkllfQwBr4D45BnTHRMJhD3HOJxhlTQ7qd2r1ICwpxd7f7socgBdGncAHByKPn0m+A+180l5LIBuI/9V4K980tavqovqWQawXdRW1MxIyna9VHLdV5QsA1qy9b9Kgc6KOQ1C//dsGBf1OkYO6FasaxXqR1FPJIv9iyQ+/ZZPMXLGVa43nKKen5wBJ5E26KKtL1Vd4MhqKGgnmh0UKGIPq6Gob82iWB2WF+LiRgrodmguYG00Sf3eXLHSTaS5N3DGwlsCOa96r73Ym4e3bkVCJ7v/uvN4ydXGWhcp0iQVz13dVhXjnZS2UA+uDqLZRQHtAGbpO4fWTXD5R+Fn9YxVq21kgO5OhJ9/Ajg/KuKz1G85nU9QaSzglRQ+pSR86zfUJU3tAL12xMhEorQu2vJS1Q9b1gC9hyKv99jLbntyIBw+HX3KFDjgVjfI98gAbezm7uUoq9V+83LJ5QjJ6tGxek3o57Jpkopp0hb8AkhiO1+jwBGfDZtgw7XoCT6beaoeCaBXkZ9aRP+sPwePiESWIxmndLd2q7NzxSPsWv5ICchB7h57WnHADtBxBpWU6cyyl1vsZXF+FWqo2E7rodEMI7fooxQXe10zr/VCB7Qk9ytibQJ1mlciGqme30yZIokldjpqEPfmsST/k2yevYs5h/a+C73Yy269WejCCXDOR2CTW10/30MHdH+9dFHOlClpd9xycskCCYBeWXJPpLeanDbCyBnTOefhf+3zWZxqccdRZzFSzI+97AbEwehN18G73Or5+R4qoNvgEo21KgsProskPbeUEG8Y4oSpJxm8qNVnL73P1Wst4ZUijYOm8/GzsLXqyg+OxHJXlhdnXhNbNs400OCHn0Ht5dpjaE4g9/GPUvxHP7TUqhsaoLtfuMj/V1aydYokHXvXncd4E8SGlE0pdrJIvFolLUDuTaOddBQvuvy4xVHs1H4ZV0wPWYsofQh+51ePvew21kA4Mhx90odDSt4fGqDbyMtVsTvcJpCW73YbWrJabprnLZ5ZQCxgrqVepxHIZf7bqd3yLQ4pLdrR+euedeRdmnJ3h2Evu+35Jnj8WvTlbvW8fA8F0D3pd/9LoQZ6GTQNdeyuDwpdIqVkUztJCAGwOJREwtcqYiNvXnh7qiRNJb12UVpxZA6xy5Rix0v5gZUY86SkdZj2cm01WTMCpswEScdVVwkF0K1Ycr/5g3VREmNjp4wZZRLEQfTizOpsl15elZAAELn+V49NHhcrnKS00C6qdxRAEl+DnzN5p7WIkkfR2Mu1KR6E3jUbRtY7r7oB3Yo1Q6EerpeQONs72W+9aahU+9xUbFGvJcld1Ol7wuaT3Zm0F00lCB2i2di9lyW8k+KUu1vWQt7EiuOljSjtZTeeNaG/eS3UVv1cOqkL0I/CcQOxNivUGW7Epum70ya2o7GcibLWw20ilf+7ZUFd4ZhJ8UdMCFG97cAkklrMj3ovbcgY4oB0kszlU4ZaubuFP/JjKSp4VOUwuhT5VSseO6qxpV8LXTwNTr8ctgcdpy5AZ80RVmaSXbhhUAYmcY84KK1O7ZwSBkp9kY4lzePubwYa1u1IrzIxoPgm5MfTSVpH5QXvoIj8SeKgJMsQePpj6AuD0hCY+jVwxtFu6Xxc0MGTaFdr8/qhJ6xXJfyMGWVdu+whvccTW1aALeGpXmxrud99+sJP1Qx9dYpOE1/F2cvud3z0LkwbX1IQiFQ+HCVzffQtN7KGw7kzYb2PZseqBgZ0K9Y/KNTNQQZNso0X+9mNPlGxfznjak8b262vNH13A3WZVjkJkEsjAuyy86+cy0xSJMmPplu0nFuoaUlNX3Kn7UsbZc2h3oCgoyUVu0h1ioVkV6WeyxuBAL0GxvRIZyvZqfsfXfJBiwSopwQJQqlnvDjblh6uW93mqPKGQYsf/lUGAPUeX35QgoI6aXu5Fh9zaIbDxCBSOhCgW7GWKdTcMBY3zj6cwg2D0OAnCCVI/0m2KUXALbuvKiNnvTTJRZRNLfN9H+nVesEyCKjTYi/X4mcTetO1AeK8fQM6y9LZ6dw16EYN05YLSkOU7UR1FhPF6dVIr2OLv2HLoi/VdexUS3PwCuq02cu1+KfQnARXTIefeuWz1PMN6FasHynUtX4GSUtdp5cW66EvicCHeugN0raUpGGh5D6b7ksVFwfajmUPhnbhox5Qp9VerrUex6N/86c+0177AnQbvBWsraDyQTZG0m3CsJ/t5hBn4EPSPCznB5fMpJXJG8q5zKLIslKet8SBy3l10/h3V7HCKWw1zfaym5QeBu+/Gn7udd19Ajq7D8yFaT/bMbeREsR73TxJ1ZO1lOAgO1BXmkFZsJdr8XEw+sXrSi/OeCueAf0EjOjE+h9Qg711na5aXo9kglLdKC8nBp1/3O1qqd9yrPbClGmpOl8Ozh8tAd5/fBVs9NKHZ0C3kfss5L7ipdM01nF6aLxeWuU8VRw+9YZH1ktHf2xfC9S/XbaMNfPmNwRbhsLaWehJXibjCdDtkC92285v9dJpGuvYpYuth04D5Hq4F17bWqB+Yt58Ni9bFt5gCfWUh8IE9LDxcNCNBE+AbsX6mEL90K2ztH53yi4ZhF4D5CBci7aN03FkZ0cHj025lN3rA0VRRku0z96Ho795tYebWJ4A3UZeLl57Evk+6Yylehj2swFyLEsVaBA5Xx6x8JOce9c3qtof2LqV5RPPRcCd5TIIvf86GKaondHfFdAr4cxct7rtWjetDKvHfjZATuuqdtPV1XO5Qh6Hu3jZUsbOrQ5gFLVb1O9sF80pWHM/TOHBWvNwBWkjvIDhlG7IiTFpzgWW7U0ZLvVHeu4vlx+HGzh8OFeubufE8dWx+m0zP8K25cvDJSDm3obCr2ehzwoMaHGGFbB2KNRJMdMe2nBu6YZ6D2SAHBrbI+/o9e7H1KuCHU+aMIErVrczcNiwPjSIyv3jMW/LtOqdR+tRcPoH4A9ODK4pobPuDJNJ17qtU2aKAXLk+AttALGXd1LgUI0ex7a0cPHS+6tqiIQWSZ3lMgx9/zXgmJrWDdDLFap20umUc8cuXa8BcsoXzYG83vay2wymLn+Y0dOrt27WVe/j0PuvhxN8S+jH4ZQ81iugBrgxL83f7exnI5HTvGL2tFXay24zEHt61tYtVap39r3emtPgvR+C5+x44Cih28h9HHL3ujEuzd+d1G0TppnmVaumzcledpvF6BkzmPrwv1VVW7d4MesWhf7woxs5oX0fBg9dg77GJ6CzffZcyma5ZXNVKhy5ZP/MhPeExlzTUXQc8GIvu40uXu/TJlWHUIiDTKR1Fstg2H8d2lbttpXQrfA2hfVSls+ene4+S8oaCd43Jd0c8GMv15pJU3Mzs7b8rqpKlh1kkvzgDHj3ZfBi5cRsAZ31ixhOoZ5uienSvcX7D3V+7WU3zkxcdAcT76h+dk3CQrevrvv1GbfhI/k+HP39q2GOJ0Bn7WmbyknZRYaJI+yZCeeZW1GRbK/wOg1qL9eiQBxkM9avo2n06D7VBMwC6iyWQbB7NvpkV0CvLMWLWq9l6eG53pNyks7GEZbubRuGvVxrhk5n01mV0qJ2nwanXCnH8r1Klcqdxbeqek/ISTo/1fyOhsujnW6IeqeuALxKAYnHjrLIMVYjSemh6K/Ogs+5ATqTCfRlUkY6RwmHaPp+A10CczkeO5pRunttNCk9CP2b2RVJBPtIaA2qDesVhXpLlIyNqm+7VzHEdjbSOSqO19fvforsjvk9KTspndU47zy6ay70CfzqA+h2OKtIflN9y5Rca7uoMGM7J7cetUbeRZEDta/2RkK4k5SWJAhiT2fp3rSm9FD8e66GF8rM6gPoNqwWUEsj4WTEnTolMXhqzFjj2Y6Y9366j8terkXT9R17q0JCpX4WQV2ZyaQPoLP6xI0shl3ObXPu7Adq0deN016uNRunc2lpk7VkCJV3pCskdP5X+MzUH/02cB/ByRlmosLceRdXjSTsZae5jZo8mSvaVzlOPUugPg7dNRuOU5ScEW8+hdOKPKVTOn/OxbXIYY1jF+Yp7ymJM8yU5DmQlL3sNPNxCxdygU3+sd71s3KBQ86jz4S3T4NSfOsxCZ3l82e7FL2bb72dl5fck/xu7scUpMFetmN/LZW7d/2spAE+Cf3ZGfC1PoDOau4wpxRDxhmW7C9JWuxlOy44JT+wq5uFhAhDoW0WelqlhP6pQn0w2W3gf3Q7dVtePXxxxtX+OzMtQuFAmuxluwk5Xam0q5uF3N6DYOds9CkVEtraAerUUFY0xk7s1O1N826s6y3iGMlvuKEkUGR/AufLfhh5/d49yIUNryXtoJbkgXMgL46xkg3dDsOL5Pd6nWBa6jl5t426Hf8KpdVetuPEfF1yCPsq6U5d9GZaojKgLyyS/09fM0xBZbsUQyYjSfwLk2Z7uZIbkuZ3+rpjgVW+mJXmwJMR6Ns+AneVAJ3V/GF2GT1NqKevPVp35YPoUlrdXgcmdfcZZQduZ9BuYwuoV0w8161a7N+HoX94DVzXA+hsPuRuF7ttgkni20uS6P71lNvLldzwcgbtxsE0Bp40wYZr0RNKgM5ihhKn46pV2c467LaXUvFdLNDXKHAkFdT4I8LrGbRbr2kD9WB49Tr0aT0SuvQYXd/8LG4zSvi73WWMjjVreWHy1IQpa+zhO3vuLxfejEnK1IT9nEG7TezpW29j45IlbtVi+T4QffQGGKh+DNaJWG8olBXLyCENYpeZxNjPITHXoRuxl3dRQGcUzDItP2fQXriZlmgyCQEdAyNUOzQXyW/xQnya6py7uo3hky7pQ9KLM69h5/IVaSKzYWjJor1sx3y/Z9BeFjAt0WSnoi9RK8lPzpWOorNVLtVHqwg258/hr2GW7WU7bgQ5g3bjaloCT05A36qy+MKknUNMUg2tHV6V1dRtLcz3GhwQe/k1iqVH1Ruh1HMG7TZ/AfUPRpzoVi3S702ov1dt5BZC7q5IRwq58xGTJzGxvbVPr8YhFi6TG8FeruRIvWfQtTjcuW8fPxg+ItxF8NnbUPgPlcVbVnbJAE12Ep+rX6N6o9jLlVMM4wy6sk8Bsjyr89KyBxJ/hWMoPC0q97cV6hPhbYfoe7IDtPFw18/3RrOXKzkS1hn0gW3bjoFYIsfSUprQvxFA/0ihrk0LUV7oMB5uL1zyVyfr58teZlvPGXRaQdx73sejXxaVW17rqn5v0wuHEqpjB2gT8hl8MRrRXrbjRpAzaAke2bF6dSkjaNrLIPRe1Up+nYIJaSe2N312d6CfnXge+9dvyNI0UkFro9rLdswNcgZ9f4ZS7A1EHxYJnblMn3Zn0CaG29/vgzwOJ/HYh/01y3RtpzPoHWvWsG35CtvEgVkCdB5dkKdvMhfHbQBdH66O9pwvV4fm1Ndv2lv3TrC/bcUKfr98Rcm5VX4tww7wclUyC+q28D4nQbltZC/1kAF0cOgcLoE52/HYQWff1NzM0ObmEkDtnryxs7Gz9dysRrzcHQo1LCiTkmhnAB2M6x0Ukb+sJCMINsvgrbIPaEqAPqJQxwVnQ7wt7aLETFL92mvQH+3lILuyIQDdRl7WOzPFhH36W6r+ai/741J3bQPoIFyrs40BtHcG9md72TuX3qzZEIBuBJVblsQcW/XdwsZe9g/pRgG0cYr5X/vUtjD2cvClMYAOzru6Whovtz37jL1c17ZqFBu6Mc6hJfVQ3uZ5k47VaziwfgN716ylq6OjvhVPcWtjL9e/OLO2/A45q+5dshRYQk9gSUNEinlZzr2r17Bj2YPI3elGKsZeDmc17SLFshT6mUMXMxXLPWruHMYuudNWEvtZUpHUWxZ9kZfv/qafZqmra+zlcJck64AegO4UQP8CuCBc1oTbm+QQO2vpfci/YRa5nfWreQsyeUtL8ny9SoH+Fo8d5vr37ktUbVG5K0uWJPRA9AGJFEv1u9B2CfXDXtSsPT97pCceu5jh/Nhhr2G9/dnlG5NbWI9OnlJv17G1H9h9H9paplBzYxvVx0BnL72PUS1zaraQsE+xjcXxJX99fnUnjKdpwngkGGXQ6NoPg2xf9iCb5i3wQV0yVV+niNxhNvHY4fJ/9IwZTH343/p0mkFAv5raJIFuYJYsn2IHC5i9FAH16Qs/xcjpVzlWTzOoxV6WVx4PeZmsqeObA3b5xjbefTdPL7zVd19JNRgoOcXayH0Wcl9Jigi7ce3efS7Xk/efNy+8zTOQK/sXYI9d8g2axr/bdsqbb72dl5fckyZ2lPJiy5XHzlRR1VjEXLxsKWPn9lVU1y1ezLpFizMz0ePQPxdAfxxy96aFartY7TJtcty0eeHtdZ8ny3m1eMvFa25X0pSfzNjL8ezMRogSG4z+YaqewhGgnb/uOQY1V9u7UeTdtnvwTrbPka3beGbieXX/cNS7FY29XC8Hvbe3O7L68Zi3cWDrVu+dJFxzCPqLqXqszi7ftvAoCjCXee8E6iTzfBt7OV5k2D2Rk4aXMPxyYSh6Ts/70MnfiRbpfNGWzVVBI2IzPzPhPX7n5qv++eufr7KpJfhEHr+LO1zU2Mu+li6UymNbWrh46f19+sqah1uIH4wen5oH352kcxwvSto9ficMiltKG3s5FHz67qQRHGISx/02GFCW0Ikn27fLtR2lql256naqt9jST415h+8NEqSBsZeDcC2cNtPXvYCo3b1LWt589jpDhX5jPgwqATrp4BInCRmHdC4zbFBzc0nlryxRJ/A39rLXLRtNPaeQT3ka1i4zaDRU1N/rAPTLc+DMHgmd7Fm0nbodh+1cyUY7WzrKc2ljL9e/kevtwc5+3rNhA8snTKy361jbD0K3zYZpPRI6f7mCx2KloNdgdm9VRQkkp3naBbTsXPEIL864OnTWGHs5dJYG6tDOfs5ahFiPQ+wb18HtJUCvhZFHyb8WiCMhNLKzn5MI7rALapEbWaJ2h1n2U2S3iccOk6WB+7J77ypr9rNM/nj09D+FR0qAlpLkCxppSSkkR2eX7N1ZtTnCTEC4iyIHyFTm5MBgSXtDuwsZQnOWrkyWeZxDj5gHHccAneQ1yrQAWpgTFS2FnvvLJh47PTC3U7flzau2GTPTQ6QHShS6cz6UHsvoBej81xT8pYf2oVeJCkRBCI2CljfQpWQE5v5ykBWJro2duv3EvPlsXrYsukEj6HkAeuMc+OMKQFszFOrhCMZz7TIKELkO6lAhbFqMvRx0JaJt56RuZ+24Srg0GH3/dVC6zH9MQrfDaUXy26Nlo33vdiBaO2Jk7GGXTmfRQW1oYy8nsZu8jTl1+cOMnj69T+UsqtsygUHoD82GR/sAWv4jqbei7Y6tXpx5DZKaN84ycsZ0znn4X/sMKYkUXpg81RcZxl72xa7AlSW667RJk2hqHs2JFZFe0qnclNqzfgMSl937jWenYJIsercVWjfBkFlwuArQSUWM2YVdSkZOSWQQZ5HEB2fc8sk+Q/oNPzX2crQrJmAcd8unEJW5Mod2rZEF3PK4+8a772Fsy1wm3nFHn+pZvF0lE8ijd82FkeXJHFO5uyV0MskO7BIBxhlHXWaG3Xm4nwSCxl6ODswC3ol3fAGJ7Kq3SEjnwIpHGbIYTCJ8GIBePQeOZTLsA+h2+OMi+RfrZZjf9k62a5zBJU6ZUrzGkxt72e+qe68v0lRyfkVZspbMoMyLgeibb4Dv2ErotNnRkgBQQB1HmdjeWsoO2rt4Cfs09nJ0qyNS9Ir2VVU3ocIeMavOMLGfj8KIm2GfI6Bbsb6tUJ8Im2lu/Tnl347DOWbnDBN63dRtYy+7rWrw7+LwkrS6bnayOLy2r15dcn71vh0lPwYnThiP5NsWx1mtIu0em3JpH8dZcMrjazkAvWMOjOo9Yh+VWz60ktx59EVbX6rKny0ZQ56Z+F6ORJTbSdT989c9W5UpRfJ9P9XsfBfa2MvRbVwBs0jmSju3PKI4sDYuWcLmZQ94yvkl/YxbeAvjFi5k4LBhtoRnEdSD0A/NhmtqArodhhewdihUKZQszuIkKeWChKjeYacDkthtUbXtntipZb8bezm6XVuR4NkAABKPSURBVOGmZovzSlLrBrmrXAZ2pYe7PBvxhC+feG6gvqPjiHPPA9BT58CqmoCWj23kE8tgcs7yh2yT4YcN6lpgdrKd5b0KyY99JInV6ydjipotR1KVRaSyxFiLel1vKWkAq9ttpbX0L+p3+ovumg8DleQe6lWqVG75torc5zS5LycxqVKywK0vkbdRjeQo68WZV9f9uJxI5HMefsg2XbCo2s9MqE7h29kTj10w70lFti3skg3IYALmxyZPCdXGFdt82vKHOXF89QOIT996W0mlT3PJo5+fC1X3em0BvQbGdmH9GpTt96gnKoCbuLrNFtQytrxsIQn8/Krg8mMx5o7PI4kM7ErXvn2smzy16gfjIJpdFOQ57ain3m/7F3VYXn+stJujAHOZyU6SWtR5OcYKotbHtYAD0H8+B/6hcjzHHdpG/mng/LgIrBzHyZ4u1xMw71z+CK/cfY+rxB4+6RLEiz5yxlWOb0s7gVkehnvd3F+OfBvYvS1VMv9mfqQU4RVVsXt1UsZK8zM4OXShCCMWwH4fgM4thNxdUTHSS79ukro3uMXGFpW87A0X77W8wFF5tuxVMht72csKhVfH7ipjXOfDdvei0yylB6DXzYFz7bjvKKG7b19Zf0hK7S4TK6A+e9n9jo/L1bulJBnhL2dc3edYzNjL9XLVX3sn2zmu6K2Sur91S5WTLK13oy30zS29osN6c7umUdhK/gkF7/e3PNHUdkrEX89odon0jb1cD0eDtbW7yrj5gQd4omVesA4DtMpO9hItyuNwO3Vbpl0T0G1YLaCWBuBPJE1EjR6z6POOr0b6HbQS0MZe9svBcOqnIVGf3ftWMru05RfLo9fNdVC3XQH9OAyxsP5HoezDa8JZT9+9iLdanGYnz7iq5gPux2zsfd2hrnZHYZLRc9/6DeZ82fcqhNMgTUC6vmNvldotZ9JhnH2Hwy3IoWfOA0cvoes5TFJ3pP0wQBxfAvKmCX3PFA+UHGVbS15wJ6/54VJ00EQOdxyLb/cztKlbJwfsUgEl9VCc3RvRabKjc+hDLdBUGUzi2YaWiu1wYZH8f9a5bqlo7vR0rByLyPGIKfFzwO64Kqm7yXa0pOn4aiD6vhvgxlqr5CqhpXEb+fVAdUhN/Otf14ilB+XXP1d1AUQ6TWoT1TWhBmicJhCliZbqpdU6D81z4fchADr3Scjd0wD7hyETxiM5zAbYhJamSb1qBF57mUOaQJQmWip55+YMK9f3JKGfg+M7sF5WqBO9LFJa6xxFs4MCb2uZV/XAd5nmFRPPDTVmOK28SAtdaQJRmmipXB+FnjEfXLNmegJ0j9r9VeCv0rIR/NJxGF3yZJfjse3OHaXPLN6L9cuLNNWXO8oX3PWNPiTFFSFWyYcLltzFuFtu6fO/02BD59B7WuDkWs4wXxJaKrfD6UWsLaDyadoQXmjpoIj8VR6723k1Dai9cDS8Onax1JJyVzSluIvdfog6ltzLHPPoz86Fr3mp61lCS2dZOMLqPWm5KCpSuZSw2KZIyJ8sot0VOiOpvWyf+uvIGkhgSWVJ4gWL+aUgrL4leRNMvzEURpTzbrtx3BegV8I5OfK/dOs0Dd/FXn6NIkddiHGK4zWSOr5VlDjqptGj+wwYt4PSLp48Dbm68+hvzgX7+742S+QL0D1SerlC9X1DJL619zRSpb3s1qhWBgsjqd24V/93O9s1brVbcpiJ+t+7xB1PXs1JXRgEI2fDXq9c9g3olTAxR/4FrwPEXc/JXnajw4DajUPRfXcK/4wr7NLpTnTS9nMO/U/z4Ho/nPcN6LRKaTd72QtT3EAtqWmy9tSol3mnoc6M9euqfBlxJe2bvu6FqtzfB7Zt48fNYxJjjUIXCvDWm+BVP0QEAnRb6baH9VzSd6XLE/VqL3thTC1QS/unF95aiiozJVwOOD3vKj+gYk9HVZwypcRtw1fOz0L/Qwv8ud95BwK0DNKG9RCoxAOg/drLXhjkBmrZZCKt05xzyss801bH6RgxKnA5JVbYs2EDyydMTJA9urMLTun9IoZXYuoANKM11q+TyN9dnlxQe9kLc2plhZT24rR5ct58E1XmhZke6zjZ0tI8bFA7gVnGist2d2KLhf56C3zGI9v6VAsM6G5bOv81BX8ZZOB62oRhL3sZv9Y5tbQXCW3sai+c9F7HzuNdbi2pddct/mLdmlGtx++SjgxT6INH4a1BpLPwqS5A/wJOOIj1Eqhj79N6X7pgNcO0l71S4BQmWm4v1y9FghgV3CtHq+vJj6c8FyuhoLWKOMqE10GSDog3+/y7vuH4+F1SIae955tDL5wHgZ00dQFaCInzTekjPcnuk8iPbRdz3HshBMyy0cJOOVt6dG38eMSua9QfDAHaxUvvd32Yrje/xeT57yV3IyCsxRfh3+jp03lHy9yqc+be/Ql/H508JVEeW+gtx8PYWSCPmgYqdQO6G9TR35d+nSKS86tOpSIQk8qN3JxlUk8ALWq4SJIwSjngoaTeL7wVCXZolOJVKrvNV8At/Nmxes2xqvLypPhBZM3civwoSELCpH8wc+jz58GzbvTW+h4KoNvhvCL5ughxIlLs5Z0UOFTPLENsK5tQVHD51XcqsjE2Lrm7dLxV7yapjC+WzfvMrbcFUjlDZEPdXY2dOxexl51emJQBJBXRtuUrqm5j1T14rw6StpnLpFjolS3wgXrnFgqgu6W09V1QNdOj+CW2q+dyRaffhjHUFxVczjCdnicVEkRKy0uJ9UhVuwsD0rccnYmDKCxNIAaWlYbwql73fl9KpKyA3+2dZz9zEBVbNJ4gtrifcbzV1QUFY+bDy97qO9cKDdDtcHIRaxOok+slStqLvSw3pYr1+e3CIMWxD1HpLlm21HWjBQW29C/vPcWhCUTKqB4gT7jjCzXtWKFBgCbqr2gilUWOmuSdZ7vbcV7plwiw0o/ssmVem0Rez0L/bUtIuQZCA3SPlA4lj3ca7GU/q+hFWgeR2E4xxpW0Bf3B8DPHoHVFtXZzSEnfcrNJgObl1UeR2NKnRJdV3tKyo1NALJL4pWUPpEQiv0llDr11CLxzFoSiiIYK6G5Q558E3hdkA6TNXvYzB7EFRS2UDexWyja2qOK1VGavgC6PJ5tW7Gs76eZGU5jfhRfCB5GmomW4FeGDqL9B/A0ylgD8xAkTGDj8zfTxnR372LN+Pfu3bk2xWaJly09cABvceOT1ewSA5u0aa4NCDfFKhNRLs73sZx5+7T3xiovkEE+rnYopxzl+S1KhqeIoPHPGdEQ19lLE6SVSOR12rBeKw62TQ989D2ofvPscMnRAd0vp3Mchd69XWrJgL3udS7meSFdxmnl15Ih0EnD/fvmKY+B2ujjghZayFiBe3ChLSf2dO6db/fUgjYUWUYFFIod9Zh/lPMPuO2xVu0xfJICWzluxfqpQH3RjRNbsZbf5VH73C2xpL2AUqSXqZOWle7/ji0ovHuOwwFMO1Dht8qQSiGsdO1XSKg4vOc5Lk0PKLz/DqR++qh05oNfCqE6s5xVqlB0TsmwvB1lUAea7Ft5S8/w6SL9e28gPhESy+T3mKtmn48cjABY71UugRiVN/V21ruRHDv2lefAFr2vnp15kElqIWIX1IY36SSVBjWIv+2F0ua6opeIsEjuz1hl2kL69tLG74FA2C4Y2N5fUZj9RVk5jitdaJLFIZL8/Il7mkd06uu1l+MAiSmGPoZdIAS3UtpFfBNxRprwR7eWgqyKgFidSraizoH0n1U6ce+IHMGq1rV66Kwdj50FHVOsTOaA15NqwHlGoDzW6vRx0kUp26YwZmQV3GcRipwc5egrKtyy10+iihvNvguejpDtyQAvxK2HYfnK/24vO9FM6US5Eue+yI0xs1spXHOIY38sY4qUW8MplCLHNDYi9cE1/egHc6aVmPXViAbQQ2Ap/8gfUk0flzWpTPHHAKY7bU+MQK4lTS4C7Z/2GUtCKsYn9Mlf/bAG4nvj47dWufmyAlsH/Heum3RS+U0hxfHYYTA2jD79RYvWMKQ4siaqSUg7yEOmb7iiremYcX9sceuMQeK/Xly/qpSxWQAuxj5D7u10UP51EkoJ6mRVn+6gBXVabJUot6VDROPka51g59I5OOOdm2BXXuLEDWib2EOo/OuDKuCaZxXGiALRI4nKoaX8Nt4xvL+g3cnDOPNgc35gJpf8Qz/f/Q23cD2fFOdksjVVP2GflPOXyQymkdPnyLLEgs7T2eLQvv6nkD463JCKhZYryiPxvUVsOwCnxTjkbo9ULaHOUlNw6K/T8+bA0CQoSA7RMVpIibEe9dBjevPeWBBdSOGYQQEus9Ga5ubV8ufFEJ7SmOfTt86DvC/Yx0pIooGWeK+HMnaiNh6EpxnmnfiinVyQqCRfnlkRlCZDNcVKyyxpm5pGgM0kc0EL4E/BHv0e9eAQGBp1Io7WrBehynLTxUKdn1S300haI7hEuj1NNBaCF1sfhgp2oJ9+AvEfaG7paJaDLHmrj3Erfsiv0w7+Ha6K6cOFnxqkBtBD9H3DBPtTaw0ZSl25jSbYSc9nBz3aOv65CrxwDV07pTrqTeEkVoIUbq+A9O1A/PwzHJc4dQ4DhQA0O5NAPNcPH0gJmITV1gBai1sK7/oB67iAMNjvKcCCNHBAwt8BHFUiujtSUVAJauLMGxu5APXvAHGmlZrMYQro5oND3z4Mb0wbm1Ero8sZphVP3oF7YD28xm8lwIB0c0N9dAH+WDlqqqUithC6TKhFlL6Oe2oMen1ILIa1ra+gKkQO6W7P+6xvhKyF2G3pXqQe0zPjHYA3GenAPxetS4UoMfRlMh+nmgO4swp/eBP+WbjozJvIeJ/c3O9FfeiPtXDX0NRAHdEcRpkWdOigshmVCQveebCv5y3dTWHHAnFWHtQdMPw4cUGi5+nj5fHB+MTBl3MscoIV/7XBWB7kn91A8KWNKRsqW35DjzAHd1gVX3wz7ssSlTAJaGNwKJx0h176L4jkmpVGWtly6aZW7zMDnFsDfpfFYyo17mQV0eWI/xfrWbop/ccRtpua74YALBxR6ZwGuyIq9bDedzANaJrUS3r8X9ch+9AijghvcBuFADv3vh+C6v4ADQdqnpU1DALrHrm56HfWTvehJRgVPy/bKAh36qIJPzIfvZYFaNxobBtDliT6GNbeD4j8eMpc73Na+33/PoX+j4MoW+G2jMKPhAC0LsxZG7kI9sg99YTGd908aZf9kdh4Kfc98uCWzE3AgvCEBXZ7ro1jz91G895A5s260fRt4Pjn0rzTMng8vBO4kxQ0bGtDC95/BWw6hHtoPF3ameCEMaVFzQB/R8JlX4O/TkFkkqtk2PKDLjGvD+vDr6Ps6KI40anhU2ymd/VroRzTcPA92pJPC8KjqN4AWlj0Kx1nkF+2n8Ol96Lw54gpvI6Wxpxx6u4br55cS4fSP0q8A/aa05u1Hse7toHjZwf6xzv1slvpoDr48Dxb1s4n3bxfwKnjfYXLf3oseb25wNcLW1105uK8T/ibOB+LSxLl+KaErF6AN64qD6Hs70KOPpml1DC0eOXAMyItvhu0eGzVkNQPoXsvahnXD6+i/ex19qkmkkI39rtAPHIXP9Xcgl1fLALpi38rLmKuwpu9H/+0B9DuMKp4+YMuNKAU/zMNfz4Xfp4/C5CgygK7B+1bylx2m+NX96HMPJ7dGZuQeDij0YQX3K7irkcI1w1xgA2gP3FwF73wD628OUJx1ED3QXP7wwLQQq+TQv9PwlSb4p1lgfltr8NYA2sfGexKGHiY39wh85iD6zENILkjDQh8s9FFVFyx4rACLF5SeEzfFCwfMbvTCJZs6bXBRAWv+IfTHDqKHmAQLARlZ0UySDChY0gnf6a9HT/Vw0gC6Hu71tG3DmtkFNx1CX3EAjYkZ98dUhX5Nwb8U4F8WwFNZTP3jb8bR1TaADpG3v4ATDmFdfgRuOEhx2mEYZM617RmcQ2/T8H0N/7oANoS4DP26KwPoCJd/FdaVb8B1R9DTjqBPPYKmf18M0S8JiC348Tz4VYSs77ddG0DHtPQrYZiF9b7X4dpOiu87CmceRQ9oVI+5Qr9hwaYC/EzDzxX853zYGRO7++0wBtAJLb0G1Q5/1ElOpPcVR1ETu9CnHYVcFtV0C71Vwboi/KwI7Qvg1wmxtl8PawCdsuWXCyOQG3cY9f4uiuO7UG/rgqajaLrQJCnRFaVbTNsV/AZ4vguezsEmoz6nZxMZQKdnLRwpeQJGHIV3aay3aPTIN+DtBVRzgeJbC3ByAYZoGFSAgUUYUERbRci52euqO4RSsl525uAQcFDDfgUdGnZreA3YUoQXCvCrm+CVDLCrX5P4/wFp/svydb+YHwAAAABJRU5ErkJggg==
+    mediatype: image/png
+  keywords: ['tektoncd', 'openshift', 'build', 'pipeline']
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - name: installs.tekton.dev
+      version: v1alpha1
+      kind: Install
+      displayName: OpenShift Pipelines Install
+      description: OpenShift Pipelines is a cloud-native CI/CD solution for building pipelines using Tekton concepts which run natively on OpenShift and Kubernetes.
+      resources:
+      - kind: clusterroles
+        version: v1
+      - kind: customresourcedefinitions
+        version: v1beta1
+      - kind: deployments
+        version: v1beta1
+      - kind: podsecuritypolicies
+        version: v1beta1
+      - kind: clusterrolebindings
+        version: v1beta1
+      - kind: services
+        version: v1
+      - kind: pods
+        version: v1
+      - kind: configmaps
+        version: v1
+      - kind: installs
+        version: v1alpha1
+      - kind: namespaces
+        version: v1
+      - kind: serviceaccounts
+        version: v1
+      specDescriptors: []
+      statusDescriptors:
+      - description: List of resources installed by the operator for this cr
+        displayName: Installed Resources
+        path: resources
+      - description: Version of Tekton Pipeline installed
+        displayName: Tekton Pipeline Version
+        path: version
+  description: |
+    # OpenShift Pipelines
+    OpenShift Pipelines is a cloud-native continuous integration and delivery (CI/CD) solution for building pipelines using [Tekton](https://tekton.dev). Tekton is a flexible Kubernetes-native open-source CI/CD framework which enables automating deployments across multiple platforms (Kubernetes, serverless, VMs, etc) by abstracting away the underlying details. 
+
+    ## Features
+    * Standard CI/CD pipelines definition
+    * Build images with Kubernetes tools such as S2I, Buildah, Buildpacks, Kaniko, etc
+    * Deploy applications to multiple platforms such as Kubernetes, serverless and VMs
+    * Easy to extend and integrate with existing tools
+    * Scale pipelines on-demand
+    * Portable across any Kubernetes platform
+    * Designed for microservices and decentralised team
+    * Integrated with OpenShift Developer Console
+
+    ## Installation
+    _OpenShift Pipelines Operator_ gets installed into a single namespace which would then install _OpenShift Pipelines_ in the `tekton-pipelines` namespace. _OpenShift Pipelines_ is however cluster-wide and can run pipelines created in any namespace.
+
+    ## Getting Started
+    In order to get familiar with _OpenShift Pipelines_ concepts and create your first pipeline, follow the [OpenShift Pipelines Tutorial](https://github.com/openshift/pipelines-tutorial).
+  displayName: OpenShift Pipelines Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - tekton.dev
+          resources:
+          - '*'
+          - installs
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - build.knative.dev
+          resources:
+          - builds
+          - buildtemplates
+          - clusterbuildtemplates
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - deployments/finalizers
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - get
+          - create
+          - update
+          - use
+        serviceAccountName: openshift-pipelines-operator
+      deployments:
+      - name: openshift-pipelines-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: openshift-pipelines-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: openshift-pipelines-operator
+            spec:
+              containers:
+              - command:
+                - openshift-pipelines-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: openshift-pipelines-operator
+                image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-1
+                imagePullPolicy: Always
+                name: openshift-pipelines-operator
+                resources: {}
+              serviceAccountName: openshift-pipelines-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces


### PR DESCRIPTION
    `openshift-pipelines-operator` provides an easy way to install and
    unintall Openshift Pipelines which is a cloud-native CI/CD solution
    for building pipelines using [Tekton](https://tekton.dev).

    Operator provides an `Install` CRD to allow installation and
    uninstallation of Openshift pipelines.

Signed-off-by: Nikhil Thomas <nikhilthomas1@gmail.com>