### PR TITLE
Elastic Cloud operator: broken readme links

### DIFF
--- a/upstream-community-operators/elastic-cloud/elastic-cloud-eck.v0.8.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/elastic-cloud/elastic-cloud-eck.v0.8.0.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ spec:
       mediatype: image/png
   links:
     - name: Documentation
-      url: 'https://www.elastic.co/guide/en/k8s/0.8/index.html'
+      url: 'https://www.elastic.co/guide/en/cloud-on-k8s/0.8/index.html'
   installModes:
     - type: OwnNamespace
       supported: true
@@ -206,5 +206,5 @@ spec:
 
     *  Kubernetes: 1.11+
 
-    See the [Quickstart](https://www.elastic.co/guide/en/k8s/0.8/index.html) to get started with ECK.
+    See the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/0.8/index.html) to get started with ECK.
 


### PR DESCRIPTION
The documentation links have changed since submitting the operator. 