### PR TITLE
Update all github link to metering repo to use 4.1 release

### DIFF
--- a/community-operators/metering/meteringoperator.v4.1.0.clusterserviceversion.yaml
+++ b/community-operators/metering/meteringoperator.v4.1.0.clusterserviceversion.yaml
@@ -204,7 +204,7 @@ spec:
   description: |
     Operator Metering is a chargeback and reporting tool to provide accountability for how resources are used across a cluster. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster wide. Operator Metering is part of the [Operator Framework](https://coreos.com/blog/introducing-operator-framework-metering).
 
-    Read the user guide for more details on [running and viewing your first report](https://github.com/operator-framework/operator-metering/blob/master/Documentation/using-metering.md).
+    Read the user guide for more details on [running and viewing your first report](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/using-metering.md).
 
     ### Core capabilities
 
@@ -224,13 +224,13 @@ spec:
 
     ### Common Configurations
 
-    Metering works out of the box without any customizations or configuration. Read the [full documentation](https://github.com/operator-framework/operator-metering/blob/master/Documentation/metering-config.md) for more details.
+    Metering works out of the box without any customizations or configuration. Read the [full documentation](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/metering-config.md) for more details.
 
-    * **Use a specific StorageClass** - Follow the example to [use your own StorageClass](https://github.com/operator-framework/operator-metering/blob/master/manifests/metering-config/custom-storage.yaml) instead of the Dynamic Provisioner.
+    * **Use a specific StorageClass** - Follow the example to [use your own StorageClass](https://github.com/operator-framework/operator-metering/blob/release-4.1/manifests/metering-config/custom-storage.yaml) instead of the Dynamic Provisioner.
 
-    * **Store data in S3 instead of PV** - Store your report output [in an S3 bucket](https://github.com/operator-framework/operator-metering/blob/master/Documentation/configuring-storage.md#storing-data-in-s3) instead of a PersistentVolume.
+    * **Store data in S3 instead of PV** - Store your report output [in an S3 bucket](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/configuring-storage.md#storing-data-in-s3) instead of a PersistentVolume.
 
-    * **Configure AWS Billing Data Source** - To assign Pod $$ costs on AWS, create a [read-only IAM user](https://github.com/operator-framework/operator-metering/blob/master/Documentation/configuring-aws-billing.md) ([example-policy](https://github.com/operator-framework/operator-metering/blob/master/Documentation/aws/read-only.json)) and [configure Metering](https://github.com/operator-framework/operator-metering/blob/master/manifests/metering-config/aws-billing.yaml) to use it.
+    * **Configure AWS Billing Data Source** - To assign Pod $$ costs on AWS, create a [read-only IAM user](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/configuring-aws-billing.md) ([example-policy](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/aws/read-only.json)) and [configure Metering](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/configuring-aws-billing.md) to use it.
 
   keywords: [metering metrics reporting prometheus chargeback]
   version: "4.1.0"
@@ -241,7 +241,7 @@ spec:
 
   links:
     - name: Documentation
-      url: https://github.com/operator-framework/operator-metering/blob/master/Documentation/index.md
+      url: https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/index.md
 
   provider:
     name: Red Hat


### PR DESCRIPTION
Currently the urls to docs are pointing to upstream but should be using the release-4.1 branch instead.