### PR TITLE
Adding ripsaw to upstream-community-operators

### DIFF
--- a/upstream-community-operators/ripsaw/ripsaw.crd.yaml
+++ b/upstream-community-operators/ripsaw/ripsaw.crd.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: benchmarks.ripsaw.cloudbulldozer.io
+spec:
+  group: ripsaw.cloudbulldozer.io
+  names:
+    kind: Benchmark
+    listKind: BenchmarkList
+    plural: benchmarks
+    singular: benchmark
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/upstream-community-operators/ripsaw/ripsaw.package.yaml
+++ b/upstream-community-operators/ripsaw/ripsaw.package.yaml
@@ -1,0 +1,4 @@
+packageName: ripsaw
+channels:
+- name: alpha
+  currentCSV: ripsaw.v0.1.0

--- a/upstream-community-operators/ripsaw/ripsaw.v0.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/ripsaw/ripsaw.v0.1.0.clusterserviceversion.yaml
@@ -1,0 +1,213 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: ripsaw.v0.1.0
+  namespace: ripsaw
+  annotations:
+    certified: "false"
+    capabilities: Seamless Upgrades
+    categories: "Developer Tools"
+    containerImage: quay.io/repository/benchmark-operator/benchmark-operator
+    description: Ripsaw is a benchmark operator to benchmark k8s and certain applications.
+    createdAt: 2019-06-28T06:42:43Z
+    support: Red Hat Performance
+    repository: https://github.com/cloud-bulldozer/ripsaw/
+    alm-examples: |-
+      [{
+      "apiVersion": "ripsaw.cloudbulldozer.io/v1alpha1",
+      "kind": "Benchmark",
+      "metadata": {
+      "name": "example-benchmark",
+      "namespace": "ripsaw"
+      },
+      "spec": {
+      "cleanup": false,
+      "workload": {
+         "name": "uperf",
+         "args": {
+            "hostnetwork": false,
+            "pin": false,
+            "pin_server": "node-0",
+            "pin_client": "node-1",
+            "samples": 2,
+            "pair": 1,
+            "test_types": [
+               "stream",
+               "rr"
+            ],
+            "protos": [
+               "tcp",
+               "udp"
+            ],
+            "sizes": [
+               16384,
+               512
+            ],
+            "runtime": 10
+         }
+      }
+      }
+      }]
+spec:
+  displayName: Ripsaw
+  keywords: ['ripsaw', 'performance', 'benchmark']
+  provider:
+    name: Red Hat Performance
+  maturity: alpha
+  version: 0.1.0
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAFAAAAAoCAYAAABpYH0BAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGYktHRAAAAAAAAPlDu38AAAAHdElNRQfjBhwQHQQtrNV+AAAAiXpUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAAjXXY7LCQMxDETvqiIljCVZn3LCsoZ0kPIj413M5h2kYTBPpvP7GfSaNDBp97A0Q6Gpye8KgYUAjdHmrrm4trRKvGsSXsEyHLof6tXfdLGw4epu3Q47uOx8CkvUrEM0rZjfyC3JgaWRvz7w0NMPTIksaGbs7BgAAAZxSURBVGje7ZjtiyRHHYCfru7q15nZnZ2dndm9vSOJF3MJIQbRcAmIiBCJIHJE74soim/kr/BvyCcRhYAiqGcEAxHyRZOLcCRRTBRRP2hy2bubmZ2Znp2Xnp7p7qr2w+4te7mcQmYmt6vzQH+pmeqqfupXL78ymDN5nufzfuc8MQzDmOf7xN3+oJPOUuCMLAXOyFLgjCwFzshS4IwsBc7IUuCMLAXOyLEUqPOcJNcc65TmAOtud+AoWZ7zh1GfK8M9JlrhCZOKJanZDjXpsC4lK6bEFwIx34zsAzP3XnzQXFjnOZe6Tf45GfOZYJWiUoyAvmnQShO6WUKkFDngCcGaZbMhbeq2Q1XarFqSQJhY/0XsvHPhYyPwb/GIX3aafKdcI+l0MUwTrRRBEFCpVsmBqdYMVUaYpbSSKY10SjtNGKiMLM9xDMGqZR0R67BmSUqmdSj2f1bgC2GLqdZ8aqqxPY+1tTXSNOXatWtsbm5iuy6/2+vy9nTMhrTZOJjSJVMiDYMszxmojGYypXkgdi9LSfKcFdPi4vomm7Yzd4HHZg3U+f5oZkpRcl0ApJSYponKMiKl+G2/w+PFMtNc81Y0oK8yplpjAJ4wOecHPLlaRQJhGNKbDhGex5+E5vluk2fqZ+be72Mj8D7X5ze9NufdgG63i2EYTCYTlFI4rosWBgXT4uGgyD2OB0AOTLRioDJ2phN+3mnwicIqhWnCYDiktr5O2Onw2OoKz8URYZaeTIETrYlUhitMAtN83/885Bd4edDlLRPOuy6tVgvTNKnX61jWfjfr0uFSp8FZNyAwTYqmSUFYlCyLgcqoS4eKlIyiMaZp4vs+fctilCQYhoFcwM690DVQ5TmXByGv9EPSPEcAHy+s8FS5iituP4K+O435YWuH79bPsC0dcuDoktXLUt6MBuxlGZHOiLQmVoqJVqR5zoVKjYf9IkopGo0GSZLg2jav24JervlGbftkbSIv9dq8OuhxcX2T045LN0t5vtOgYFqcdlx0Dk+UymxI+7D+i+Eu/5rGPFM/c7hzJknCaDTCc1083wcgS1NGoxGWbeP4HjkGptYMh0OEEARBgFaKyIBnm1f5avUU97n+ybnS72cZlwchX9s4xSNBkbIlOev6fLt+hnaa0EwSdtMpP2i+Sz9L4cD7Z1fXibXiyrC3LyrLuHHjBnEc02g2iaIIrTU3Gg2i8ZjdVovJKMI2DHZ3dxkMBoRhSBiGSNvmtdGAmnS41/UX8p0LWwOvTmMEBve43i3lZUvydKXOP+IITU6kNW932pSjGIRASsnn/BK/2uvyoF8kSPYX/q2tLVqtFnEcY1kWSim2t7fpdruMx2OCIGAymbC1tUWapoTdLiOV8fpoj4vrm/OfagcsJAL/Mh7y0/Z1HvACpHFrE1cGPX7Svs5YKxKtaSZT/polvGlommiUzvmIdHjIL/BCt4V0bIQQ7OzsEMcxQRBgS4mUkms7O4yGQwqFwuG0bTQatNttVool3hgNWLUs7vcWE32wgAhspwk/azf44lqN86XyLSM/UBkv9tp8pbrFx4ISAH+PI37U2qHmOFzJEr5ZrVPwAp7yPZ698Q6vRUMerdcZx2Ns28FwHBKgXKsxHo/3z4quy0RripU1TNdFCEEkLV5p7fDl9U3EwuJvAQL/HA2pWJLH3yPv5m85Oee8wmHZR72A750+S9G0+PHudd4Y9bnfCygdZA+Xuk1eHoQIw+COSc7N4iMNTrXmk4UVHvSDhclbiMAk19ji9jH/46jPr7stPr9WxT5yhBFA0dzvhisErw56POD4nM0NNnP4VrHCUGsMIRBCIISBYQgMwzjy3N4PT5iULbnA2FuQwHNewOV+yDuT+HADyfKcl3odLlRqPFEq37HuF9Y2OO24/KLT5EvKxDk4EFuWhWVZmJaFlHJ/DbRtHNvGdmzEHQ7nHwZzF3iv6/PplTW+37zKo0GJomnhCMFQZWw77n+s6wmT88Uyl/s90pUij5zahoPIuzXiDm9W7pq4myxkF36yXOXrtW0MYDfdv8erSpvfD3qkBzfNd3oayYS9LKXuBzieh+M4SCn3I9A0b5F5HPjQrrMayZTnWtdIco0v3n/K5UCYJTxWXOVCpbaQ3fNEpXLvZawV70xiYq3u2HBF2mzbLuaCIuxECzwOnJhc+P+FpcAZWQqckaXAGVkKnJGlwBlZCpyRpcAZ+TfIPbxmvL4GawAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNi0yOFQxNjoyOTowNC0wNDowMNoG5W0AAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDYtMjhUMTY6Mjk6MDQtMDQ6MDCrW13RAAAAGHRFWHRleGlmOkV4aWZJbWFnZUxlbmd0aAA2NjROFQEbAAAAF3RFWHRleGlmOkV4aWZJbWFnZVdpZHRoADY3Mbr7QccAAAASdEVYdGV4aWY6RXhpZk9mZnNldAA2Njd3Z2EAAAAddEVYdGV4aWY6U29mdHdhcmUAU2hvdHdlbGwgMC4yOC4zsNrAFwAAAABJRU5ErkJggg==
+      mediatype: image/png
+  links:
+    - name: ripsaw
+      url: https://www.ripsaw.cloudbulldozer.io
+  maintainers:
+  - name: Aakarsh Gopi
+    email: aakarsh.g2012@gmail.com
+  - name: Dustin Black
+    email: dblack@redhat.com
+  - name: Joe Talerico
+    email: jtaleric@redhat.com
+  description: |
+    Ripsaw is useful to deploy common workloads to benchmark Kubernetes cluster on your provider.
+
+    Ripsaw also supports benchmarking of some common applications such as databases - mongodb/couchbase as well.
+
+    For further information about Ripsaw, read through our documentation on github.
+
+    * [Ripsaw](https://github.com/cloud-bulldozer/ripsaw/tree/master/docs)
+  minKubeVersion: 1.12.0
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: benchmark-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: benchmark-operator
+          template:
+            metadata:
+              labels:
+                name: benchmark-operator
+            spec:
+              serviceAccountName: benchmark-operator
+              containers:
+                - name: benchmark-operator
+                  # Replace this with the built image name
+                  image: quay.io/benchmark-operator/benchmark-operator:master
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: ANSIBLE_VERBOSITY
+                      value: "4"
+                    - name: OPERATOR_NAME
+                      value: "benchmark-operator"
+                - name: redis-master
+                  image: k8s.gcr.io/redis:v1
+                  env:
+                    - name: MASTER
+                      value: "true"
+                  ports:
+                    - containerPort: 6379
+                  resources:
+                    limits:
+                      cpu: "0.1"
+                  volumeMounts:
+                    - mountPath: /redis-master-data
+                      name: data
+              volumes:
+                - name: data
+                  emptyDir: {}
+      permissions:
+      - serviceAccountName: benchmark-operator
+        rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          - clusterroles
+          - clusterrolebindings
+          - persistentvolumes
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - pods/log
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - ripsaw.cloudbulldozer.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          - extensions
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+  customresourcedefinitions:
+    owned:
+    - displayName: Benchmark
+      description: The type of benchmark for Ripsaw to be run
+      group: ripsaw.cloudbulldozer.io
+      kind: Benchmark
+      name: benchmarks.ripsaw.cloudbulldozer.io
+      version: v1alpha1


### PR DESCRIPTION
### New Submissions

* [x] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md)?
* [x] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
* [x] Have you tested your Operator with all Custom Resource Definitions?
* [x] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md#operator-metadata)?

### Updates to existing Operators

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Have you tested an update to your Operator when deployed via OLM?

### Your submission should not

* [x] Modify more than one operator
* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo