### PR TITLE
Removed vscode excluded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,10 +47,6 @@ Temporary Items
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files


### PR DESCRIPTION
This PR is not about a new operator.
It's about removing excluded VSCode files from the .gitignore file.
With the current .gitignore, customization that people have in their VSCode environment (like settings.json, extensions.json, and tasks.json) can be committed upstream and are not ignored.
At the same time the launch.json which makes sense in case of debugging configuration.
With this PR all the `.vscode` folder content is taken out of committing upstream.