### PR TITLE
Add MongoDB Enterprise 1.3.0 manifest

### DIFF
--- a/upstream-community-operators/mongodb-enterprise/1.3.0/mongodb-enterprise.v1.3.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/mongodb-enterprise/1.3.0/mongodb-enterprise.v1.3.0.clusterserviceversion.yaml
@@ -1,0 +1,292 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: "[\n  {\n    \"kind\": \"MongoDB\",\n    \"apiVersion\": \"mongodb.com/v1\"\
+      ,\n    \"metadata\": {\n        \"name\": \"sample-replica-set\"\n    },\n \
+      \   \"spec\": {\n      \"version\": \"4.0.10\",\n      \"type\": \"ReplicaSet\"\
+      ,\n      \"project\": \"my-project\",\n      \"persistent\": false,\n      \"\
+      members\": 3,\n      \"credentials\": \"my-credentials\"\n    },\n    \"status\"\
+      : {\n      \"version\": \"4.0.10\",\n      \"type\": \"ReplicaSet\",\n     \
+      \ \"phase\": \"Running\",\n      \"members\": 3,\n      \"link\": \"https://cloud.mongodb.com/v2/5d35f7cdbf994268c3\"\
+      ,\n      \"lastTransition\": \"2019-07-23T09:00:00Z\"\n    }\n  },\n  {\n  \
+      \  \"apiVersion\": \"mongodb.com/v1\",\n    \"kind\": \"MongoDB\",\n    \"metadata\"\
+      : {\n        \"name\": \"sample-sharded-cluster\"\n    },\n    \"spec\": {\n\
+      \        \"configServerCount\": 3,\n        \"credentials\": \"my-credentials\"\
+      ,\n        \"mongodsPerShardCount\": 3,\n        \"mongosCount\": 2,\n     \
+      \   \"persistent\": false,\n        \"project\": \"my-project\",\n        \"\
+      shardCount\": 1,\n        \"type\": \"ShardedCluster\",\n        \"version\"\
+      : \"3.6.8\"\n    },\n    \"status\": {\n        \"lastTransition\": \"2019-07-23T09:00:00Z\"\
+      ,\n        \"phase\": \"Running\"\n    }\n  },\n  {\n    \"apiVersion\": \"\
+      mongodb.com/v1\",\n    \"kind\": \"MongoDBUser\",\n    \"metadata\": {\n   \
+      \     \"name\": \"sample-user\"\n    },\n    \"spec\": {\n        \"db\": \"\
+      $external\",\n        \"project\": \"my-project\",\n        \"roles\": [\n \
+      \           {\n                \"db\": \"admin\",\n                \"name\"\
+      : \"clusterAdmin\"\n            }\n        ],\n        \"username\": \"CN=mms-user-1,OU=cloud,O=MongoDB,L=New\
+      \ York,ST=New York,C=US\"\n    }\n  },\n  {\n  \"apiVersion\": \"mongodb.com/v1\"\
+      ,\n  \"kind\": \"MongoDBOpsManager\",\n  \"metadata\": {\n    \"name\": \"ops-manager\"\
+      \n  },\n  \"spec\": {\n    \"version\": \"4.2.0\",\n    \"adminCredentials\"\
+      : \"ops-manager-admin\",\n    \"configuration\": {\n      \"mms.fromEmailAddr\"\
+      : \"admin@thecompany.com\"\n    },\n    \"applicationDatabase\": {\n      \"\
+      members\": 3,\n      \"version\": \"4.2.0\",\n      \"persistent\": true,\n\
+      \      \"type\": \"ReplicaSet\",\n      \"podSpec\": {\n        \"cpu\": \"\
+      0.25\"\n      }\n    }\n  }\n}\n]\n"
+    capabilities: Deep Insights
+    categories: Database
+    certified: 'true'
+    containerImage: quay.io/mongodb/mongodb-enterprise-operator:1.3.0
+    createdAt: 2019-10-23T14:42:02Z
+    description: The MongoDB Enterprise Kubernetes Operator enables easy deploys of
+      MongoDB into Kubernetes clusters, using our management, monitoring and backup
+      platforms, Ops Manager and Cloud Manager.
+    repository: https://github.com/mongodb/mongodb-enterprise-kubernetes
+    support: MongoDB Community Support
+  name: mongodb-enterprise.v1.3.0
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: MongoDB Deployment
+      displayName: MongoDB Deployment
+      group: mongodb.com
+      kind: MongoDB
+      name: mongodb.mongodb.com
+      version: v1
+    - description: MongoDB x509 User
+      displayName: MongoDB User
+      group: mongodb.com
+      kind: MongoDBUser
+      name: mongodbusers.mongodb.com
+      version: v1
+    - description: MongoDB Ops Manager Alpha
+      displayName: MongoDB Ops Manager
+      group: mongodb.com
+      kind: MongoDBOpsManager
+      name: opsmanagers.mongodb.com
+      version: v1
+  description: 'The MongoDB Enterprise Kubernetes Operator enables easy deploys of
+    MongoDB
+
+    into Kubernetes clusters, using our management, monitoring and backup
+
+    platforms, Ops Manager and Cloud Manager.
+
+
+    The Operator has alpha support for a containerized Ops Manager with the `MongoDBOpsManager`
+    custom resource.
+
+
+    ## Before You Start
+
+
+    To start using the operator you''ll need an account in MongoDB Cloud Manager or
+    a MongoDB Ops Manager deployment.
+
+
+    * [Create a Secret with your OpsManager API key](https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/#create-credentials)
+
+
+
+    * [Create a ConfigMap with your OpsManager project ID and URL](https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/#create-onprem-project)
+
+
+
+    By installing this integration, you will be able to deploy MongoDB instances
+
+    with a single simple command.
+
+
+    ## Required Parameters
+
+
+    * `project` - Enter the name of the ConfigMap containing project information
+
+
+
+    * `credentials` - Enter the name of the Secret containing your OpsManager credentials
+
+
+
+    ## Supported MongoDB Deployment Types ##
+
+
+
+    * Standalone: An instance of mongod that is running as a single server and
+
+    not as part of a replica set, this is, it does not do any kind of
+
+    replication.
+
+
+
+    * Replica Set: A replica set in MongoDB is a group of mongod processes that
+
+    maintain the same data set. Replica sets provide redundancy and high
+
+    availability, and are the basis for all production deployments. This section
+
+    introduces replication in MongoDB as well as the components and architecture
+
+    of replica sets. The section also provides tutorials for common tasks
+
+    related to replica sets.
+
+
+
+    * Sharded Cluster: The set of nodes comprising a sharded MongoDB deployment.
+
+    A sharded cluster consists of config servers, shards, and one or more mongos
+
+    routing processes. Sharding is a A database architecture that partitions
+
+    data by key ranges and distributes the data among two or more database
+
+    instances. Sharding enables horizontal scaling.
+
+
+    ## Security ##
+
+
+    The operator can enable TLS for all traffic between servers and also between
+
+    clients and servers. Before enabling `security.tls.enabled` to `true` you should
+
+    create your certificates or you can leave the operator to create all the
+
+    certificates for you. For more information, please read the official MongoDB
+
+    Kubernetes Operator [docs](https://docs.mongodb.com/kubernetes-operator/stable/).
+
+    '
+  displayName: MongoDB
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAH8AAAB/CAYAAADGvR0TAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4ggYEhkp9JVi8gAAFENJREFUeNrtnXmcVeV5x7/Pe86dGUZQUdwAo4Kaam1cUAdm3DAYl1ZjmmhMYkUlkMYtMVVrVExqY7q4oabNp6EuMdpEq8ZGpf1oJCbKJgxqlWiIgIrACCgimwJznv5xlvue5d65dxjsvXPP4+d4t3OB+/7e37O/7wsNKhdNv9iZ8uqNQgOLadhfLnLA7CV/OOrT/3JMDn7D/XDh02s3bRr/h4ufz8FvNOnu1s9v2rL5/EZW+06j/eCJT09i1Pijdhb46ZpNGwa4Jw4x7097+9mGtHyN+KMn/fob/yyYK998byWLV727FXQPgfcXXjIjV/v9Uc7/nwkATHhq4t+q6pWKUjAOgroCf73wkhkc+KOOnPn9dwJceIkx5k6DwRjDyg/XsmD52+Eg7LHwkhkrc+b3Izl32nkAnDftgkcV7kRBUVQVxxhAw1ufOfBHHaaR2N+vwf/KE+fS7W0Z8LVp5z2t6BcIQPfhViSu9w4BLlt4yQxG3NmRg1/v8vO/uB/EmY3qOFDUC3iuiiq4xsHXBOAB3cptI+/s+KvFl87ggAaYAP3S5n/pV18WjNnBUZllxBwiAo44CIIYgxHBiMP6jzcxd8kixFIBAp7AV/546YyHcubXoXy03gVPf6noIaGS93xLT6DxAcU1DhIMQngJGFUe3P+OjhMB9r+jI2d+PciZj30JcUWkW6Yb5AQxBgeDiGCMYDCIBMw3ho82b2XOooUx5lviASe9cdmM6Tnz60AeO/NhdKveBHqCRgh6Edsjex+8doz0RIxn9r+j41BfA7TnzK9VGff0WbSu964V4QdGDIJgQpYHjyImYL/giKFblecXvo6RcsOgHrDHG5fNXN3fwHf7yw9pWbe1DZEbQNBoVvvPNHxHFSR8D1Q1dp/lECS14//uf0f7/t3CRuPBom/NzMGvFTnl4TP2VHS2IqAB3AKqgieKo4IHGAkifFVUFNcxKIogKdA1/rgXMGvJpTMPzW1+jcjJD5/u2y7hwZDJSRB9WIvve9FzP9YPX3kUn2vxFqR4fWbk7e33Aoy8vX/Y/7ot6Y576DSePutJTn749O+DjAd82y0SZe5EAk0QvCcUH0FA4K33VvvvV/bXHrbLqXu/suhbM1/LHb7/RznxodMwyJ+ImFccEdd36ASDH8b5Dl8Q3gVhXuj8SfC+4zg8+9rve3D40h4gMAp4sd5tf92q/elnT0PR/0Q914spdgJ1roE61+i1F5mAwMUT6S1h7u8PTl/dgj/2wVNvVThEAzx8e2/bdBJef2jMLd9Atbd//cEjb29/LAf/E5ZjfzGK439xyi6q+o2wQqfqUXT4Am8+8Nw8y7FLagXdtn/K50dMaT8OYMSU9hz8T0KeO6cTD+9nCq2hCbYJrBnPovvs/H4vma9avICHARZ/e2YO/ichHf9x0qkopyVr82GDBpE2KDZtqHWvhpogeL+lUCgJbtaVkN1GTGmfmqv97SyjH/hsyNfvpZMwCdWeUuqhdogS/CXB7oWcO2JK+3Bf/Y/Jwd8eMvtrzzD6gc8eC9rmqaXC1c/RqfoFHE81075HvgCWBthWq+//qS2gj+bM386i8IiStu+R8leNWXjb67dDvMgxrBp8zbgAOGrElDFfWPztWTn4fS2j7h/LkQ+ceKaiu0VAaqjOk2zGsvvF19ZDZPfRLPi1zFVWrgUYeduYHPy+ksPvH0vnub9B4W+8BGsjSGL2PAGVxplP4vt+Sb9igKMsjxDL+yPKqJG3jTl50eWzcvD7Sl489zccdv/Yg1T1mBg3LeRDhnuZXr+t/hNaQqHgOj1CngQ7OU+s4tCjAPvVCfvrQu2r6r1gVd80bs9Dey+AemrX7YqRgGrC69fIfJRgcnRF0YD1b7Avay607nfbmDPZsiUHf1vlT+87nkN+dsLexTRu3JVTjSduvIR6Twd8dhRgpX9LMzle6q3EMKheseSqeex36+gc/G2RBef9FlRPUWj1U7aaAEIDmy4Z6t1iOxpL+GA5gl4Gm8uC3HMWqGO/W0cftuQ7s3Pweyv73ndcyObJIavjSRvbU/fifrpGjVsxb59EgFecPGWZ3Jss0L/Wg9qv6Xr+gfcd1+bAbCeozTviPwrghvV6kUSzZrGG74hBwH8UgwiEzZ2OGFzH4dW3l7Fu00d9NhDBn7MROBh4a3ENa4CaVvuiXBxT82qHepbXL/HQL5b0EUmVedmGDJ/0cAXSCpyyuMZVf002cI786bEItCi021k5FX/4QxstqsWmXJGiLRcJ7vcfRSRKBdjNnapUFOb1LkJhMvBvuc2vUhaNfw6FQQojwyXVWM4YqjGvH5VEsVaLqd6MeN+2/64xlTA5Ow9ouQJe4lIYtu8tozty8HshnuqXvXj1naxcnP/cSyV80l4/VnJHoySPY6RH+kehnw2uVhT+fScHv3dyeXzwNeq/KC7FSoIdDwND0KP2bdUMSONM9rJY3Pty75H73jK6NQe/CtnvnvbBqowopmxJlWHTGkFT+Xs0I0ljN3daKrsS+98L+RSwRw5+hTL87na6VcbZ9hrNAFATmT6NR/Hx9K4mcoPxhVzbK4YOUsaX5uBXKO9cOBPfyy9n7232B80cVi9fmA3ESvhkNXdq34CbeVnz7KIc/OrkzzwbSEtd26ocqy+PhJOX8vpJN3d621DGreKrzfvc3HZYDn6lMTJ6UBHwEKSMjpykVlAt7fVnNHdGwEp5FvcMdrF+4GVcwMn73NyWg9+TDLtrtKMwFEpU5EJHzvrQixie5QymJ0LsDnuVZkUTMwvsHhVBx1tXzMkzfD1JNzLWsRmugooPsETZPcW/R2IFHN+DV8LQXVRRMUEKMPxMYgma0kxOmgoyzEdFmT6Aw3O1X5mM1WTEZoVu8UZMUmVem9BRCZdkG1eyEuBFXUAVMrks2BlFwOH73tS2Yw5+z2p1XFaRxqvI609z1s7yxU2HWhpfKmZ0T+X80DE0iQs4Kwe/Z/APTa6viK27s7J1ttdfbXOnJl35KsEtBXJ2TUABPSG3+WVkt7vaBgEFjaJ38JDAvqeZLyWehyAhQf+eiNXNE34mUcyvHiWrOJKeHxW7hQk5Jge/7JjJEBXfsfMiFoWUlcBpI3Lo1C7hkiz9UtxtJ6jrq6eokZRLJ71SgVrFXYL6qd5c7ZeRnYNwO8bwLAcs+VnKS1dKNnfaWT9T0ZYsPS/gKH4ieMHVHT33P9v7prYhOfglxIMhsZ46jdttuxQbX2xZfXNn2LpdcA3lV+lkAV0EtzsGspSLFATIwS/DsB2ChFtmNi9ksO39q/auuTMxfcpyPQ10hUo/mUhQHZTb/AwZPLUNYGcPMBQ3SkRBRYNuHX9m+EkeuyYnMTNgYuz3k0Rhy5f/OnQnQ21h+mKnDog2dSw5AXbJmZ8haybOQWFgejPEeMq2VJnXs5o7PXvcJavM62f7wnu9Sku7qki5q/y3BRiQg196bAfGnTVSS6/CnL5nq2dNLse2l2dZSR6NL+UuklIqA3vbf2IhB78MO7I8+hAkz4/YYuCFyzPC1TZZzZ3JvF9sJU/vmdwbGZiDX1r20MTOKWECx4uFcHFVrclevNhzDxL782BNKlNFzN7LjKU9iWtqkUxNJXkUXS+RI1bcDtlDMYHjpgkl7QXungabK4f7Knqov8LW2mhRk16/KK5r+gTgWGhaJ1Jj4LNOiDdlSjHHl1nmdaLPLc/fXqhhfU+iFR69a9hUa+ZplQpDtq+CqX/wSXFeLIb7QHsKjhAu0wlCQaxVPFb6N4rrJbg1SPwE6/3K9fFpKSZrDwCXvFcBNufgl5bV9vq7MMZPTweNGjnsoo79WTSVxAT2XvxCj81+wDHGdyQrZW85nd+zfJQ7fGXC/axxTfbc99Tc6VmsVs06REGjtK+UOGcnc+lWun+cKto+FFifM7+EeMqHRgJeBupcokRN0fe3tYOHX5zRmMkAzQKagP1Blg8tbuci2Wq6r2Vdzvwyah8oEcRlLbDKDKeKmoH4Hj6aTA6FMWTyeI3t55mtzcEvLe96mraimuq5tdV9Vmt3Yv+9jOROBLZsH7AzNm9SD97PwS+lEye9sCL8N6l1SEKsBaua5s4UlzXe3FltvFYZyLGyrtX7Lx6szMEvP5wvJ7N0sRi/THNnvAwbP1ghy2RUw/keQSZ74YclH6y4eu7WHPzy8lRy1L2kzdf4ku2wuTOaJJa697dlIb7lOumNmtKTJ35FUUCPK3pKNoXU3LGstQj+Q1piG1UyGJ+eFOk0bkyD2Dt3EqzBz4CqsrV5Ve3P+1QOfo92f+48YItmeP3pHn57V83k2XiasXmTvcwqDPO0t0yu9qf9Mge/Uruv2RF3chdNz8rwkfAPsvbwKf4hyZp+KTb3TYj3znfnrRr+D0fm4FcgL0SJnxJePwn7H2/uJHHAAtnNnfKJxfevArzz3Xk5+OVk0E+OAvh1qbNtyYj9yzd3SvxbGt+fY/NWb/vpr+JKn85aZFgt2nyAx1KAa7H33o6hY15/LOGTbACLO4ihryCS7BDoE7CT5mR6Dn7lE0CBB2MnY2Tw39um5s7q9+Cs8uQtW57Mwa9ObshKxKQOTbK47SXUf1ZzZywrCGwtofarBLec/Peya+ZtzcGvzu4vAV2qatvrDJ/cbu4kq7kzWeaNr+CNFmv2DdBZ8v1aZVetqn3WTZq7ybaVqdCbnps7S63vKzqF2tdAJ2UVsGDYD4+sSfBdaluuBh0fdubYnTqVNHfaZ+l4QStX6Cs4wfKfrVs9ZPv11M5fds28DTnze6H6102a2wU8mqnuS2yhni7zxhs8U3F/H1O/mBZWgB/WMrNqFvx1k+aGtv8GoDt5nl6m1x9L4JMq83qprKHS3e31GdhiOQ0Kbyy7Zt7vht84Kge/97LlZdClWXbf9vq9MsmfeEtXMczzAM+rDtwkyF54kSr1XgHwzrWdNTuyQh3IoJ8cdQzIc0b83nuDf7iC/drgvzYIjpHgeBWJ3ncQRARXgvtFcI1h2dtr6e7W9IBoOrNQhYFYA4wAPlhew+CbOgCedZPmPg88kQJBExk7SLR3pb38ZCa/e4sXi/GSTK66P9e/bll+bWdNA19HzD8a4EgR5orFcqF44FLI5kgDBIctOYGWcAIN4QQHNUnwuHTxB7339rNnxOrl13XuVg/jWhcnaq6b9ALrJr0wT5VfJcc9eyl3afarlfDxVCtlcjXl/OupE6mrI9SBs4H3SjV3UqK5UxNef/i1yNb3Sa8GAB8CU4f+YFRdDKZTT8hvfnxZd8sZwzYDp/gLMHwTQGACwv31JEjoiP+/xD3BcxG8bmXj2s29Nn4Zq3qOX35d59J101fkzN8esnbiC1OAWSFjk2pd1Gr7DmieLvMG3+khxq/wDL3w739i2XWdc4bVCevrEvydph4N8OcKG8s1dybbvWJl3lDtJ1ZoVnKsWtbqoOCMnosBll3XmYO/ndm/RtGrifFZMxI6JZo7g46eJnVioGeBXOqkrcT6/jNWTO58e6+/H1VX4yj1CP5OU49m7cQXGDy17QGBrxoJbHxWwkfEP1c3CgWLCZ8dNxZYvPK9aCMH6d3OGtMFxinoismdOfifhAT79g0E3jbCYBMAKhG4xcfoEGYER8LJIQzd0MpLq7p8h7B3of1moKVrcqfW4xiaegV/zcQ5rJk4Zz1whMLmrNZtteZ3uA9nsblTGZKxLV7lob0CjO2a3Kl71pm6r3vwQ/avmTjnTYGz00uxrJbu1N59/n+70lqy8aOcqxcUiW/smtw5E6CrztR9vwB/zcQ57DK1jfe+Pue/QCfan3lJniaaOz1gT7NDopOnCK4Em7IaDS+iS5Qfd02ef92QG4+o5+GrryRPlmx6fBm7/nsb7319zvwdzhg+FGFUmPAJfYAw4SPi+/Xhhk0dW4ay6OP32aAfR/UB0R5P0J4DfHHQ2L303cnz63rshH4mQ+4a/YhB/jL0+p0gCnCCvXfcwPFTUa7aeDRPbvgjszYsrdTpWwAcvvz6+Vv6w1iZfga8rJ4w+4vA42o5eGGyx473W9XFxfCZAXvSXaLAkzjQ4RWFY/sL8P0O/NUTZuvud41h5YRZZwC/S2b2bH9gL28gHsrQwo4MMG7ZjReAJQptmtgtrN7FpR/K7neNoQXGfgyPKZxerAKGXb7K8O5BYPxunt0Lg3hnc8m9kuYDY7uun7+pv42T6W8/aOWEWaycMIuPwevyNcDP7eSMBrt47OPthAq4jsMRA4exVb0spf8ydI+mxrZQy8HvQbomzGLoXWNYPmHmVxWuDIEHKOAwmBbECCKGk4ccxGB3QBTxB3H8j4FRXde/vKXr+vmag19nsnzCLIbd3c6yC2feDHxToRtgR68JFx94YwweylUjPkerFEB1M8qVXde/eBHB/f1VhAaSfe7p2FeQBQfozq3neAfhOAWaCk00NTXT3NyCNLXwT68/fvBzl097ba+/O5wV33uxX4+HaRTgP3V3B29dMOPNN2X50GO6h/mt38ZEl2NcWp3Cxc9dPu21S+/5Zr8HvuGYH8rUqVfc6zru+EKhiaZCE81NLTS3DFjluk0HGnE+OPGkCxtiHNxGBN8x5hERM96IwTEOxnEwxv39uM9N/KCRxsE0IvjGOAuNMVt8le/gOC6OcZ9tuHGgIUWXGuNsdYyDBPbecZyXcvAbQM6/4B83OkZWi3FwHRfHdTGOuzQHv2FUvzsj8vSdAq5bWJGD3zDgm07HMRingOO67DBghw9y8BvH43/diIPruriOi1tokhz8BvL4HccNVT5OoUAOfqP8cMdd5YPv4LpNFNzmHPxGkTPOvHyN4zg+8wtNNLe05OA3GPspuAUKhSYU2TkHv4Gk4BQ8t9BEU6GZ5qbmQTn4jeTxu4WX3EKBQnMzheaW3XPwG0Se++0DtB97zqjWloG7NhVa7m5pGjCYXBpHXlsQ3wZ/w/plDfX7/w9sJTyL9hMvGQAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - certificates.k8s.io
+          resources:
+          - certificatesigningrequests
+          verbs:
+          - get
+          - create
+          - list
+          - watch
+        serviceAccountName: mongodb-enterprise-operator
+      deployments:
+      - name: mongodb-enterprise-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              k8s-app: mongodb-enterprise-operator
+          template:
+            metadata:
+              labels:
+                k8s-app: mongodb-enterprise-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: MANAGED_SECURITY_CONTEXT
+                  value: 'false'
+                - name: OPERATOR_ENV
+                  value: prod
+                - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
+                  value: quay.io/mongodb/mongodb-enterprise-database:1.3.0
+                - name: IMAGE_PULL_POLICY
+                  value: Always
+                image: quay.io/mongodb/mongodb-enterprise-operator:1.3.0
+                imagePullPolicy: Always
+                name: mongodb-enterprise-operator
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 100Mi
+                  requests:
+                    cpu: 100m
+                    memory: 50Mi
+              serviceAccountName: mongodb-enterprise-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - secrets
+          - services
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - delete
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - mongodb.com
+          resources:
+          - mongodb
+          - mongodb/finalizers
+          - mongodbusers
+          - opsmanagers
+          - opsmanagers/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update
+        serviceAccountName: mongodb-enterprise-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - mongodb
+  - database
+  - nosql
+  links:
+  - name: Documentation
+    url: https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/index.html
+  maintainers:
+  - email: support@mongodb.com
+    name: MongoDB, Inc
+  maturity: stable
+  minKubeVersion: 1.11.0
+  provider:
+    name: MongoDB, Inc
+  replaces: mongodb-enterprise.v1.2.4
+  version: 1.3.0

--- a/upstream-community-operators/mongodb-enterprise/1.3.0/mongodb.mongodb.com.crd.yaml
+++ b/upstream-community-operators/mongodb-enterprise/1.3.0/mongodb.mongodb.com.crd.yaml
@@ -1,0 +1,276 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mongodb.mongodb.com
+spec:
+  group: mongodb.com
+  version: v1
+  scope: Namespaced
+  names:
+    kind: MongoDB
+    plural: mongodb
+    shortNames:
+    - mdb
+    singular: mongodb
+  additionalPrinterColumns:
+    - name: Type
+      type: string
+      description: "The type of MongoDB deployment. One of 'ReplicaSet', 'ShardedCluster' and 'Standalone'."
+      JSONPath: .spec.type
+    - name: State
+      type: string
+      description: The current state of the MongoDB deployment.
+      JSONPath: .status.phase
+    - name: Version
+      type: string
+      description: The version of MongoDB.
+      JSONPath: .spec.version
+    - name: Age
+      type: date
+      description: The time since the MongoDB resource was created.
+      JSONPath: .metadata.creationTimestamp
+  validation: # there are 3 possible schemas, ReplicaSet, ShardedCluster and Standalone
+    openAPIV3Schema:
+      oneOf:
+      - properties: # Standalone schema
+          spec:
+            properties:
+              credentials:
+                type: string
+              project:
+                type: string
+                description: "DEPRECATED The name of a configMap in the same namespace"
+              opsManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+              cloudManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+              version:
+                type: string
+                pattern: "^[0-9]+.[0-9]+.[0-9]+(-.+)?$"
+              logLevel:
+                type: string
+                enum: ["DEBUG", "INFO", "WARN", "ERROR", "FATAL"]
+              type:
+                type: string
+                pattern: "^Standalone$"
+              security:
+                type: object
+                properties:
+                  authentication:
+                    properties:
+                      enabled:
+                        type: boolean
+                      modes:
+                        type: array
+                        items:
+                          type: string
+                          enum: ["X509"]
+                  tls:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      ca:
+                        type: string
+              additionalMongodConfig:
+                properties:
+                  net:
+                    properties:
+                      ssl:
+                        properties:
+                          mode:
+                            type: string
+                            enum: ["disabled", "allowSSL", "preferSSL", "requireSSL", "allowTLS", "preferTLS", "requireTLS"]
+              exposedExternally:
+                type: boolean
+            anyOf:
+              - required: [project]
+              - required: [opsManager]
+              - required: [cloudManager]
+            required:
+            - credentials
+            - version
+            - type
+      - properties: # ReplicaSet schema
+          spec:
+            properties:
+              members:
+                maximum: 50
+                minimum: 1
+                type: integer
+              credentials:
+                type: string
+              project:
+                type: string
+                description: "DEPRECATED The name of a configMap in the same namespace"
+              opsManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+              cloudManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+              version:
+                type: string
+                pattern: "^[0-9]+.[0-9]+.[0-9]+(-.+)?$"
+              logLevel:
+                type: string
+                enum: ["DEBUG", "INFO", "WARN", "ERROR", "FATAL"]
+              type:
+                type: string
+                pattern: "^ReplicaSet$"
+              security:
+                type: object
+                properties:
+                  authentication:
+                    properties:
+                      enabled:
+                        type: boolean
+                      modes:
+                        type: array
+                        items:
+                          type: string
+                          enum: ["X509"]
+                      internalCluster:
+                        type: string
+                        enum: ["X509"]
+                  tls:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      ca:
+                        type: string
+                  clusterAuthenticationMode:
+                    # Warning: please refer to the documentation before enabling X509 in your MongoDB resource.
+                    # https://docs.mongodb.com/kubernetes-operator/
+                    type: string
+                    enum: ["x509"]
+              additionalMongodConfig:
+                properties:
+                  net:
+                    properties:
+                      ssl:
+                        properties:
+                          mode:
+                            type: string
+                            enum: ["disabled", "allowSSL", "preferSSL", "requireSSL", "allowTLS", "preferTLS", "requireTLS"]
+              exposedExternally:
+                type: boolean
+            anyOf:
+              - required: [project]
+              - required: [opsManager]
+              - required: [cloudManager]
+            required:
+            - credentials
+            - version
+            - type
+            - members
+            # TODO: add validation for OpsManager or Cloud Manager being required
+      - properties:
+          spec:
+            properties: # ShardedCluster schema
+              configServerCount:
+                maximum: 50
+                minimum: 1
+                type: integer
+              mongodsPerShardCount:
+                maximum: 50
+                minimum: 1
+                type: integer
+              mongosCount:
+                minimum: 1
+                type: integer
+              shardCount:
+                minimum: 1
+                type: integer
+              credentials:
+                type: string
+              project:
+                type: string
+                description: "DEPRECATED The name of a configMap in the same namespace"
+              opsManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+              cloudManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+              version:
+                type: string
+                pattern: "^[0-9]+.[0-9]+.[0-9]+(-.+)?$"
+              logLevel:
+                type: string
+                enum: ["DEBUG", "INFO", "WARN", "ERROR", "FATAL"]
+              type:
+                type: string
+                pattern: "^ShardedCluster$"
+              security:
+                type: object
+                properties:
+                  authentication:
+                    properties:
+                      enabled:
+                        type: boolean
+                      modes:
+                        type: array
+                        items:
+                          type: string
+                          enum: ["X509"]
+                      internalCluster:
+                        type: string
+                        enum: ["X509"]
+                  tls:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      ca:
+                        type: string
+                  clusterAuthenticationMode:
+                    # Warning: please refer to the documentation before enabling X509 in your MongoDB resource.
+                    # https://docs.mongodb.com/kubernetes-operator/
+                    type: string
+                    enum: ["x509"]
+              additionalMongodConfig:
+                properties:
+                  net:
+                    properties:
+                      ssl:
+                        properties:
+                          mode:
+                            type: string
+                            enum: ["disabled", "allowSSL", "preferSSL", "requireSSL", "allowTLS", "preferTLS", "requireTLS"]
+              exposedExternally:
+                type: boolean
+            anyOf:
+              - required: [project]
+              - required: [opsManager]
+              - required: [cloudManager]
+            required:
+            - credentials
+            - version
+            - type
+            - shardCount
+            - mongodsPerShardCount
+            - mongosCount
+            - configServerCount

--- a/upstream-community-operators/mongodb-enterprise/1.3.0/mongodbusers.mongodb.com.crd.yaml
+++ b/upstream-community-operators/mongodb-enterprise/1.3.0/mongodbusers.mongodb.com.crd.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mongodbusers.mongodb.com
+spec:
+  group: mongodb.com
+  version: v1
+  scope: Namespaced
+  names:
+    kind: MongoDBUser
+    plural: mongodbusers
+    shortNames:
+    - mdbu
+    singular: mongodbuser
+  validation:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              username:
+                type: string
+                description: "The username of the user"
+              db:
+                type: string
+                description: "The database the user is stored in"
+                enum: ["$external"]
+              project:
+                type: string
+                description: "DEPRECATED The project the user belongs to"
+              mongodbResourceRef:
+                properties:
+                  name:
+                    type: string
+                    description: "The name of a MongoDB resource in the same namespace"
+              roles:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: "The name of the role"
+                    db:
+                      type: string
+                      description: "The db the role can act on"
+                  required:
+                    - name
+                    - db
+            required:
+              - username
+              - db

--- a/upstream-community-operators/mongodb-enterprise/1.3.0/opsmanagers.mongodb.com.crd.yaml
+++ b/upstream-community-operators/mongodb-enterprise/1.3.0/opsmanagers.mongodb.com.crd.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: opsmanagers.mongodb.com
+spec:
+  group: mongodb.com
+  version: v1
+  scope: Namespaced
+  names:
+    kind: MongoDBOpsManager
+    plural: opsmanagers
+    shortNames:
+    - om
+    singular: opsmanager
+  additionalPrinterColumns:
+    - name: Version
+      type: string
+      description: The version of MongoDBOpsManager.
+      JSONPath: .spec.version
+    - name: Version (DB)
+      type: string
+      description: The version of Application Database  .
+      JSONPath: .spec.applicationDatabase.version
+    - name: State
+      type: string
+      description: The current state of the MongoDBOpsManager.
+      JSONPath: .status.opsManager.phase
+    - name: State (DB)
+      type: string
+      description: The current state of the MongoDBOpsManager Application Database.
+      JSONPath: .status.applicationDatabase.phase
+    - name: Age
+      type: date
+      description: The time since the MongoDBOpsManager resource was created.
+      JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            version:
+              type: string
+            backup:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+
+                headDB:
+                  type: object
+                  properties:
+                    storage:
+                      type: string
+                    storageClass:
+                      type: string
+
+            applicationDatabase:
+              type: object
+              properties:
+                members:
+                  maximum: 50
+                  minimum: 3
+                  type: integer
+                version:
+                  type: string
+                  pattern: "^[0-9]+.[0-9]+.[0-9]+(-.+)?$"
+                logLevel:
+                  type: string
+                  enum: ["DEBUG", "INFO", "WARN", "ERROR", "FATAL"]
+                exposedExternally:
+                  type: boolean
+              required:
+                - version
+                - type
+                - members
+          required:
+            - version
+            - applicationDatabase

--- a/upstream-community-operators/mongodb-enterprise/mongodb-enterprise.package.yaml
+++ b/upstream-community-operators/mongodb-enterprise/mongodb-enterprise.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: mongodb-enterprise.v1.2.4
+- currentCSV: mongodb-enterprise.v1.3.0
   name: stable
 defaultChannel: stable
 packageName: mongodb-enterprise


### PR DESCRIPTION
We're releasing 1.3.0 of the MongoDB Enterprise Kubernetes Operator. I believe I correctly adjusted to the new nested structure.

Released version: https://github.com/mongodb/mongodb-enterprise-kubernetes/releases/tag/1.3.0