### PR TITLE
community-operators/metering: Add deprecation notice

### DIFF
--- a/community-operators/metering/meteringoperator.v4.1.0.clusterserviceversion.yaml
+++ b/community-operators/metering/meteringoperator.v4.1.0.clusterserviceversion.yaml
@@ -194,14 +194,26 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-metering-helm-operator:latest
     createdAt: 2019-01-01T11:59:59Z
-    description: Chargeback and reporting tool to provide accountability for how resources
-      are used across a cluster
+    description: The community version of metering is deprecated. Please update to using the metering-ocp package from the Red Hat Catalog within OperatorHub instead.
     repository: https://github.com/operator-framework/operator-metering
     support: Red Hat, Inc.
 
 spec:
-  displayName: Metering
+  displayName: Metering (deprecated)
   description: |
+    # Deprecation Notice
+
+    The community version of metering is **deprecated**.
+    Please update to using the **metering-ocp** package from the Red Hat Catalog within OperatorHub instead.
+
+    In the future, this version of the Metering package may be removed, so please plan accordingly.
+
+    *Tip*: To find the correct package from the OperatorHub page: filter by setting `Provider Type` to `Red Hat`  and search for `metering-ocp`.
+
+    ------------------
+
+    ### Summary
+
     Operator Metering is a chargeback and reporting tool to provide accountability for how resources are used across a cluster. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster wide. Operator Metering is part of the [Operator Framework](https://coreos.com/blog/introducing-operator-framework-metering).
 
     Read the user guide for more details on [running and viewing your first report](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/using-metering.md).
@@ -232,7 +244,7 @@ spec:
 
     * **Configure AWS Billing Data Source** - To assign Pod $$ costs on AWS, create a [read-only IAM user](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/configuring-aws-billing.md) ([example-policy](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/aws/read-only.json)) and [configure Metering](https://github.com/operator-framework/operator-metering/blob/release-4.1/Documentation/configuring-aws-billing.md) to use it.
 
-  keywords: [metering metrics reporting prometheus chargeback]
+  keywords: []
   version: "4.1.0"
   maturity: alpha
   maintainers:


### PR DESCRIPTION
Metering 4.1.0 via community-operators is deprecated as Metering is now
available via the Red Hat operator's catalog. There will be no further
updates to the community-operator/metering package except for a
potential removal in the future.


I don't really want to change the version because it's generally just a description update and I wouldn't want that to trigger an update, and that should be fine for how OLM/marketplace works IIRC.