### PR TITLE
Updating ripsaw to use v0.8.1 of operator-framework

### DIFF
--- a/upstream-community-operators/ripsaw/ripsaw.v0.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/ripsaw/ripsaw.v0.1.0.clusterserviceversion.yaml
@@ -187,6 +187,7 @@ spec:
           - daemonsets
           - replicasets
           - statefulsets
+          - deployments/finalizers
           verbs:
           - '*'
         - apiGroups:


### PR DESCRIPTION
Follows cloud-bulldozer/ripsaw#112

