### PR TITLE
Update package for Operator 4.1.0

### DIFF
--- a/community-operators/postgresql/4.1.0/pgbackups.crunchydata.com.crd.yaml
+++ b/community-operators/postgresql/4.1.0/pgbackups.crunchydata.com.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pgbackups.crunchydata.com
+spec:
+  group: crunchydata.com
+  names:
+    kind: Pgbackup
+    listKind: PgbackupList
+    plural: pgbackups
+    singular: pgbackup
+  scope: Namespaced
+  version: v1

--- a/community-operators/postgresql/4.1.0/pgclusters.crunchydata.com.crd.yaml
+++ b/community-operators/postgresql/4.1.0/pgclusters.crunchydata.com.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pgclusters.crunchydata.com
+spec:
+  group: crunchydata.com
+  names:
+    kind: Pgcluster
+    listKind: PgclusterList
+    plural: pgclusters
+    singular: pgcluster
+  scope: Namespaced
+  version: v1

--- a/community-operators/postgresql/4.1.0/pgpolicies.crunchydata.com.crd.yaml
+++ b/community-operators/postgresql/4.1.0/pgpolicies.crunchydata.com.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pgpolicies.crunchydata.com
+spec:
+  group: crunchydata.com
+  names:
+    kind: Pgpolicy
+    listKind: PgpolicyList
+    plural: pgpolicies
+    singular: pgpolicy
+  scope: Namespaced
+  version: v1

--- a/community-operators/postgresql/4.1.0/pgreplicas.crunchydata.com.crd.yaml
+++ b/community-operators/postgresql/4.1.0/pgreplicas.crunchydata.com.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pgreplicas.crunchydata.com
+spec:
+  group: crunchydata.com
+  names:
+    kind: Pgreplica
+    listKind: PgreplicaList
+    plural: pgreplicas
+    singular: pgreplica
+  scope: Namespaced
+  version: v1

--- a/community-operators/postgresql/4.1.0/pgtasks.crunchydata.com.crd.yaml
+++ b/community-operators/postgresql/4.1.0/pgtasks.crunchydata.com.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pgtasks.crunchydata.com
+spec:
+  group: crunchydata.com
+  names:
+    kind: Pgtask
+    listKind: PgtaskList
+    plural: pgtasks
+    singular: pgtask
+  scope: Namespaced
+  version: v1

--- a/community-operators/postgresql/4.1.0/postgresoperator.v4.1.0.clusterserviceversion.yaml
+++ b/community-operators/postgresql/4.1.0/postgresoperator.v4.1.0.clusterserviceversion.yaml
@@ -1,0 +1,549 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: "[{\n    \"apiVersion\": \"crunchydata.com/v1\",\n    \"kind\":\
+      \ \"Pgcluster\",\n    \"metadata\": {\n        \"labels\": {\n            \"\
+      archive\": \"false\",\n            \"archive-timeout\": \"60\",\n          \
+      \  \"crunchy-pgbadger\": \"false\",\n            \"crunchy_collect\": \"false\"\
+      ,\n            \"current-primary\": \"fromcrd\",\n            \"deployment-name\"\
+      : \"fromcrd\",\n            \"name\": \"fromcrd\",\n            \"pg-cluster\"\
+      : \"fromcrd\",\n            \"pgo-backrest\": \"false\",\n            \"pgo-version\"\
+      : \"4.1.0\",\n            \"primary\": \"true\"\n        },\n        \"name\"\
+      : \"fromcrd\",\n      \"namespace\": \"pgo\"\n    },\n    \"spec\": {\n    \
+      \    \"ArchiveStorage\": {\n            \"accessmode\": \"\",\n            \"\
+      fsgroup\": \"26\",\n            \"matchLabels\": \"\",\n            \"name\"\
+      : \"\",\n            \"size\": \"\",\n            \"storageclass\": \"fast\"\
+      ,\n            \"storagetype\": \"dynamic\",\n            \"supplementalgroups\"\
+      : \"\"\n        },\n        \"BackrestStorage\": {\n            \"accessmode\"\
+      : \"ReadWriteOnce\",\n            \"fsgroup\": \"26\",\n            \"matchLabels\"\
+      : \"\",\n            \"name\": \"\",\n            \"size\": \"1G\",\n      \
+      \      \"storageclass\": \"fast\",\n            \"storagetype\": \"dynamic\"\
+      ,\n            \"supplementalgroups\": \"\"\n        },\n        \"ContainerResources\"\
+      : {\n            \"limitscpu\": \"\",\n            \"limitsmemory\": \"\",\n\
+      \            \"requestscpu\": \"\",\n            \"requestsmemory\": \"\"\n\
+      \        },\n        \"PrimaryStorage\": {\n            \"accessmode\": \"ReadWriteOnce\"\
+      ,\n            \"fsgroup\": \"26\",\n            \"matchLabels\": \"\",\n  \
+      \          \"name\": \"fromcrd\",\n            \"size\": \"1G\",\n         \
+      \   \"storageclass\": \"fast\",\n            \"storagetype\": \"dynamic\",\n\
+      \            \"supplementalgroups\": \"\"\n        },\n        \"ReplicaStorage\"\
+      : {\n            \"accessmode\": \"ReadWriteOnce\",\n            \"fsgroup\"\
+      : \"26\",\n            \"matchLabels\": \"\",\n            \"name\": \"\",\n\
+      \            \"size\": \"1G\",\n            \"storageclass\": \"fast\",\n  \
+      \          \"storagetype\": \"dynamic\",\n            \"supplementalgroups\"\
+      : \"\"\n        },\n        \"backuppath\": \"\",\n        \"backuppvcname\"\
+      : \"\",\n        \"ccpimage\":\"crunchy-postgres\",\n        \"ccpimagetag\"\
+      : \"centos7-11.5-2.4.2\",\n        \"clustername\": \"fromcrd\",\n        \"\
+      customconfig\": \"\",\n        \"database\": \"userdb\",\n        \"name\":\
+      \ \"fromcrd\",\n      \"namespace\":\"pgo\",\n        \"nodename\": \"\",\n\
+      \        \"policies\": \"\",\n        \"port\": \"5432\",\n        \"primaryhost\"\
+      : \"fromcrd\",\n        \"primarysecretname\": \"fromcrd-primaryuser-secret\"\
+      ,\n        \"replicas\": \"0\",\n        \"rootsecretname\": \"fromcrd-postgres-secret\"\
+      ,\n        \"secretfrom\": \"\",\n        \"status\": \"\",\n        \"strategy\"\
+      : \"1\",\n        \"user\": \"testuser\",\n        \"userlabels\": {\n     \
+      \       \"archive\": \"false\",\n            \"archive-timeout\": \"60\",\n\
+      \            \"crunchy-pgbadger\": \"false\",\n            \"crunchy_collect\"\
+      : \"false\",\n            \"pgo-backrest\": \"false\",\n            \"pgo-version\"\
+      : \"4.1.0\"\n        },\n        \"usersecretname\": \"fromcrd-testuser-secret\"\
+      \n    }\n},{\n    \"apiVersion\": \"crunchydata.com/v1\",\n    \"kind\": \"\
+      Pgreplica\",\n    \"metadata\": {\n        \"name\": \"fromcrd\",\n        \"\
+      namespace\": \"pgo\"\n    },\n    \"spec\": {}\n},{\n    \"apiVersion\": \"\
+      crunchydata.com/v1\",\n    \"kind\": \"Pgpolicy\",\n    \"metadata\": {\n  \
+      \      \"name\": \"fromcrd\",\n        \"namespace\": \"pgo\"\n    },\n    \"\
+      spec\": {}\n},{\n    \"apiVersion\": \"crunchydata.com/v1\",\n    \"kind\":\
+      \ \"Pgtask\",\n    \"metadata\": {\n        \"name\": \"fromcrd\",\n       \
+      \ \"namespace\": \"pgo\"\n    },\n    \"spec\": {}\n},{\n    \"apiVersion\"\
+      : \"crunchydata.com/v1\",\n    \"kind\": \"Pgbackup\",\n    \"metadata\": {\n\
+      \        \"name\": \"fromcrd\",\n        \"namespace\": \"pgo\"\n    },\n  \
+      \  \"spec\": {}\n}] \n"
+    capabilities: Full Lifecycle
+    categories: Database
+    certified: 'false'
+    containerImage: crunchydata/postgres-operator:centos7-4.1.0
+    createdAt: 10/29/2019
+    description: A Postgres Operator from Crunchydata.com
+    repository: https://github.com/CrunchyData/postgres-operator
+    support: crunchydata.com
+  name: postgresoperator.v4.1.0
+  namespace: pgo
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents a Postgres primary cluster member
+      displayName: Postgres Primary Cluster Member
+      kind: Pgcluster
+      name: pgclusters.crunchydata.com
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: Service
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of member Pods for the deployment.
+        displayName: Size
+        path: size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      statusDescriptors:
+      - description: The current status of the application.
+        displayName: Status
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Explanation for the current status of the application.
+        displayName: Status Details
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase:reason
+      version: v1
+    - description: Represents a Postgres replica cluster member
+      displayName: Postgres Replica Cluster Member
+      kind: Pgreplica
+      name: pgreplicas.crunchydata.com
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: Service
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of member Pods for the deployment.
+        displayName: Size
+        path: size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      statusDescriptors:
+      - description: The current status of the application.
+        displayName: Status
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Explanation for the current status of the application.
+        displayName: Status Details
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase:reason
+      version: v1
+    - description: Represents a Postgres sql policy
+      displayName: Postgres SQL Policy
+      kind: Pgpolicy
+      name: pgpolicies.crunchydata.com
+      resources:
+      - kind: Pgpolicy
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The pgpolicy name.
+        displayName: Name
+        path: name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:name
+      - description: The pgpolicy sql.
+        displayName: SQL
+        path: sql
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:sql
+      statusDescriptors:
+      - description: The current status of the application.
+        displayName: Status
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Explanation for the current status of the application.
+        displayName: Status Details
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase:reason
+      version: v1
+    - description: Represents a Postgres workflow task
+      displayName: Postgres workflow task
+      kind: Pgtask
+      name: pgtasks.crunchydata.com
+      resources:
+      - kind: Pgtask
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The pgtask name.
+        displayName: Name
+        path: name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:name
+      - description: The pgtask type.
+        displayName: TaskType
+        path: tasktype
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:tasktype
+      statusDescriptors:
+      - description: The current status of the application.
+        displayName: Status
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Explanation for the current status of the application.
+        displayName: Status Details
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase:reason
+      version: v1
+    - description: Represents a Postgres backup task
+      displayName: Postgres backup task
+      kind: Pgbackup
+      name: pgbackups.crunchydata.com
+      resources:
+      - kind: Pgbackup
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The pgbackup name.
+        displayName: Name
+        path: name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:name
+      - description: The pgbackup status.
+        displayName: BackupStatus
+        path: backupstatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:backupstatus
+      statusDescriptors:
+      - description: The current status of the application.
+        displayName: Status
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Explanation for the current status of the application.
+        displayName: Status Details
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase:reason
+      version: v1
+  description: "The PostgreSQL Operator runs within a Kubernetes cluster and provides\
+    \ a means to deploy and manage PostgreSQL clusters.\n\n## Before You Begin\n\n\
+    There are several manual steps that the cluster administrator must perform prior\
+    \ to installing the operator. The\noperator must be provided with an initial configuration\
+    \ to run in the cluster, as well as certificates and\ncredentials that need to\
+    \ be generated.\n\nStart by cloning the operator repository locally.\n\n```\n\
+    git clone -b 4.1.0 https://github.com/CrunchyData/postgres-operator.git\ncd postgres-operator\n\
+    ```\n\n### Operator Configuration\n\nEdit `conf/postgres-operator/pgo.yaml` to\
+    \ configure the operator deployment. Look over all of the options and make any\n\
+    changes necessary for your environment.\n\n#### Image\n\nUpdate the `CCPImageTag`\
+    \ tag to configure the postgres image being used, updating for the version of\
+    \ postgres as needed.\n\n```\nCCPImageTag:  centos7-11.5-2.4.2\n```\n\n#### Storage\n\
+    \nConfigure the backend storage for the Persistent Volumes used by each cluster.\
+    \ Depending on the type of persistent\nstorage you wish to make available, adjust\
+    \ the `StorageClass` as necessary. In this case, we are deployed on AWS using\
+    \ `gp2`\nis the default for the cluster.\n\n```\nstorageos:\n  AccessMode:  ReadWriteOnce\n\
+    \  Size:  1G\n  StorageType:  dynamic\n  StorageClass:  gp2\n  Fsgroup:  26\n\
+    ```\n\nOnce the storage backend is defined, enable the new storage option as needed.\n\
+    \n```\nPrimaryStorage: storageos\nXlogStorage: storageos\nBackupStorage: storageos\n\
+    ReplicaStorage: storageos\nBackrestStorage: storageos\n```\n\n### Certificates\n\
+    \nYou will need to either generate new TLS certificates or use existing certificates\
+    \ for the operator API.\n\nYou can generate new self-signed certificates using\
+    \ scripts in the operator repository.\n\n```\nexport PGOROOT=$(pwd)\ncd $PGOROOT/deploy\n\
+    $PGOROOT/deploy/gen-api-keys.sh\n$PGOROOT/deploy/gen-sshd-keys.sh\ncd $PGOROOT\n\
+    ```\n\n### Configuration and Secrets\n\nOnce the configuration changes have been\
+    \ updated and certificates are in place, we can save the information to the cluster.\n\
+    \nCreate the pgo namespace if it does not exist already. This single namespace\
+    \ is where the operator should be deployed to. Postgres clusters will also be\
+    \ deployed here.\n\n```\noc create namespace pgo \n```\n\nCreate the `pgo-backrest-repo-config`\
+    \ Secret that is used by the operator.\n\n```\noc create secret generic -n\
+    \ pgo pgo-backrest-repo-config \\\n  --from-file=config=$PGOROOT/conf/pgo-backrest-repo/config\
+    \ \\\n\t--from-file=sshd_config=$PGOROOT/conf/pgo-backrest-repo/sshd_config \\\
+    \n  --from-file=aws-s3-credentials.yaml=$PGOROOT/conf/pgo-backrest-repo/aws-s3-credentials.yaml\
+    \ \\\n  --from-file=aws-s3-ca.crt=$PGOROOT/conf/pgo-backrest-repo/aws-s3-ca.crt\n\
+    \n\n```\n\nCreate the `pgo-auth-secret` Secret that is used by the operator.\n\
+    \n```\noc create secret generic -n pgo pgo-auth-secret \\\n  --from-file=server.crt=$PGOROOT/conf/postgres-operator/server.crt\
+    \ \\\n  --from-file=server.key=$PGOROOT/conf/postgres-operator/server.key \\\n\
+    ```\n\nInstall the bootstrap credentials: \n\
+    \n```\n $PGOROOT/deploy/install-bootstrap-creds.sh\n```    
+    \n\nInstall the security context constraint for openshift (do not use kubectl to do this): \n\
+    \n```\n oc create -f $PGOROOT/deploy/pgo-scc.yaml\n```  
+    \n\nRemove existing credentials for pgo-apiserver TLS REST API, if they exist.\n\
+    \n```\noc delete secret -n pgo tls pgo.tls\n```
+    \n\nCreate credentials for\
+    \ pgo-apiserver TLS REST API\n```\noc create secret -n pgo tls pgo.tls \\\
+    \n  --key=$PGOROOT/conf/postgres-operator/server.key \\\n  --cert=$PGOROOT/conf/postgres-operator/server.crt\n\
+    ```\n\nCreate the `pgo-config` ConfigMap that is used by the operator.\n\n```\n\
+    oc create configmap -n pgo pgo-config \\\n--from-file=$PGOROOT/conf/postgres-operator\n\
+    \n```\n\nOnce these resources are in place, the operator can be installed into\
+    \ the cluster.\n\n## After You Install\n\nOnce the operator is installed in the\
+    \ cluster, you will need to perform several steps to enable usage.\n\n### Service\n\
+    \n```\noc expose deployment -n pgo postgres-operator --type=LoadBalancer\n```\n\
+    \nFor the pgo client to communicate with the operator, it needs to know where\
+    \ to connect. Export the service url as the PGO_APISERVER_URL for the pgo client\
+    \ in the shell\n\n```\nexport PGO_APISERVER_URL=https://<url of exposed service>:8443\n\
+    ```\n\n### Security\n\nWhen postgres operator deploys, it creates a set of certificates\
+    \ the pgo client will need to communicate. \n\n### Client Certificates\n\nCopy\
+    \ the client certificates from the apiserver to the local environment - we use\
+    \ /tmp for this example. \n\n```\noc cp <pgo-namespace>/<postgres-operator-pod>:/tmp/server.key\
+    \ /tmp/server.key -c apiserver\noc cp <pgo-namespace>/<postgres-operator-pod>:/tmp/server.crt\
+    \ /tmp/server.crt -c apiserver\n```\n\nConfigure the shell for the pgo command\
+    \ line to use the certificates\n\n```\nexport PGO_CA_CERT=/tmp/server.crt\nexport\
+    \ PGO_CLIENT_CERT=/tmp/server.crt\nexport PGO_CLIENT_KEY=/tmp/server.key\n```\n"
+  displayName: Crunchy PostgreSQL Enterprise
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAKgElEQVR4Xu2dX2wcRx3Hf3NO7CTun5CmTkxNKqq0RG4xKSKEBsW7xwM0qEUIhPj70Aq1/HlpnAcUqRJIgITaSEFFgNS8wEvhBcFLa0tUcDN3IZFJr4lCZEGkiLaB5k//kNgX22ff7aBde897692d3+zO7E2cu6fE95uZ3/w+8/39ZmfXawLdj1ERIEZ503UGukAMWwRdIF0ghkXAMHe6CukCMSwChrnTVUgXSIYIHJrgGVovNT16wOhFaLRzoAKAiKBhgMwDkgeEOEgGwDEDyNj4dSDkDtFizu37DoLpLJBOqgFDt9boh2OPz2JMVdl0BsjY+Fkg5KOqJqG9nxwVkz8Q01WRRDcHMPkBuZlBBCHV3uqFY99Z1KXKfICsFRhBCprUoh+IAhj26897oaAf/4GuhZmuXw1Q9AE5NHENAO5MN9P2Vj6QWwGKHiAKVOEjGXjv3PXhN8dbYMMqCcLCwL/Rd9fiqQe/vR5ji7ZRqBT1QBTCcAPSt3DdeeTci4Wo4DSbjQcrlcoUJnCWVawRAv1B27e3jsyf3/HoBkx7oY0iKGqBKIbhB6EtZdGStM+WVXyPENjipbzl9rZdbB1UKqtNCqBITy52pWiCYVWPOITwgh9I4UoNGfiBj2q/c+fOvqGhD827TS4M7q9fHHykT7b/VfYZoagB8sz4U9BDjmWeTDiYrz8PnMMfGSt9OU3fllX8HSHw9SAMyyrOMVbaGOzPh3buvi/W3938QEehqAGiUB1Z01Mw0JZVvEIIDIRhRqmlpSRVW+uUSskORAOMtOkpTkXBegHAN1JKvTQV/pgAJRuQmwCGG/SkOhJS1EuEwDe84q9CKY3Fe+EXX3hLJt2mB3Lwld1QKJyWGSzJdiVV8YcppWdU9Svbj/Ldl2TqSg9EoTq8Vbx8POIH0HH4C+UyPSgbUBX2nYSSDohiGFFA3J9dvXqlb2pqakFFkGX78KGcfOi7UO/NeDNTQiXGAsEU9uBKbjb5k5UK/a1s4BPT6PLFo5J6goQiD0SDOsIKwcDYs8fe3t9PLvkBxbSRhWVZ1tOEFF5UUuSbsAteOPAvkQ9GAVlYqG87ceLEVZHTwe9dleiA4Y+htJ4gVCIHRIM6Wvc6UpxRyYDLYutD+eeOR+cubx1pu8qX6td0IDcDjLBSMtcTARS8QhSqY/T0EafAeYFz57OMsVelVlmHjG3bXgdAvHvpmaB0CsjWa+dn6+tv3zTTP9gK4dDlyWs732abvUklpKjRUfvn5TId61DsY4f1U9diT9/i3z72TPqbXAlQtCjET0WcO88SQi5wTrwLvFpterRarbY9sdF+zpQMygRASs67MgORSFdp6gL2rMkEIJZVvEgIDGVKXaYDMSHQMj7oVAkuZSEVgr2XsTQh/i6l9G6ZQJhkmxlKjErEQMZe3g+kpywKhg/DcZovlcvlb8XZt11oGXztIbr49Ofx/m33zp994KvyD0qkBoJQR1zdiLuKvplqhnes03ogghcppVTJtUkeQPztrCjgllWcJwT6dB55iBQt8/3+/fYTPT3kN2F//XnWNtx947XhJ9seMRL3zx04+vmesJ04ZUkoZKVzvp5S2hA7tWRhWcU6IdArAajHtote/xJtsO5E2gnVnuYOY4RKMgPBFvLlwF8mBLbFRUY2uP4KnZmZ3lytVq9nirigsQgI230IeGGdnAs6gUgGs2DbxSYh8FipVHpFbhbt1j6UNCfFMuMmnSqn3nEZBEQmFkJbUc0SdiAw2Ldv30Bvb9+VuEWXH5Cxib8Agc8k+ZvmyjxrgMLtbdveCkDe0VVTMMBTQZFWiERBl0xZqpmgH/VJM3Bg2/thSukbUX0YAcQEdfjBwaziNDDcNpi+bdv+GQA5PNf7gdrkQ0/dhhpLtUJuBSAyJwvSKlmrQGSChlq5ASNM3+FbCOXdh8DBbIHXIhDM/RRMykmqC/53ojoZ9OXCPfbcxW2fTL7/Lg1kbKIEBOy4VdXplIWBEawBMruwcN9p2ybe7pUG8kRpA2yZnxMBAeBnKKUPhyePSw/8OUrpYZxt8KCvvYXoGgG7ypfmYP8egHwt7JNIIUH7tlQXd6wiDcQdIWHre8/V12bv/89fN2GDqcNOECTvREAGxt69e+/YuHHTqmMYGRjhnZ+nrigoqoG0Bg49KI1x3rbtTwCQU2kh4cZY+T1CzvmfGKNfShrPsopHCYHIhysw44nq0CoouoC4jux6Yxy2v3+u7fR1dNQ+XyiQ+4OOqji/WlmB9iKlNPLpD8sqvkkI7MAGMqpmBP3G9iMFRScQL/eGlJJ29c/MTPdXq9VVr0WyLOt7hBR+jSmwMjsrEQzMeKK5RtSUS3D0wAfD7TIfv4c7jIIiWl2WZU8TQm4XTUrUT1TuTgomBoRM/RH5j7mmEQM5OPE0FMB7Alz204ltcVKQHYf/A8D5ZqHQcxYzF3cBuP1xzkuM0cRDVkx/Xhbxf8Uh5nkCMRC3F8QhY5xDeUGRWe2Y4Pkwlmy5eyu9iGmHsUm6t6IdyPrGLHz67C8xfnbcZm5u9s7JycnpqNSHTZdZJ6EdSGtyigp+1glHteec1xijq2oYJuer9gcHJGPaajnNOdinj3j/lVlxqtNRMIhJfqx5IGnqSadgBAuwyp2WSFG5KcSH0Ww2BiqVine7FfPRBQSj0PDYnPN3GKOrXtWBmQfWBg8kQ9qSeVQo6Hhwi6gKDOfgMFZa9YBaVMCixuQc/sxY6XPYAMva5QoEsyrjgESlENnJph0/ahzZvrC+ygFJoZIdl07U77t03Hvlkcwk4i6gbLt4GSD+YbvwxDl3fsIY+yE2IL4dRpEy88GOrx1ImkIeVIOOSWOCgwGyvMjc1w9m/zMay07JA5FUSRogfjCaTf6VSoX+ARNA1TZYIKp3YEYDMV0d4UVQr88PnTx58r9ZFkc6IBIqESkkaSXeuMEHT52ibs3I9SOrjrBzWRZSeiBjE98HAr8SRUoEBFtE83ozUBYYnHPKWLZDyPRAkCrBApHd1mZZhUmLKB0QPkipGiVnA4KAoguIyjSBVamOMcN9ZgcigJIXkODEOHd+zBj7kSidBr+XUYYudbr+qAEyNn4aCNkdFwAXCuf8DGNLz25FfVafG0GDsZLw9RXYQEYFcXh4uHdgYFsdC45zmGaspOQPDMSNqQaIApWoOurGAsJC8O3y2lSoA5IABZO2/EA2GosfOX78+HnZgIXtR0ZG+rdsuauWtR+/vc40FfRRLZAYKCIgqtSBTYeykPKCoa6GhGcY8VBEEhTRkxiyAVQJxnH4ZLlMP6XKB1E/6hXijxiCYgIQ1zXLsv9OCNkjCkzeqcofTx8Qd4SD489CgfzU/eeuf7+8uP1/U96uKZgC8lJHGAC2+OeZrvSlrJgUFqWSTgFxXcRAWZtAlov9yhuD+OFymT4XDEreE/fXjAhK3n7pTVkRiTrqPnnekw66dcsD8VVBaWld3i+QSbP7ynux5K6QqNWZ96SxBZ5zWGCslP1PIGG3dMrOsiQGNNW0PXVxRimN/WVXnXPoqEJ0Tky2bxdIp5Wa37ZXNjq3sH1XIYbB7wLpAjEsAoa501VIF4hhETDMna5CDAPyf2qmgLAYU5k7AAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - pgclusters
+          - pgpolicies
+          - pgtasks
+          - pgbackups
+          - pgreplicas
+          verbs:
+          - '*'
+        - apiGroups:
+          - '*'
+          resources:
+          - nodes
+          - pods
+          - namespaces
+          - configmaps
+          - storageclasses
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - '*'
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - create
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - list
+          - watch
+        serviceAccountName: postgres-operator
+      deployments:
+      - name: postgres-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: postgres-operator
+          template:
+            metadata:
+              labels:
+                name: postgres-operator
+            spec:
+              containers:
+              - env:
+                - name: TIMEOUT
+                  value: '3600'
+                - name: CCP_IMAGE_PREFIX
+                  value: crunchydata
+                - name: CCP_IMAGE_TAG
+                  value: centos7-11.5-2.4.2
+                - name: PGO_IMAGE_PREFIX
+                  value: crunchydata
+                - name: PGO_IMAGE_TAG
+                  value: centos7-4.1.0
+                - name: PGO_INSTALLATION_NAME
+                  value: devtest
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: PGO_OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                image: crunchydata/pgo-scheduler:centos7-4.1.0
+                imagePullPolicy: IfNotPresent
+                name: scheduler
+              - env:
+                - name: CRUNCHY_DEBUG
+                  value: 'true'
+                - name: CCP_IMAGE_PREFIX
+                  value: crunchydata
+                - name: CCP_IMAGE_TAG
+                  value: centos7-11.5-2.4.2
+                - name: PGO_IMAGE_PREFIX
+                  value: crunchydata
+                - name: PGO_IMAGE_TAG
+                  value: centos7-4.1.0
+                - name: PORT
+                  value: '8443'
+                - name: PGO_INSTALLATION_NAME
+                  value: devtest
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: PGO_OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                image: crunchydata/postgres-operator:centos7-4.1.0
+                imagePullPolicy: IfNotPresent
+                name: operator
+              - env:
+                - name: CRUNCHY_DEBUG
+                  value: 'true'
+                - name: CCP_IMAGE_PREFIX
+                  value: crunchydata
+                - name: CCP_IMAGE_TAG
+                  value: centos7-11.5-2.4.2
+                - name: PGO_IMAGE_PREFIX
+                  value: crunchydata
+                - name: PGO_IMAGE_TAG
+                  value: centos7-4.1.0
+                - name: PORT
+                  value: '8443'
+                - name: PGO_INSTALLATION_NAME
+                  value: devtest  
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: PGO_OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: TLS_NO_VERIFY
+                  value: 'false'
+                image: crunchydata/pgo-apiserver:centos7-4.1.0
+                imagePullPolicy: IfNotPresent
+                name: apiserver
+                ports:
+                - containerPort: 8443
+                  protocol: TCP
+              - env:
+                - name: CRUNCHY_DEBUG
+                  value: 'true'
+                - name: CCP_IMAGE_PREFIX
+                  value: crunchydata
+                - name: CCP_IMAGE_TAG
+                  value: centos7-11.5-2.4.2
+                - name: PGO_IMAGE_PREFIX
+                  value: crunchydata
+                - name: PGO_IMAGE_TAG
+                  value: centos7-4.1.0
+                - name: PORT
+                  value: '8443'
+                - name: PGO_INSTALLATION_NAME
+                  value: devtest
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: PGO_OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                image: crunchydata/pgo-event:centos7-4.1.0
+                imagePullPolicy: IfNotPresent
+                name: event
+              restartPolicy: Always
+              serviceAccount: postgres-operator
+              serviceAccountName: postgres-operator
+              terminationGracePeriodSeconds: 5
+      permissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - pods/exec
+          - pods/log
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          - extensions
+          resources:
+          - jobs
+          - deployments
+          verbs:
+          - '*'
+        serviceAccountName: postgres-operator
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ''
+          resources:
+          - pods/exec
+          verbs:
+          - create
+        serviceAccountName: pgo-backrest
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - postgres
+  - app
+  labels:
+    alm-owner-enterprise-app: postgres-operator
+    alm-status-descriptors: postgres-operator.v4.1.0
+  links:
+  - name: Crunchy Data
+    url: https://crunchydata.com
+  - name: Crunchy Postgres Operator v4.1 Quick Deploy
+    url: https://github.com/CrunchyData/postgres-operator/tree/develop/examples/olm
+  maintainers:
+  - email: support@crunchydata.com
+    name: Crunchy Data
+  maturity: stable
+  minKubeVersion: 1.11.0
+  provider:
+    name: CrunchyData.com
+  version: 4.1.0

--- a/community-operators/postgresql/postgresql.package.yaml
+++ b/community-operators/postgresql/postgresql.package.yaml
@@ -1,4 +1,4 @@
 channels:
-- currentCSV: postgresoperator.v4.0.1
+- currentCSV: postgresoperator.v4.1.0
   name: alpha
 packageName: postgresql


### PR DESCRIPTION
Updates existing operator to 4.1.0.  Due to changes made between 4.0.1 and 4.1.0, it is not possible to upgrade this operator automatically. All existing postgres clusters should be removed (keep the existing pvcs), Operator 4.0.1 removed and Operator 4.1.0  installed. The clusters can then be recreated with the new operator using the existing PVCs. 