### PR TITLE
bump SDK and Kube version to OCP 4.2

### DIFF
--- a/scripts/utils/Makefile
+++ b/scripts/utils/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help
-SDK_VER="v0.10.0"
-KUBE_VER="v1.13.0"
+SDK_VER="v0.12.0"
+KUBE_VER="v1.14.0"
 MAKEFLAGS+ = --no-print-directory
 OP_PATH=''
 OP_CHANNEL=''


### PR DESCRIPTION
Signed-off-by: dmesser <dmesser@redhat.com>
