### PR TITLE
Update Federator.ai operator to v4.1.20

### DIFF
--- a/upstream-community-operators/federatorai/federatorai-AlamedaService.crd.yaml
+++ b/upstream-community-operators/federatorai/federatorai-AlamedaService.crd.yaml
@@ -10,5 +10,21 @@ spec:
     plural: alamedaservices
     singular: alamedaservice
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
   version: v1alpha1
-
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/upstream-community-operators/federatorai/federatorai.package.yaml
+++ b/upstream-community-operators/federatorai/federatorai.package.yaml
@@ -1,5 +1,4 @@
 packageName: federatorai
 channels:
-- name: alpha
-  currentCSV: federatorai.v0.1.0
-
+- name: stable
+  currentCSV: federatorai.v4.1.20

--- a/upstream-community-operators/federatorai/federatorai.v4.1.20.clusterserviceversion.yaml
+++ b/upstream-community-operators/federatorai/federatorai.v4.1.20.clusterserviceversion.yaml
@@ -1,0 +1,360 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: federatorai.v4.1.20
+  namespace: placeholder
+  annotations:
+    capabilities: Auto Pilot
+    categories: "AI/Machine Learning, OpenShift Optional"
+    certified: "false"
+    repository: https://quay.io/repository/prophetstor/federatorai-operator-ubi
+    containerImage: quay.io/prophetstor/federatorai-operator-ubi:v4.1.20
+    createdAt: 2019-06-30T10:00:00Z
+    description: Federator.ai Operator provides easy configuration and management of AI-based Kubernetes resource orchestrator
+    support: ProphetStor Data Services, Inc.
+    alm-examples: >-
+        [{"apiVersion":"federatorai.containers.ai/v1alpha1","kind":"AlamedaService","metadata":{"name":"my-alamedaservice"},"spec":{"selfDriving":false,"enableExecution":true,"enableGui":true,"version":"v4.1.39","prometheusService":"https://prometheus-k8s.openshift-monitoring:9091","storages":[{"usage":"log","type":"ephemeral"},{"usage":"data","type":"ephemeral"}]}}]
+spec:
+  replaces: federatorai.v0.1.0
+  version: 4.1.20
+  maturity: stable
+  displayName: Federator.ai
+  description: |
+    **Federator.ai**, ProphetStor's Artificial Intelligence for IT Operations (AIOps) platform, provides intelligence to orchestrate container resources on top of VMs (virtual machines) or bare metal, allowing users to operate applications without the need to manage the underlying computing resources. It aims to provide optimal resource planning recommendations that will help enterprises make better decisions. The benefits of **Federator.ai** include:
+    - Up to 60% resource savings
+    - Increased operational efficiency
+    - Reduced manual configuration time with digital intelligence
+
+    For more information, visit our [website](https://www.prophetstor.com/federator-ai/federator-ai-for-openshift/) and [github](https://github.com/containers-ai/federatorai-operator).
+
+    **Federator.ai Operator** is an Operator that manages **Federator.ai** components for an OpenShift cluster. Once installed, it provides the following features:
+    - **Create/Clean up**: Launch **Federator.ai** components using the Operator.
+    - **Easy Configuration**: Easily configure data source of Prometheus and enable/disable add-on components, such as GUI, and predictive autoscaling.
+    - **Pod Scaling Recommendation/Autoscaling**: Use provided CRD to setup target pods and desired policies for scaling recommendation and autoscaling.
+
+    ### Prerequisite
+    **Federator.ai** requires a Prometheus datasource to get historical metrics of pods and nodes. When launching **Federator.ai** components, Prometheus connection settings need to be provided.
+
+    ### Common Configurations
+        apiVersion: federatorai.containers.ai/v1alpha1
+        kind: AlamedaService
+        metadata:
+          name: my-alamedaservice
+        spec:
+          # experimental feature, set true to enable
+          selfDriving: false
+          enableExecution: true
+          enableGui: true
+          version: v4.1.39
+          prometheusService: https://prometheus-k8s.openshift-monitoring:9091
+          # storages is optional. Omit this field if not needed.
+          storages:
+            - usage: log       # the supported usages are log and data
+              type: ephemeral  # the supported types are ephemeral and pvc
+            - usage: data
+              type: ephemeral
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAACWCAMAAACsAjcrAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAC91BMVEUAAAD9/v3r78n09PTx8fHu7u719fX29vba2tpiZWLc3Nzf39/b4p/DxMPHx8fLy8zO13zExcTIyMjMzM3G0WjH0mrr78rIx8js8M3a29r19PXd3N329+X5+fn4+Pj6+/L5+vDs8M7s78v4+u3H0Wj///65x0T///25x0X+/f66x0b9/vy3xT7I0mvI0mrI02vU3Ir9/v3K1HHr78nCzlzM1nXM1nbX3pPL1XP09+L19fXz8/Px8fHx8fHx8fHx8fHv8O/t7e3s7Ozs7Ozy8vL9/f3+/v/r6+zm5ubm5ubm5ubw8PD+/v3f39/W1tbQ0NDf4N/x8fHKysrT09P9/f+8vL3MzM34+Pje5ajQ2YHE0GPF0GXF0GTd5KTMzcy9vr3b3Nv////x8fG5ubnu7+6UlJaurrD09PTS24i/y1S+v766urrv7++WlpiwsLH09PXL1XW1wzrM1ne2xT22xD3v8O+6ubqVlZevr7HL1XT19+TMzszc3Nzv7u/X35T19+Tg4ODW19bh4eHy8fLMzMzU09T19PW9vb7Ozs75+fj3+On19+T19+X29+X6+vr4+Pj29vb29vb29vb29vb29vb19fXz9PPz8/P09PT39/f8/Pz9/f3z8/Pw8PDw8PDw8PD29vb+/v76+/Hu8tPq7sXq7sbP2H62xD35+u/s8Mzm67zn673n7L7g5q61wzns8Mzq7sfr78n4+ezDzl22xDy3xD23xT+1wzeltg6mtxCmtxK0wzmltw+mtxGnuBOmuBOnuBXPz8/P0M++vr6/vr+/v7+qqqupqaqys7K1trWzs7OXlpeYl5iZmJl3d3l2dnivvyuwwC2wwCzR2oSztLO2t7a1tLWamZqbmpt5eXt4eHqktQultg2ktg3K1HHL1XO0wziltg+0tLS1wzjR2oPH0mnH0mrR0dHAv8DAwMCrq62rq6zBzVmtvSSuvieuviWouRa7yEi9yk+ouRepuhqpuhnN13jn7MDg5qvh5q3h5qzt8M////9HTZ/9AAAAs3RSTlMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7ArsCuwK7Av7r5+upAfIxCQsLCPEnBWZ9e3cWA2F9e2EDAVp+e31mBQvT/nxD6cgCu9MLFoaOjo6OC9O7AnXIBbvTCyfx08gFu9MLJ/En8fEFyLvT8ScLuwXDFgvThkvtyAW70wuOjpBBBnWPjogaA2+QjpBvAwFokI6PdQYCBQUFK/JY3tvb2+H9ZmZmZjqy/PcAAAABYktHRGGysEyGAAAACXBIWXMAAAGQAAABkABW8NvoAAACuklEQVR42u3cVVQUURzH8RUUA1tssVHADgxs7EbEVhQLC2ywu7s7UbC7WGRRUbAQOxCMtVuxxRefFnc8d/+Mc9T5z/H3fb73nv/nzOudqztw8JDSDhd10PHpSIheaaHFiqs9vVlHwwxKC3d0Unt6QAABBBBA1A4QQAABBBBAAAEEEEAA+Z8gx1hDQsNld9y5hNrTW4boS5YqLbcyZcupPT0BKV+hoovMKlVOofb0BKRKVSu1RwIEEFYBwi1AuAUItwDhFiDcAoRbgHCLgFi7Vqteg6hmrZSiE1PVruNWl8itXn0b0b4GDRs1JmrStFlqhZA0zVuciCBq6Z5WdKJ1K4+Tp4giW7umE+3zbBN1miiqbTtb09L07Tt07GRe5y4UJINX1zNUZ7t5CyHdz52PJrrQo2dGIaRXzEWimN4+mUxLM/fpe+myeVeuUpAsXv2uUV23BLkRfZPoVv8BWYUQ39jbRLF+A7OZltoNGhwXb96du9qEZB8yNEQytuGeViHDpBA9IIAAAggggAACCCCAAAIIIIAAAggggAACCCCAAAIIIIAAAggggAACCCCAaBsy/G9A7hslj38Z/wTkAQ3xt/BFAmjICBryUPriWdjIUTmSIKOTgYxR9kX8x+YU7XNIBuLnQ0IePX4iadz4XKbluSdMpK40RjydJJpHl2fylMhnRM+nTssrhEx/8ZJqxkxbCjJrtqQ5c/MlnWw/b/6ChUSLFguvfdosWbpsOdGKlavyi/atXrN2HdH6DRvtKYgmA4RbgHALEG4Bwi1AuAUItwDhFiDcAuRfVCBw0+YgmXkHb+ELKbh12/YdMtu5a7eRLaTQnlev38jt7TsDW4jV3oRf/i38jQABBBBAAAEEEEAAAQQQQAABBBBAAAFEixADI0jhfe8/fFTap89qj/+zIvu/fP2msMTE7z8AofGIUB1IPooAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDMtMTRUMTc6MDA6NTIrMDE6MDCjbINkAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAzLTE0VDE3OjAwOjUyKzAxOjAw0jE72AAAACB0RVh0cGRmOkhpUmVzQm91bmRpbmdCb3gANDA4eDI2NiswKzDr8x6EAAAAHXRFWHRwZGY6U3BvdENvbG9yLTAAUEFOVE9ORSA0MjEgQx6zNCoAAAAldEVYdHBkZjpTcG90Q29sb3ItMQBQQU5UT05FIENvb2wgR3JheSA3IEOzNDMdAAAAJXRFWHRwZGY6U3BvdENvbG9yLTIAUEFOVE9ORSBDb29sIEdyYXkgOSBDz08nKgAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNQ1Ag1dMAAAAAElFTkSuQmCC
+    mediatype: image/png
+  keywords: ['AI', 'Resource Orchestration', 'NoOps']
+  maintainers:
+  - email: support@prophetstor.com
+    name: ProphetStor Data Services, Inc.
+  provider:
+    name: ProphetStor Data Services, Inc.
+  links:
+  - name: Website
+    url: https://www.prophetstor.com/federator-ai/federator-ai-for-openshift/
+  - name: Quickstart guide
+    url: https://github.com/containers-ai/federatorai-operator/blob/master/docs/quickstart.md
+  labels:
+    alm-owner-federatorai: federatorai-operator
+    alm-status-descriptors: federatorai-operator.4.1.20
+  selector:
+    matchLabels:
+      alm-owner-federatorai: federatorai-operator
+  customresourcedefinitions:
+    owned:
+    - name: alamedaservices.federatorai.containers.ai
+      version: v1alpha1
+      kind: AlamedaService
+      displayName: AlamedaService
+      description: An instance of Alameda.
+      resources:
+      - kind: Deployment
+        version: v1
+      - kind: ReplicaSet
+        version: v1
+      - kind: Pod
+        version: v1
+      specDescriptors:
+      - description: Apply AlamedaScaler on Alameda itself for autoscaling
+        displayName: Enable self driving
+        path: selfDriving
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Deploy components to automatically execute Alameda recommendation
+        displayName: Enable Execution
+        path: enableExecution
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Deploy Grafana to visualize Alameda prediction and recommendation
+        displayName: Enable Dashboard
+        path: enableGui
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Alameda core component image version tag
+        displayName: Alameda Version
+        path: version
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      - description: Prometheus database connection settings for metrics retrieval
+        displayName: Prometheus Service
+        path: prometheusService
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      statusDescriptors:
+        - description: Alameda service condictions
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - 'urn:alm:descriptor:io.kubernetes.conditions'
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - federatorai.containers.ai
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - autoscaling.containers.ai
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          - persistentvolumeclaims
+          - serviceaccounts
+          verbs:
+          - delete #[issue 150]for openshift v3.09
+          - get
+          - list
+          - watch
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - patch
+        - apiGroups:
+          - extensions
+          - ""
+          resources:
+          - replicationcontrollers
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - delete #[issue 150]for openshift v3.09
+          - create
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - delete #[issue 150]for openshift v3.09
+          - create
+          - list
+          - update
+          - watch
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+          - list
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - delete #[issue 150]for openshift v3.09
+          - create
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - "*"
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - "*"
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - list
+      permissions:
+      - serviceAccountName: federatorai-operator
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - events
+          - endpoints
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - services
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - statefulsets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+      deployments:
+      - name: federatorai-operator
+        spec:
+          replicas: 1
+          strategy:
+            rollingUpdate:
+              maxSurge: 1
+              maxUnavailable: 1
+            type: RollingUpdate
+          selector:
+            matchLabels:
+              name: federatorai-operator
+          template:
+            metadata:
+              labels:
+                name: federatorai-operator
+                app: Federator.ai
+            spec:
+              serviceAccountName: federatorai-operator
+              containers:
+                - name: federatorai-operator
+                  image: quay.io/prophetstor/federatorai-operator-ubi:v4.1.20
+                  imagePullPolicy: IfNotPresent
+                  command:
+                  - federatorai-operator
+                  env:
+                    - name: WATCH_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.annotations['olm.targetNamespaces']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "federatorai-operator"
+                    - name: DISABLE_OPERAND_RESOURCE_PROTECTION
+                      value: "true"


### PR DESCRIPTION
Hi Operator community,
This Federator.ai operator v4.1.20 replaces version v0.1.0.
This PR committed for upstream-community-operators. And tested deployment via OLM.

Signed-off-by: CheeSiong.Lee <CheeSiong.Lee@ProphetStor.com>
