### PR TITLE
Bump kiali capabilities to Deep Insights

### DIFF
--- a/upstream-community-operators/kiali/kiali.v1.4.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/kiali/kiali.v1.4.2.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.4.2
-    capabilities: Basic Install
+    capabilities: Deep Insights
     support: Kiali
     description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
     repository: https://github.com/kiali/kiali


### PR DESCRIPTION
Bumping the capabilities to `Deep Insights` based on the following reasons:
 * The custom resource Kiali exposes metrics at `:9090/metrics`
 * It integrates with Grafana, Jaeger and Prometheus for graphs, tracing and logging
 * Also provides a monitoring dashboard  