### PR TITLE
MongoDB update alm-examples

### DIFF
--- a/upstream-community-operators/mongodb-enterprise/1.3.1/mongodb-enterprise.v1.3.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/mongodb-enterprise/1.3.1/mongodb-enterprise.v1.3.1.clusterserviceversion.yaml
@@ -1,36 +1,93 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: "[\n  {\n    \"kind\": \"MongoDB\",\n    \"apiVersion\": \"mongodb.com/v1\"\
-      ,\n    \"metadata\": {\n        \"name\": \"sample-replica-set\"\n    },\n \
-      \   \"spec\": {\n      \"version\": \"4.0.10\",\n      \"type\": \"ReplicaSet\"\
-      ,\n      \"project\": \"my-project\",\n      \"persistent\": false,\n      \"\
-      members\": 3,\n      \"credentials\": \"my-credentials\"\n    },\n    \"status\"\
-      : {\n      \"version\": \"4.0.10\",\n      \"type\": \"ReplicaSet\",\n     \
-      \ \"phase\": \"Running\",\n      \"members\": 3,\n      \"link\": \"https://cloud.mongodb.com/v2/5d35f7cdbf994268c3\"\
-      ,\n      \"lastTransition\": \"2019-07-23T09:00:00Z\"\n    }\n  },\n  {\n  \
-      \  \"apiVersion\": \"mongodb.com/v1\",\n    \"kind\": \"MongoDB\",\n    \"metadata\"\
-      : {\n        \"name\": \"sample-sharded-cluster\"\n    },\n    \"spec\": {\n\
-      \        \"configServerCount\": 3,\n        \"credentials\": \"my-credentials\"\
-      ,\n        \"mongodsPerShardCount\": 3,\n        \"mongosCount\": 2,\n     \
-      \   \"persistent\": false,\n        \"project\": \"my-project\",\n        \"\
-      shardCount\": 1,\n        \"type\": \"ShardedCluster\",\n        \"version\"\
-      : \"3.6.8\"\n    },\n    \"status\": {\n        \"lastTransition\": \"2019-07-23T09:00:00Z\"\
-      ,\n        \"phase\": \"Running\"\n    }\n  },\n  {\n    \"apiVersion\": \"\
-      mongodb.com/v1\",\n    \"kind\": \"MongoDBUser\",\n    \"metadata\": {\n   \
-      \     \"name\": \"sample-user\"\n    },\n    \"spec\": {\n        \"db\": \"\
-      $external\",\n        \"project\": \"my-project\",\n        \"roles\": [\n \
-      \           {\n                \"db\": \"admin\",\n                \"name\"\
-      : \"clusterAdmin\"\n            }\n        ],\n        \"username\": \"CN=mms-user-1,OU=cloud,O=MongoDB,L=New\
-      \ York,ST=New York,C=US\"\n    }\n  },\n  {\n  \"apiVersion\": \"mongodb.com/v1\"\
-      ,\n  \"kind\": \"MongoDBOpsManager\",\n  \"metadata\": {\n    \"name\": \"ops-manager\"\
-      \n  },\n  \"spec\": {\n    \"version\": \"4.2.0\",\n    \"adminCredentials\"\
-      : \"ops-manager-admin\",\n    \"configuration\": {\n      \"mms.fromEmailAddr\"\
-      : \"admin@thecompany.com\"\n    },\n    \"applicationDatabase\": {\n      \"\
-      members\": 3,\n      \"version\": \"4.2.0\",\n      \"persistent\": true,\n\
-      \      \"podSpec\": {\n        \"cpu\": \"\
-      0.25\"\n      }\n    }\n  }\n}\n]\n"
+    alm-examples: >
+      [
+        {
+          "apiVersion": "mongodb.com/v1",
+          "kind": "MongoDB",
+          "metadata": {
+            "name": "my-replica-set"
+          },
+          "spec": {
+            "credentials": "my-credentials",
+            "members": 3,
+            "opsManager": {
+              "configMapRef": {
+                "name": "my-project"
+              }
+            },
+            "type": "ReplicaSet",
+            "version": "4.2.1"
+          }
+        },
+        {
+          "apiVersion": "mongodb.com/v1",
+          "kind": "MongoDB",
+          "metadata": {
+            "name": "sample-sharded-cluster"
+          },
+          "spec": {
+            "configServerCount": 3,
+            "credentials": "my-credentials",
+            "mongodsPerShardCount": 3,
+            "mongosCount": 2,
+            "persistent": false,
+            "opsManager": {
+              "configMapRef": {
+                "name": "my-project"
+              }
+            },
+            "shardCount": 1,
+            "type": "ShardedCluster",
+            "version": "4.2.1"
+          }
+        },
+        {
+          "apiVersion": "mongodb.com/v1",
+          "kind": "MongoDBUser",
+          "metadata": {
+            "name": "my-replica-set-x509-user"
+          },
+          "spec": {
+            "db": "$external",
+            "mongodbResourceRef": {
+              "name": "my-replica-set"
+            },
+            "roles": [
+              {
+                "db": "admin",
+                "name": "dbOwner"
+              }
+            ],
+            "username": "CN=my-replica-set-x509-user,OU=cloud,O=MongoDB,L=New York,ST=New York,C=US"
+          }
+        },
+        {
+          "apiVersion": "mongodb.com/v1",
+          "kind": "MongoDBOpsManager",
+          "metadata": {
+            "name": "ops-manager"
+          },
+          "spec": {
+            "version": "4.2.0",
+            "adminCredentials": "ops-manager-admin",
+            "configuration": {
+              "mms.fromEmailAddr": "admin@thecompany.com"
+            },
+            "applicationDatabase": {
+              "members": 3,
+              "version": "4.2.0",
+              "persistent": true,
+              "podSpec": {
+                "cpu": "0.25"
+              }
+            }
+          }
+        }
+      ]
     capabilities: Deep Insights
     categories: Database
     certified: 'true'


### PR DESCRIPTION
This removes the status fields from the examples, addressing https://github.com/mongodb/mongodb-enterprise-kubernetes/issues/48, and updates them to use non-deprecated fields. I also made it a lot easier to read them.


For easy comparison, this is what the unescaped fields were previously:
```json
[
  {
    "kind": "MongoDB",
    "apiVersion": "mongodb.com/v1",
    "metadata": {
      "name": "sample-replica-set"
    },
    "spec": {
      "version": "4.0.10",
      "type": "ReplicaSet",
      "project": "my-project",
      "persistent": false,
      "members": 3,
      "credentials": "my-credentials"
    },
    "status": {
      "version": "4.0.10",
      "type": "ReplicaSet",
      "phase": "Running",
      "members": 3,
      "link": "https://cloud.mongodb.com/v2/5d35f7cdbf994268c3",
      "lastTransition": "2019-07-23T09:00:00Z"
    }
  },
  {
    "apiVersion": "mongodb.com/v1",
    "kind": "MongoDB",
    "metadata": {
      "name": "sample-sharded-cluster"
    },
    "spec": {
      "configServerCount": 3,
      "credentials": "my-credentials",
      "mongodsPerShardCount": 3,
      "mongosCount": 2,
      "persistent": false,
      "project": "my-project",
      "shardCount": 1,
      "type": "ShardedCluster",
      "version": "3.6.8"
    },
    "status": {
      "lastTransition": "2019-07-23T09:00:00Z",
      "phase": "Running"
    }
  },
  {
    "apiVersion": "mongodb.com/v1",
    "kind": "MongoDBUser",
    "metadata": {
      "name": "sample-user"
    },
    "spec": {
      "db": "$external",
      "project": "my-project",
      "roles": [
        {
          "db": "admin",
          "name": "clusterAdmin"
        }
      ],
      "username": "CN=mms-user-1,OU=cloud,O=MongoDB,L=New York,ST=New York,C=US"
    }
  },
  {
    "apiVersion": "mongodb.com/v1",
    "kind": "MongoDBOpsManager",
    "metadata": {
      "name": "ops-manager"
    },
    "spec": {
      "version": "4.2.0",
      "adminCredentials": "ops-manager-admin",
      "configuration": {
        "mms.fromEmailAddr": "admin@thecompany.com"
      },
      "applicationDatabase": {
        "members": 3,
        "version": "4.2.0",
        "persistent": true,
        "podSpec": {
          "cpu": "0.25"
        }
      }
    }
  }
]
```