### PR TITLE
Fixed aws s3 operator to required not owned crds

### DIFF
--- a/community-operators/awss3-operator-registry/1.0.1/awss3operator.1.0.1.clusterserviceversion.yaml
+++ b/community-operators/awss3-operator-registry/1.0.1/awss3operator.1.0.1.clusterserviceversion.yaml
@@ -16,7 +16,8 @@ metadata:
   namespace: placeholder
 spec:
   customresourcedefinitions:
-    owned:
+    owned: []
+    required:
     - description: instance of an AWS S3 Bucket
       displayName: Object Bucket
       kind: ObjectBucket


### PR DESCRIPTION
adding `required` keyword rather than owned for the spec CRDs