### PR TITLE
Fix broken links - OLM Documentation was replaced by doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-
+# Intelij IDEA
+.idea
 # Created by https://www.gitignore.io/api/macos,linux,windows,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=macos,linux,windows,visualstudiocode
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -46,7 +46,7 @@ Operators submitted to the `community-operators/` directory are tested against a
 [registry-bundle]:https://github.com/operator-framework/operator-registry#manifest-format
 [courier-verify]:https://github.com/operator-framework/operator-courier/#command-line-interface
 [registry]:https://github.com/operator-framework/operator-registry
-[olm-alm-examples]:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md#crd-templates
+[olm-alm-examples]:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#crd-templates
 [courier-docs]:https://github.com/operator-framework/operator-courier/#operator-courier
 [quay]:https://quay.io
 [quay-create-repo]:https://docs.quay.io/guides/create-repo.html

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,7 +15,7 @@ This repository makes use of the [Operator Framework](https://github.com/operato
 
 To add your operator to any of the above platforms, you will need to submit your Operator packaged for use with [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager/). This mainly consists of a YAML file called `ClusterServiceVersion` which contains references to all of the `CustomResource Definitions` (CRDs), RBAC rules, `Deployment` and container image needed to install and securely run your Operator. It also contains user-visible info like a description of its features and supported Kubernetes versions (also see  further recommendations below).  Note that your Operator is not supposed to self-register it's CRDs.
 
-[Follow this guide to create an OLM-compatible CSV for your operator](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md). You can also see an example [here](./required-fields.md#example-csv). An Operator's CSV must contain the fields and mentioned [here](./required-fields.md#required-fields-for-operatorhub) for it to be displayed properly within the various platforms.
+[Follow this guide to create an OLM-compatible CSV for your operator](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md). You can also see an example [here](./required-fields.md#example-csv). An Operator's CSV must contain the fields and mentioned [here](./required-fields.md#required-fields-for-operatorhub) for it to be displayed properly within the various platforms.
 
 ### Bundle format
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -6,7 +6,7 @@ Thanks submitting your Operator. Please check below list before you create your 
 * [ ] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md)?
 * [ ] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
 * [ ] Have you tested your Operator with all Custom Resource Definitions?
-* [ ] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md#operator-metadata)?
+* [ ] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
 
 ### Updates to existing Operators
 

--- a/docs/required-fields.md
+++ b/docs/required-fields.md
@@ -2,7 +2,7 @@
 
 ## Preparing your CSV for use with OLM
 
-Before you begin, we strongly advise that you follow Operator-Lifecycle-Manager's docs on [building a CSV for the Operator Framework](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md). These outline the functional purpose of the CSV and which fields are required for installing your Operator CSV through OLM.
+Before you begin, we strongly advise that you follow Operator-Lifecycle-Manager's docs on [building a CSV for the Operator Framework](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md). These outline the functional purpose of the CSV and which fields are required for installing your Operator CSV through OLM.
 
 ## Required fields for OperatorHub
 

--- a/docs/testing-operators.md
+++ b/docs/testing-operators.md
@@ -376,5 +376,5 @@ operator-sdk scorecard --olm-deployed --crds-dir my-operator/ --csv-path my-oper
 
 ## Additional Resources
 
-* [Cluster Service Version Spec](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md)
+* [Cluster Service Version Spec](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md)
 * [Example Bundle](https://github.com/operator-framework/community-operators/tree/master/upstream-community-operators/etcd)

--- a/upstream-community-operators/lib-bucket-provisioner/lib-bucket-provisioner.v1.0.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/lib-bucket-provisioner/lib-bucket-provisioner.v1.0.0.clusterserviceversion.yaml
@@ -97,7 +97,7 @@ spec:
 
     This operator package is **CRD-only** and the operator is a no-op operator.
 
-    Instead, bucket provisioners using this library are using these CRD's and using CSV [required-crds](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md#required-crds) them so that OLM can install it as a dependency.
+    Instead, bucket provisioners using this library are using these CRD's and using CSV [required-crds](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#required-crds) them so that OLM can install it as a dependency.
 
     ### Generic Bucket Provisioning
 


### PR DESCRIPTION
**Description of the change:**
The Dir of docs in OLM was changed from Documentation to doc. This change is to fix the broken links. 

**Motivation for the change:**

- https://github.com/operator-framework/operator-sdk/issues/1887
