### PR TITLE
[upstream] Update Postgres Operator image to release version

### DIFF
--- a/upstream-community-operators/postgres-operator/postgres-operator.v1.2.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/postgres-operator/postgres-operator.v1.2.0.clusterserviceversion.yaml
@@ -8,8 +8,8 @@ metadata:
     categories: Database
     certified: "false"
     repository: https://github.com/zalando/postgres-operator
-    containerImage: registry.opensource.zalan.do/acid/postgres-operator:v1.1.0-33-gec5b1d4
-    createdAt: 2019-05-10T10:30:00Z
+    containerImage: registry.opensource.zalan.do/acid/postgres-operator:v1.2.0
+    createdAt: 2019-07-24T10:30:00Z
     description: Postgres operator creates and manages PostgreSQL clusters running in Kubernetes.
     support: Zalando SE
     alm-examples: |-
@@ -55,7 +55,7 @@ metadata:
                       "debug_logging": true,
                       "enable_database_access": true
                   },
-                  "docker_image": "registry.opensource.zalan.do/acid/spilo-11:1.5-p7",
+                  "docker_image": "registry.opensource.zalan.do/acid/spilo-11:1.5-p9",
                   "etcd_host": "",
                   "kubernetes": {
                       "cluster_domain": "cluster.local",
@@ -179,7 +179,7 @@ spec:
 
     ### Configuring the operator
 
-    The operator can be configured by defining an `OperatorConfiguration` custom resource or by creating a ConfigMap that contains the parameters to be changed. The YAML example shows the default configuration used internally when creating the operator via OLM. For a detailed description of each parameter checkout out the operator reference: https://github.com/zalando/postgres-operator/blob/master/docs/reference/operator_parameters.md
+    The operator can be configured by defining an `OperatorConfiguration` custom resource or by creating a ConfigMap that contains the parameters to be changed. The YAML example shows the default configuration used internally when creating the operator via OLM. For a detailed description of each parameter checkout out the [operator reference](https://github.com/zalando/postgres-operator/blob/master/docs/reference/operator_parameters.md)
 
     In order to obtain changes from the configuration first create an `OperatorConfiguration` or ConfigMap. Then edit the Postgres Operator CSV and add a reference to this resource in the `spec.containers` section of the `postgres-operator` deployment. Then delete the running operator deployment so that the CSV respawns an updated deployment.
 
@@ -187,7 +187,7 @@ spec:
     # for CRD-based configuration
     - env:
       - name: POSTGRES_OPERATOR_CONFIGURATION_OBJECT
-        value: postgresql-operator-default-confizkuguration
+        value: postgresql-operator-default-configuration
 
     # for ConfigMap-based configuration
     - env:
@@ -195,7 +195,7 @@ spec:
         value: "postgres-operator"
     ```
 
-    Please, check out the user documentation for more details about how to use the operator: https://github.com/zalando/postgres-operator/blob/master/docs/user.md
+    Please, check out the [user guide](https://github.com/zalando/postgres-operator/blob/master/docs/user.md) for more details about how to use the operator.
   keywords: ['postgresql', 'kubernetes', 'database', 'managed-services', 'data-infrastructure', 'cloud-native', 'postgres-operator']
   maintainers:
   - name: Zalando SE
@@ -416,7 +416,7 @@ spec:
               serviceAccount: operator
               serviceAccountName: operator
               containers:
-              - image: registry.opensource.zalan.do/acid/postgres-operator:v1.1.0-33-gec5b1d4
+              - image: registry.opensource.zalan.do/acid/postgres-operator:v1.2.0
                 imagePullPolicy: IfNotPresent
                 name: postgres-operator
                 resources:


### PR DESCRIPTION
Time to reference the 1.2.0 Postgres-Operator CSV with the correct release image