### PR TITLE
Fixed Travis build error for upstream operator with alpha numeric name

### DIFF
--- a/scripts/ci/operators-env
+++ b/scripts/ci/operators-env
@@ -38,7 +38,7 @@ for op_distro in "${!OP_TYPES[@]}"; do
         # Get latest CSV version for the changed operator.
         OP_VER="$(yq r --tojson "$PKG_FILE" "channels" \
           | jq ".[] | .currentCSV" | sort -V | tail -1 \
-          | sed -E "s,"[a-zA-Z\-]+\.?v?${SEMVER_REGEX}",\1,")"
+          | sed -E "s,"[a-zA-Z0-9\-]+\.?v?${SEMVER_REGEX}",\1,")"
         declare $OP_TYPE_VAR="${!OP_TYPE_VAR}${!OP_TYPE_VAR:+" "}${OP_PATH}:${OP_VER}"
       fi
     done


### PR DESCRIPTION
This fixes error in travis build `` main [ERRO] Must provide filename``
Two PR's are pending with this error [t8c](https://github.com/operator-framework/community-operators/pull/399)  and [awss3operator](https://github.com/operator-framework/community-operators/pull/408) 
Related [Issue](https://github.com/operator-framework/community-operators/issues/590)