### PR TITLE
 Fix Capability Level for Upstream StorageOS Operator 1.4.1

### DIFF
--- a/upstream-community-operators/storageos/1.4.1/storageos.v1.4.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/storageos/1.4.1/storageos.v1.4.1.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   name: storageosoperator.v1.4.1
   namespace: placeholder
   annotations:
-    capabilities: Full Lifecycle
+    capabilities: Deep Insights
     categories: Storage
     description: Cloud-native, persistent storage for containers.
     containerImage: storageos/cluster-operator:1.4.1


### PR DESCRIPTION
The capability level for the StorageOS operator was updated to `Deep Insights`, however the most recent 1.4.1 version of the CSV has regressed back to the previous level of `Full Lifecycle`. This change updates the capability level back to the verified level of `Deep Insights`.