### PR TITLE
improve start minikube nad fix kubeconfig problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ olm.install: ## Install OLM to your cluster
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
+	@scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
 
 operator.verify: check_path ## Run only courier
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ MAKEFLAGS += --no-print-directory
 OP_PATH=''
 CLEAN_MODE='NORMAL'
 VM_DRIVER=none
+KUBECONFIG?=~/.kube/config
 
 help:
 	@grep -E '^[a-zA-Z0-9/._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -14,15 +15,14 @@ minikube.install: ## Install the local minikube
 	@echo "Installed"
 
 minikube.start: ## Start local minikube
-	@scripts/ci/run-script "minikube start --vm-driver=${VM_DRIVER} --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 -p operators" "Start minikube"
+	@scripts/ci/run-script "scripts/ci/start-minikube" "Start minikube"
 
 olm.install: ## Install OLM to your cluster
-	@docker run --network host -v ~/.kube:/root/.kube -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory
+	@scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	@scripts/ci/check-kubeconfig
-	@docker run --network host -v ~/.kube:/root/.kube -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
+	scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
 
 operator.verify: check_path ## Run only courier
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 
-
 for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
   . "$f"
 done
 
 export_color
 
-if kubectl cluster-info | grep -q 'running'; then
-  printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
-else
-  printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
-  exit 1
-fi
+if [[ -f $KUBECONFIG && "$(cat $KUBECONFIG  | grep -o current-context)" = "current-context"  ]]; then
 
-if [[ -f ~/.kube/config && "$(cat ~/.kube/config  | grep -o current-context)" = "current-context"  ]]; then
+    if kubectl cluster-info | grep -q 'running'; then
+      printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
+    else
+      printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+      exit 1
+    fi
+
     CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
     if [[ $CONTEXT != '' ]]; then
       printf "Find kube config %s\t[ ${OK} CONTEXT: ${CONTEXT} ${NC} ]\n"  | expand  -t 50;

--- a/scripts/ci/start-minikube
+++ b/scripts/ci/start-minikube
@@ -1,0 +1,8 @@
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ -z "${VM_DRIVER}" ]]; then
+    export VM_DRIVER=hyperkit
+  fi
+fi
+
+minikube start --vm-driver=${VM_DRIVER} --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 -p operators


### PR DESCRIPTION
improved version of kubeconfig fix + improvment of minikube.start ( use default VM_DRIVER for mac os hyperkit instead of none which is not supported)

and fixed problem with no kubeconfig which now start minikube instead of falure

tested: 
- mac os 
- fedora 
- ubuntu 