### PR TITLE
fix explanation to use operator-courier verify --ui_validate_io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Intelij IDEA
-.idea
+# IDEA Golang files
+.idea/*
+
 # Created by https://www.gitignore.io/api/macos,linux,windows,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=macos,linux,windows,visualstudiocode
 

--- a/docs/testing-operators.md
+++ b/docs/testing-operators.md
@@ -78,7 +78,7 @@ git clone https://github.com/operator-framework/operator-lifecycle-manager.git
 Before you begin your current working dir should look like the following, with `my-operator/` as an example for the name of your bundle:
 
 ```
-my-operator/
+my-operator-bundle/
 operator-marketplace/
 operator-courier/
 operator-lifecycle-manager/


### PR DESCRIPTION
## What

- Fix the explanation to use the command `verify --ui_validate_io`.(the info over the dir was not accurate)
- Improve description over how to push quay.io application bundle
- Fix index which was outdated since was made manually. Add doctoc to generated it. 

## Step to verify
Check here the changes performed: https://github.com/operator-framework/community-operators/blob/64c71f731f7dd2be25c2ee8177f850b0d6870409/docs/testing-operators.md