### PR TITLE
noobaa: update csv InstallModes to allow only OwnNamespace

### DIFF
--- a/upstream-community-operators/noobaa/noobaa-operator.v0.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/noobaa/noobaa-operator.v0.1.0.clusterserviceversion.yaml
@@ -83,11 +83,11 @@ spec:
   installModes:
   - supported: true
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   install:
     spec:


### PR DESCRIPTION
Hi @J0zi 
Thanks for the help getting the noobaa operator on the hub!

I am making this change to fix the flow of installing from operatorhub,io.
The instructions on the hub install dialog are:
> This Operator will be installed in the "operators" namespace and will be usable from all namespaces in the cluster

But I supported a single namespace only.

The question is if I leave just the OwnNamespace option enabled, will the subscription yaml that the hub hosts be different (https://operatorhub.io/install/noobaa-operator.yaml) - will it offer a specific new own namespace to install the operator into?

In addition - I wonder if I'm doing the right thing that I update the same CSV version (0.1.0) to remove support for installModes that I didn't plan to support but accidentally my CSV said it is supported. Or does that require a new 0.1.1 patch version instead?

Thanks!
Guy


Thanks submitting your Operator. Please check below list before you create your Pull Request.

### New Submissions

* [x] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md)?
* [x] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
* [x] Have you tested your Operator with all Custom Resource Definitions?
* [x] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md#operator-metadata)?

### Updates to existing Operators

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [ ] Have you tested an update to your Operator when deployed via OLM?

### Your submission should not

* [x] Modify more than one operator
* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo

Remember that you can preview your CSV [here](https://operatorhub.io/preview).

--

<sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file a PR against this repo and explain your need

<sup>2</sup> For more information see [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.svg)