### PR TITLE
Increase the capabilities of MongoDB Enterprise

### DIFF
--- a/upstream-community-operators/mongodb-enterprise/mongodb-enterprise.v0.3.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/mongodb-enterprise/mongodb-enterprise.v0.3.2.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: placeholder
   annotations:
     repository: https://github.com/mongodb/mongodb-enterprise-kubernetes
-    capabilities: Full Lifecycle
+    capabilities: Deep Insights
     categories: "Database"
     certified: "false"
     containerImage: quay.io/mongodb/mongodb-enterprise-operator:0.7

--- a/upstream-community-operators/mongodb-enterprise/mongodb-enterprise.v0.9.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/mongodb-enterprise/mongodb-enterprise.v0.9.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     containerImage: quay.io/mongodb/mongodb-enterprise-operator:0.9
     support: MongoDB Community Support
     createdAt: 2019-03-21T10:30:00Z
-    capabilities: Full Lifecycle
+    capabilities: Deep Insights
     categories: "Database"
     certified: "true"
     description: The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB into Kubernetes clusters, using our management, monitoring and backup platforms, Ops Manager and Cloud Manager.

--- a/upstream-community-operators/mongodb-enterprise/mongodb-enterprise.v1.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/mongodb-enterprise/mongodb-enterprise.v1.1.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     containerImage: quay.io/mongodb/mongodb-enterprise-operator:1.1
     support: MongoDB Community Support
     createdAt: 2019-07-23T10:30:00Z
-    capabilities: Full Lifecycle
+    capabilities: Deep Insights
     categories: "Database"
     certified: "true"
     description: The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB into Kubernetes clusters, using our management, monitoring and backup platforms, Ops Manager and Cloud Manager.


### PR DESCRIPTION
I work on the Operator Enablement team at Red Hat and have verified that the MongoDB Enterprise operator provides Deep Insights capability. Please see the following link and screenshots to confirm and drive any specific questions/concerns:

https://www.mongodb.com/cloud/cloud-manager

![mongo](https://user-images.githubusercontent.com/3989695/63293788-812f0e00-c28e-11e9-90ad-84f095f8ec08.png)

![mongo-metrics](https://user-images.githubusercontent.com/3989695/63293802-87bd8580-c28e-11e9-9274-04ab1e730e2d.png)

MongoDB Enterprise operator works with Cloud Manager (seen in the attached images) and Ops Manager which is "Cloud Manager" deployed on your own infrastructure.