### PR TITLE
Make the CSI provisioner tag optional, this will prevent user errors.

### DIFF
--- a/upstream-community-operators/robin-operator/robin-operator.v5.1.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/robin-operator/robin-operator.v5.1.1.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
          Robin Storage operator enables advanced data management capabilities to Kubernetes apps like snapshot,clone,rollback,backup,restore,import,etc.
       support: https://robin.io/support/
       alm-examples: >-
-          [{ "apiVersion": "robin.io/v1alpha1", "kind": "RobinCluster", "metadata": { "name": "robin", "namespace": "placeholder" }, "spec": { "host_type": "physical", "image_robin": "robinsys/robin-storage:5.1.1", "k8s_provider": "openshift", "source": "operatorhub", "image_provisioner": "robinsys/csi-provisioner:v1.0.0_robin"} } ]
+          [{ "apiVersion": "robin.io/v1alpha1", "kind": "RobinCluster", "metadata": { "name": "robin", "namespace": "placeholder" }, "spec": { "host_type": "physical", "image_robin": "robinsys/robin-storage:5.1.1", "k8s_provider": "openshift", "source": "operatorhub", "image_provisioner": "robinsys/csi-provisioner"} } ]
 spec:
   displayName: Robin Storage
   keywords: 
@@ -229,7 +229,7 @@ spec:
         path: image_robin
         x-descriptors:
         - "urn:alm:descriptor:com.tectonic.ui:label"
-      - description: Robin Storage Provisioner Image (Use robinsys/csi-provisioner with tag v1.0.0_robin for k8s version >= 1.13, v0.4.1_robin for k8s version v1.11-12)
+      - description: CSI Provisioner Image (Use robinsys/csi-provisioner, tag is optional, if specified should be based on the k8s version. k8s version < 1.13 use v0.4.1_robin. k8s version >= 1.13 use v1.0.0_robin)
         displayName: Provisioner Image
         path: image_provisioner
         x-descriptors:


### PR DESCRIPTION
Operator will figure out the right version of CSI provisioner image
based on the K8s version on which Robin storage is being installed.