### PR TITLE
Deprecate KnativeServing in favor of the new Serverless operator

### DIFF
--- a/community-operators/knative-serving-operator/knative-serving-operator.v0.7.1.clusterserviceversion.yaml
+++ b/community-operators/knative-serving-operator/knative-serving-operator.v0.7.1.clusterserviceversion.yaml
@@ -29,6 +29,15 @@ spec:
         path: version
       version: v1alpha1
   description: |
+
+    ## DEPRECATED
+
+    NOTICE: This operator should be considered DEPRECATED and will be
+    removed by October 2019. In order to install Knative Serving in
+    OpenShift we recommend using the OpenShift Serverless operator.
+
+    ## DEPRECATED
+
     Knative Serving builds on Kubernetes to support deploying and
     serving of serverless applications and functions. Serving is easy
     to get started with and scales to support advanced scenarios. The


### PR DESCRIPTION
Add a warning to the description letting folks know the operator is now deprecated.