### PR TITLE
Operator install and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFLAGS += --no-print-directory
 OP_PATH=''
 CLEAN_MODE='NORMAL'
 VM_DRIVER=none
-KUBECONFIG?=~/.kube/config
+KUBECONFIG?=${HOME/.kube/config}
 
 help:
 	@grep -E '^[a-zA-Z0-9/._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -19,11 +19,11 @@ minikube.start: ## Start local minikube
 
 olm.install: ## Install OLM to your cluster
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory"
+	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory"
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
+	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
 
 operator.verify: check_path ## Run only courier
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,12 @@ minikube.start: ## Start local minikube
 	@scripts/ci/run-script "scripts/ci/start-minikube" "Start minikube"
 
 olm.install: ## Install OLM to your cluster
-	@scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory
+	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
+	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory"
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
+	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
 
 operator.verify: check_path ## Run only courier
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFLAGS += --no-print-directory
 OP_PATH=''
 CLEAN_MODE='NORMAL'
 VM_DRIVER=none
-KUBECONFIG?=${HOME/.kube/config}
+KUBECONFIG?="${HOME}/.kube/config"
 
 help:
 	@grep -E '^[a-zA-Z0-9/._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -20,6 +20,10 @@ minikube.start: ## Start local minikube
 olm.install: ## Install OLM to your cluster
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
 	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory"
+
+operator.install:
+	#@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
+	scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.install --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ olm.install: ## Install OLM to your cluster
 	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory"
 
 operator.install:
-	#@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.install --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
+	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
+	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.install --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ MAKEFLAGS += --no-print-directory
 OP_PATH=''
 CLEAN_MODE='NORMAL'
 VM_DRIVER=none
+KUBECONFIG?=~/.kube/config
 
 help:
 	@grep -E '^[a-zA-Z0-9/._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -14,15 +15,14 @@ minikube.install: ## Install the local minikube
 	@echo "Installed"
 
 minikube.start: ## Start local minikube
-	@scripts/ci/run-script "minikube start --vm-driver=${VM_DRIVER} --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 -p operators" "Start minikube"
+	@scripts/ci/run-script "scripts/ci/start-minikube" "Start minikube"
 
 olm.install: ## Install OLM to your cluster
-	@docker run --network host -v ~/.kube:/root/.kube -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory
+	@scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -it quay.io/operator-framework/operator-testing olm.install --no-print-directory
 
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
-	@scripts/ci/check-kubeconfig
-	@docker run --network host -v ~/.kube:/root/.kube -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
+	scripts/ci/check-kubeconfig && docker run -v ${KUBECONFIG}:/root/.kube/config -v ~/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}
 
 operator.verify: check_path ## Run only courier
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ operator.install:
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
 	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.install --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"
 
+operator.cleanup:
+	@scripts/ci/run-script "scripts/ci/cleanup" "Cleaning"
+
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull quay.io/operator-framework/operator-testing" "Pulling docker image"
 	@scripts/ci/run-wrapper "docker run -v ${KUBECONFIG}:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators -ti quay.io/operator-framework/operator-testing operator.test --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE}"

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 
-
 for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
   . "$f"
 done
 
 export_color
 
-if kubectl cluster-info | grep -q 'running'; then
-  printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
-else
-  printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
-  exit 1
-fi
+if [[ -f $KUBECONFIG && "$(cat $KUBECONFIG  | grep -o current-context)" = "current-context"  ]]; then
 
-if [[ -f ~/.kube/config && "$(cat ~/.kube/config  | grep -o current-context)" = "current-context"  ]]; then
+    if kubectl cluster-info | grep -q 'running'; then
+      printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
+    else
+      printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+      exit 1
+    fi
+
     CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
     if [[ $CONTEXT != '' ]]; then
       printf "Find kube config %s\t[ ${OK} CONTEXT: ${CONTEXT} ${NC} ]\n"  | expand  -t 50;

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -4,11 +4,14 @@ for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
   . "$f"
 done
 
+if [ -z "${KUBECONFIG}" ]; then
+    export KUBECONFIG=~/.kube/config
+fi
 export_color
+
 CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
 
 if [[ -f $KUBECONFIG && "${CONTEXT}" != ""  ]]; then
-    READY=1
 
     IP="$(kubectl config view -o jsonpath="{.clusters[?(@.name=='$CONTEXT')].cluster.server}")"
     echo ${IP#*//} | sed -e "s/:/ /" | while read ip port
@@ -17,7 +20,7 @@ if [[ -f $KUBECONFIG && "${CONTEXT}" != ""  ]]; then
         set -e
         nc -zvw3 $ip $port 2> /dev/null
       } || {
-        printf "Kube api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+        printf "Api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
         exit 1
       }
       if [[ $(kubectl cluster-info | grep -q 'running') && $READY == 0 ]]; then

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -6,34 +6,35 @@ done
 
 export_color
 
-CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
 
-if [[ -f $KUBECONFIG && "${CONTEXT}" != ""  ]]; then
 
-    IP="$(kubectl config view -o jsonpath="{.clusters[?(@.name=='$CONTEXT')].cluster.server}")"
-    echo ${IP#*//} | sed -e "s/:/ /" | while read ip port
-    do
-      {
-        set -e
-        nc -zvw3 $ip $port 2> /dev/null
-      } || {
-        printf "Api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
-        exit 1
-      }
-      if kubectl cluster-info | grep -q 'running'; then
-        printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
-      else
-        printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
-        exit 1
-      fi
+if [[ -f $KUBECONFIG  ]]; then
+    CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
+    if [[  "${CONTEXT}" != "" ]]; then
+      IP="$(kubectl config view -o jsonpath="{.clusters[?(@.name=='$CONTEXT')].cluster.server}")"
+      echo ${IP#*//} | sed -e "s/:/ /" | while read ip port
+      do
+        {
+          set -e
+          nc -zvw3 $ip $port 2> /dev/null
+        } || {
+          printf "Api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+          exit 1
+        }
+        if kubectl cluster-info | grep -q 'running'; then
+          printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
+        else
+          printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+          exit 1
+        fi
 
-      if [[ $CONTEXT != '' ]]; then
-        printf "Find kube config %s\t[ ${OK} CONTEXT: ${CONTEXT} ${NC} ]\n"  | expand  -t 50;
-      else
-        printf "Find kube config %s\t[ ${WARN} NOT FOUND ${NC} ]\n"  | expand  -t 50; make minikube.start;
-      fi
-    done
-
+        if [[ $CONTEXT != '' ]]; then
+          printf "Find kube config %s\t[ ${OK} CONTEXT: ${CONTEXT} ${NC} ]\n"  | expand  -t 50;
+        else
+          printf "Find kube config %s\t[ ${WARN} NOT FOUND ${NC} ]\n"  | expand  -t 50; make minikube.start;
+        fi
+      done
+    fi
 else
     printf "Find kube config %s\t[ ${WARN} NOT FOUND ${NC} ]\n"  | expand  -t 50; make minikube.start;
 fi

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -5,22 +5,35 @@ for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
 done
 
 export_color
+CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
 
-if [[ -f $KUBECONFIG && "$(cat $KUBECONFIG  | grep -o current-context)" = "current-context"  ]]; then
+if [[ -f $KUBECONFIG && "${CONTEXT}" != ""  ]]; then
+    READY=1
 
-    if kubectl cluster-info | grep -q 'running'; then
-      printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
-    else
-      printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
-      exit 1
-    fi
+    IP="$(kubectl config view -o jsonpath="{.clusters[?(@.name=='$CONTEXT')].cluster.server}")"
+    echo ${IP#*//} | sed -e "s/:/ /" | while read ip port
+    do
+      {
+        set -e
+        nc -zvw3 $ip $port 2> /dev/null
+      } || {
+        printf "Kube api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+        exit 1
+      }
+      if [[ $(kubectl cluster-info | grep -q 'running') && $READY == 0 ]]; then
+        printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
+      else
+        printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
+        exit 1
+      fi
 
-    CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"
-    if [[ $CONTEXT != '' ]]; then
-      printf "Find kube config %s\t[ ${OK} CONTEXT: ${CONTEXT} ${NC} ]\n"  | expand  -t 50;
-    else
-      printf "Find kube config %s\t[ ${WARN} NOT FOUND ${NC} ]\n"  | expand  -t 50; make minikube.start;
-    fi
+      if [[ $CONTEXT != '' ]]; then
+        printf "Find kube config %s\t[ ${OK} CONTEXT: ${CONTEXT} ${NC} ]\n"  | expand  -t 50;
+      else
+        printf "Find kube config %s\t[ ${WARN} NOT FOUND ${NC} ]\n"  | expand  -t 50; make minikube.start;
+      fi
+    done
+
 else
     printf "Find kube config %s\t[ ${WARN} NOT FOUND ${NC} ]\n"  | expand  -t 50; make minikube.start;
 fi

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -4,9 +4,6 @@ for f in "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd)"/lib/*; do
   . "$f"
 done
 
-if [ -z "${KUBECONFIG}" ]; then
-    export KUBECONFIG=~/.kube/config
-fi
 export_color
 
 CONTEXT="$(kubectl config view -o jsonpath='{.current-context}')"

--- a/scripts/ci/check-kubeconfig
+++ b/scripts/ci/check-kubeconfig
@@ -23,7 +23,7 @@ if [[ -f $KUBECONFIG && "${CONTEXT}" != ""  ]]; then
         printf "Api not listening on $ip:$port %s[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2
         exit 1
       }
-      if [[ $(kubectl cluster-info | grep -q 'running') && $READY == 0 ]]; then
+      if kubectl cluster-info | grep -q 'running'; then
         printf "cluster is running and ready for installing olm %s\t[ ${OK} OK ${NC} ]\n"  | expand  -t 50;
       else
         printf "cluster probably not running %s\t[ ${ERR} FAILED ${NC} ]\n" | expand  -t 50 >&2

--- a/scripts/ci/cleanup
+++ b/scripts/ci/cleanup
@@ -1,0 +1,11 @@
+NAMESPACES=$(kubectl get namespaces -o jsonpath="{.items[*]['metadata.name']}" -l operator=test)
+NAMESPACES=$(echo $NAMESPACES | tr " " "\n")
+
+for namespace in  $NAMESPACES
+do
+  kubectl delete subs -l operator=test --wait -n $namespace > /dev/null 2>&1
+  kubectl delete operatorgroup -l operator=test --wait -n $namespace --all > /dev/null 2>&1
+  kubectl delete pod,configmap,deployment,secret,sts --wait -n $namespace --all > /dev/null 2>&1
+  kubectl delete namespace --wait $namespace > /dev/null 2>&1
+done
+

--- a/scripts/ci/install-olm
+++ b/scripts/ci/install-olm
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-if [[ ! "$(kubectl api-resources | grep -o operatorgroup)" == "operatorgroup" ]]; then
+if [[ "$(kubectl api-resources | grep -o operatorgroup)" != "operatorgroup" ]]; then
   operator-sdk alpha olm install > /dev/null 2>&1
 
   # Delete "operatorhubio-catalog"

--- a/scripts/ci/make-tmp
+++ b/scripts/ci/make-tmp
@@ -35,6 +35,7 @@ fi
 if ! kubectl get namespace "$NAMESPACE" > /dev/null 2>&1; then
   printf "Creating namespace %s\t[ ${WARN} Processing ${NC} ]\n" | expand  -t 50 >&2
   kubectl create namespace "$NAMESPACE" > /dev/null
+  kubectl label namespace "$NAMESPACE" operator=test > /dev/null
   printf "Creating namespace %s\t[ ${OK} OK ${NC} ]\n" | expand  -t 50 >&2
 fi
 

--- a/scripts/ci/run-wrapper
+++ b/scripts/ci/run-wrapper
@@ -1,0 +1,8 @@
+{
+  set -e
+  scripts/ci/check-kubeconfig
+} || {
+  exit 1
+}
+
+$1

--- a/scripts/ci/run-wrapper
+++ b/scripts/ci/run-wrapper
@@ -1,3 +1,7 @@
+if [ -z "${KUBECONFIG}" ]; then
+    export KUBECONFIG=~/.kube/config
+fi
+
 {
   set -e
   scripts/ci/check-kubeconfig

--- a/scripts/ci/start-minikube
+++ b/scripts/ci/start-minikube
@@ -1,0 +1,8 @@
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ -z "${VM_DRIVER}" ]]; then
+    export VM_DRIVER=hyperkit
+  fi
+fi
+
+minikube start --vm-driver=${VM_DRIVER} --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 -p operators

--- a/scripts/ci/testscript-wrapper
+++ b/scripts/ci/testscript-wrapper
@@ -12,4 +12,6 @@ fi
 /scripts/ci/run-script "/scripts/ci/install-olm" "Install OLM"
 /scripts/ci/run-script "/scripts/ci/build-registry-image" "Make registry configmap"
 /scripts/ci/run-script "/scripts/ci/operator-test" "Operator deployment"
-/scripts/ci/run-script "/scripts/ci/scorecard" "Test operator with scorecard"
+if [[ $2 != "false" ]]; then
+  /scripts/ci/run-script "/scripts/ci/scorecard" "Test operator with scorecard"
+fi

--- a/scripts/lib-python/files/create_operator_group_file.py
+++ b/scripts/lib-python/files/create_operator_group_file.py
@@ -51,6 +51,9 @@ def main(argv):
                 'kind': 'OperatorGroup',
                 'metadata': {
                     'name': "{}-og".format(op_name),
+                    'labels': {
+                       'operator': 'test'
+                    },
                     'namespace': namespace,
                 }
             }
@@ -63,6 +66,9 @@ def main(argv):
                 'metadata': {
                     'name': "{}-og".format(op_name),
                     'namespace': namespace,
+                    'labels': {
+                        'operator': 'test'
+                    }
                 },
                 'spec': {
                     'targetNamespaces': [namespace]

--- a/scripts/lib/file
+++ b/scripts/lib/file
@@ -19,6 +19,8 @@ kind: CatalogSource
 metadata:
   name: ${op_name}-ocs
   namespace: $namespace
+  labels:
+    operator: test
 spec:
   displayName: $op_name Community Operator
   image: $op_image
@@ -42,6 +44,8 @@ kind: Subscription
 metadata:
   name: ${op_name}-sub
   namespace: $namespace
+  labels:
+    operator: test
 spec:
   name: $pkg_name
   source: ${op_name}-ocs

--- a/scripts/utils/Makefile
+++ b/scripts/utils/Makefile
@@ -72,6 +72,11 @@ operator.registry.build: check_path ## Build registry image
 	@scripts/ci/make-tmp
 	@scripts/ci/run-script "scripts/ci/build-registry-image" "Make registry configmap"
 
+operator.install: check_path
+	@scripts/ci/make-tmp
+	@make operator.verify
+	@scripts/ci/testscript-wrapper "false"
+
 operator.test: check_path ## Operator test which run courier and scorecard
 	@scripts/ci/make-tmp
 	@make operator.verify


### PR DESCRIPTION
Now it take only second to detect non answering api and logs look like:
```
Pulling docker image                                      [  OK  ]
Kube api not listening on kubernetes.docker.internal:6443 [  FAILED  ]
````

when you have config but you haven't specified `current-cluster` now tooling will start new minikube instance.

also added `operator.install` command - need to be documented

also added `operator.cleanup` command - need rebuild image for test 

For test locally:
run in scripts:
`docker build -t quay.io/operator-framework/operator-testing . -f Dockerfile.command`
and comment out pulling image in make file 