### PR TITLE
[upstream][kiali] forgot to add these permissions.

### DIFF
--- a/upstream-community-operators/kiali/kiali.v1.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/kiali/kiali.v1.1.0.clusterserviceversion.yaml
@@ -325,6 +325,8 @@ spec:
           resources:
           - clusterrolebindings
           - clusterroles
+          - rolebindings
+          - roles
           verbs:
           - create
           - delete


### PR DESCRIPTION
see https://github.com/kiali/kiali/issues/1252

Note: this is simply adding a couple missing roles to the operator. Does this require an entirely new version? Or can I simply patch the current version?