### PR TITLE
Updating ripsaw to use 0.8.1 operator framework

### DIFF
--- a/community-operators/ripsaw/ripsaw.v0.1.0.clusterserviceversion.yaml
+++ b/community-operators/ripsaw/ripsaw.v0.1.0.clusterserviceversion.yaml
@@ -92,6 +92,12 @@ spec:
         * Which distribution to use
         * Which platform to deploy the k8s cluster on
         * Which storage class to provision storage volumes
+    
+    Steps to follow to install ripsaw:
+    * Create a project/namespace called `my-ripsaw`
+    * Install ripsaw into the `my-ripsaw` project/namespace
+    * Read through documentation above for a CR of Benchmark to apply
+    * Get the results
 
   minKubeVersion: 1.12.0
   installModes:
@@ -192,6 +198,7 @@ spec:
           - daemonsets
           - replicasets
           - statefulsets
+          - deployments/finalizers
           verbs:
           - '*'
         - apiGroups:


### PR DESCRIPTION
Also updated description for install steps

Follows cloud-bulldozer/ripsaw#112
