### PR TITLE
Upstream operator - Fixed Jaeger permissions with legacy CRD

### DIFF
--- a/upstream-community-operators/jaeger/1.14.0/jaeger-operator.v1.14.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/jaeger/1.14.0/jaeger-operator.v1.14.0.clusterserviceversion.yaml
@@ -108,6 +108,12 @@ spec:
           - get
           - create
         - apiGroups:
+          - io.jaegertracing
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
           - extensions
           resources:
           - replicasets
@@ -228,6 +234,12 @@ spec:
           verbs:
           - get
           - create
+        - apiGroups:
+          - io.jaegertracing
+          resources:
+          - '*'
+          verbs:
+          - '*'
         - apiGroups:
           - extensions
           resources:


### PR DESCRIPTION
This PR reinstates the permissions that were wrongly removed for v1.14.

cc @jkandasa

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

### Updates to existing Operators

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**
