### PR TITLE
fixing upstream operator with required not owned CRDs

### DIFF
--- a/upstream-community-operators/awss3operator/1.0.1/awss3operator.v1.0.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/awss3operator/1.0.1/awss3operator.v1.0.1.clusterserviceversion.yaml
@@ -16,7 +16,8 @@ metadata:
   namespace: placeholder
 spec:
   customresourcedefinitions:
-    owned:
+    owned: []
+    required:
     - description: instance of an AWS S3 Bucket
       displayName: Object Bucket
       kind: ObjectBucket


### PR DESCRIPTION
changing crd's from owned to required so noobaa operator and other operators that use the shared library can coexist