### PR TITLE
Avoid docker pull -q

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ olm.install: ## Install OLM to your cluster
 	@scripts/ci/check-kubeconfig && docker run --network host -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory
 
 operator.test: check_path ## Operator test which run courier and scorecard
-	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing -q" "Pulling docker image"
+	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
 	@scripts/ci/check-kubeconfig && docker run --network host -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
 
 operator.verify: check_path ## Run only courier
-	@docker pull quay.io/operator-framework/operator-testing -q
+	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
 	@docker run -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.verify --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE}


### PR DESCRIPTION
Docker 18.06, at least as packaged in Fedora, doesn’t support -q, and
in versions which do support it, it’s redundant with the VERBOSE
setting in the Makefile. This patch removes "-q", relying on
run-script instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>
