### PR TITLE
Correcting provider name for knative operators

### DIFF
--- a/community-operators/knative-eventing-operator/knative-eventing-operator.v0.6.0.clusterserviceversion.yaml
+++ b/community-operators/knative-eventing-operator/knative-eventing-operator.v0.6.0.clusterserviceversion.yaml
@@ -171,5 +171,5 @@ spec:
     name: Knative team
   maturity: alpha
   provider:
-    name: Knative Community
+    name: Red Hat
   version: 0.6.0

--- a/community-operators/knative-serving-operator/knative-serving-operator.v0.6.0.clusterserviceversion.yaml
+++ b/community-operators/knative-serving-operator/knative-serving-operator.v0.6.0.clusterserviceversion.yaml
@@ -200,6 +200,6 @@ spec:
     name: Knative Team
   maturity: alpha
   provider:
-    name: Knative Community
+    name: Red Hat
   replaces: knative-serving-operator.v0.5.2
   version: 0.6.0


### PR DESCRIPTION
The images these operators install are based on Red Hat's UBI rather
than the published upstream images. CSV's for the latter will reside
in `upstream-community-operators` eventually.
