### PR TITLE
Upgrade olm version for CI, form 0.10.1 to 0.11.0

### DIFF
--- a/scripts/ci/install-olm-local
+++ b/scripts/ci/install-olm-local
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Try twice, since order matters
-kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.10.1/crds.yaml
-kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.10.1/olm.yaml
+kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.11.0/crds.yaml
+kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.11.0/olm.yaml
 
 # Delete "operatorhubio-catalog"
 kubectl delete catalogsource operatorhubio-catalog -n olm


### PR DESCRIPTION
Updated olm installs version to 0.11.0 for CI scripts.