### PR TITLE
Fix hangs on non-existing cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFLAGS += --no-print-directory
 OP_PATH=''
 CLEAN_MODE='NORMAL'
 VM_DRIVER=none
-KUBECONFIG?=~/.kube/config
+KUBECONFIG?=${HOME/.kube/config}
 
 help:
 	@grep -E '^[a-zA-Z0-9/._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -19,11 +19,11 @@ minikube.start: ## Start local minikube
 
 olm.install: ## Install OLM to your cluster
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory"
+	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory"
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
+	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
 
 operator.verify: check_path ## Run only courier
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,12 @@ minikube.start: ## Start local minikube
 	@scripts/ci/run-script "scripts/ci/start-minikube" "Start minikube"
 
 olm.install: ## Install OLM to your cluster
-	@scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory
+	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
+	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory"
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
+	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
 
 operator.verify: check_path ## Run only courier
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ MAKEFLAGS += --no-print-directory
 OP_PATH=''
 CLEAN_MODE='NORMAL'
 VM_DRIVER=none
+KUBECONFIG?=~/.kube/config
 
 help:
 	@grep -E '^[a-zA-Z0-9/._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -14,15 +15,14 @@ minikube.install: ## Install the local minikube
 	@echo "Installed"
 
 minikube.start: ## Start local minikube
-	@scripts/ci/run-script "minikube start --vm-driver=${VM_DRIVER} --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 -p operators" "Start minikube"
+	@scripts/ci/run-script "scripts/ci/start-minikube" "Start minikube"
 
 olm.install: ## Install OLM to your cluster
-	@docker run --network host -v ~/.kube:/root/.kube -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory
+	@scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	@scripts/ci/check-kubeconfig
-	@docker run --network host -v ~/.kube:/root/.kube -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
+	scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
 
 operator.verify: check_path ## Run only courier
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 
-
 for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
   . "$f"
 done
 
 export_color
 
-if kubectl cluster-info | grep -q 'running'; then
-  printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
-else
-  printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
-  exit 1
-fi
+if [[ -f $KUBECONFIG && "$(cat $KUBECONFIG  | grep -o current-context)" = "current-context"  ]]; then
 
-if [[ -f ~/.kube/config && "$(cat ~/.kube/config  | grep -o current-context)" = "current-context"  ]]; then
+    if kubectl cluster-info | grep -q 'running'; then
+      printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
+    else
+      printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+      exit 1
+    fi
+
     CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
     if [[ $CONTEXT != '' ]]; then
       printf "Find kube config %s\t[ ${OK} CONTEXT: ${CONTEXT} ${NC} ]\n"  | expand  -t 50;

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -4,11 +4,14 @@ for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
   . "$f"
 done
 
+if [ -z "${KUBECONFIG}" ]; then
+    export KUBECONFIG=~/.kube/config
+fi
 export_color
+
 CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
 
 if [[ -f $KUBECONFIG && "${CONTEXT}" != ""  ]]; then
-    READY=1
 
     IP="$(kubectl config view -o jsonpath="{.clusters[?(@.name=='$CONTEXT')].cluster.server}")"
     echo ${IP#*//} | sed -e "s/:/ /" | while read ip port
@@ -17,7 +20,7 @@ if [[ -f $KUBECONFIG && "${CONTEXT}" != ""  ]]; then
         set -e
         nc -zvw3 $ip $port 2> /dev/null
       } || {
-        printf "Kube api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+        printf "Api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
         exit 1
       }
       if [[ $(kubectl cluster-info | grep -q 'running') && $READY == 0 ]]; then

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -5,22 +5,35 @@ for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
 done
 
 export_color
+CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
 
-if [[ -f $KUBECONFIG && "$(cat $KUBECONFIG  | grep -o current-context)" = "current-context"  ]]; then
+if [[ -f $KUBECONFIG && "${CONTEXT}" != ""  ]]; then
+    READY=1
 
-    if kubectl cluster-info | grep -q 'running'; then
-      printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
-    else
-      printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
-      exit 1
-    fi
+    IP="$(kubectl config view -o jsonpath="{.clusters[?(@.name=='$CONTEXT')].cluster.server}")"
+    echo ${IP#*//} | sed -e "s/:/ /" | while read ip port
+    do
+      {
+        set -e
+        nc -zvw3 $ip $port 2> /dev/null
+      } || {
+        printf "Kube api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+        exit 1
+      }
+      if [[ $(kubectl cluster-info | grep -q 'running') && $READY == 0 ]]; then
+        printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
+      else
+        printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+        exit 1
+      fi
 
-    CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
-    if [[ $CONTEXT != '' ]]; then
-      printf "Find kube config %s\t[ ${OK} CONTEXT: ${CONTEXT} ${NC} ]\n"  | expand  -t 50;
-    else
-      printf "Find kube config %s\t[ ${WARN} NOT FOUND ${NC} ]\n"  | expand  -t 50; make minikube.start;
-    fi
+      if [[ $CONTEXT != '' ]]; then
+        printf "Find kube config %s\t[ ${OK} CONTEXT: ${CONTEXT} ${NC} ]\n"  | expand  -t 50;
+      else
+        printf "Find kube config %s\t[ ${WARN} NOT FOUND ${NC} ]\n"  | expand  -t 50; make minikube.start;
+      fi
+    done
+
 else
     printf "Find kube config %s\t[ ${WARN} NOT FOUND ${NC} ]\n"  | expand  -t 50; make minikube.start;
 fi

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -23,7 +23,7 @@ if [[ -f $KUBECONFIG && "${CONTEXT}" != ""  ]]; then
         printf "Api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
         exit 1
       }
-      if [[ $(kubectl cluster-info | grep -q 'running') && $READY == 0 ]]; then
+      if kubectl cluster-info | grep -q 'running'; then
         printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
       else
         printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2

--- a/scripts/ci/run-wrapper
+++ b/scripts/ci/run-wrapper
@@ -1,0 +1,8 @@
+{
+  set -e
+  scripts/ci/check-kubeconfig
+} || {
+  exit 1
+}
+
+$1

--- a/scripts/ci/start-minikube
+++ b/scripts/ci/start-minikube
@@ -1,0 +1,8 @@
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ -z "${VM_DRIVER}" ]]; then
+    export VM_DRIVER=hyperkit
+  fi
+fi
+
+minikube start --vm-driver=${VM_DRIVER} --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 -p operators


### PR DESCRIPTION
now it take only second to detect non answering api and logs look like:

```
Pulling docker image                                      [  OK  ]
Kube api not listening on kubernetes.docker.internal:6443 [  FAILED  ]
```

when you have config but you haven't specified `current-cluster` now tooling will start new minikube instance.