### PR TITLE
[docker] error "no tables found in db" 

### DIFF
--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -15,4 +15,4 @@ COPY --from=builder /build/bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]
-CMD ["--database", "bundles.db"]
+CMD ["--database", "/bundles.db"]

--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3 as manifests
 
-RUN pip3 install operator-courier==1.0.2
+RUN pip3 install operator-courier==2.1.7
 WORKDIR /usr/src
 COPY upstream-community-operators /usr/src/upstream-community-operators
 RUN for file in /usr/src/upstream-community-operators/*; do operator-courier nest $file /manifests/$(basename $file); done
 
-FROM quay.io/operator-framework/upstream-registry-builder:v1.1.0 as builder
+FROM quay.io/operator-framework/upstream-registry-builder:v1.3.0 as builder
 COPY --from=manifests /manifests manifests
 RUN ./bin/initializer -o ./bundles.db
 


### PR DESCRIPTION
The image built using upstream.Dockerfile failed to run (CrashBackOff in k8s), prompting the following error:

```
time="2019-08-27T05:02:12Z" level=fatal msg="no tables found in db" database=bundles.db port=50051
```

I guess that the path of bundles.db is incorrect,.
After I modified it, the pod is running normally.

```
time="2019-08-27T05:05:05Z" level=info msg="serving registry" database=/bundles.db port=50051
```