### PR TITLE
[Strimzi Kafka Operator] Split cluster permissions and permissions

### DIFF
--- a/community-operators/strimzi-kafka-operator/0.14.0/strimzi-cluster-operator.v0.14.0.clusterserviceversion.yaml
+++ b/community-operators/strimzi-kafka-operator/0.14.0/strimzi-cluster-operator.v0.14.0.clusterserviceversion.yaml
@@ -462,7 +462,7 @@ spec:
     mediatype: image/svg+xml
   install:
     spec:
-      clusterPermissions:
+      permissions:
       - rules:
         - apiGroups:
           - ''
@@ -730,29 +730,6 @@ spec:
           - patch
           - update
         - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterrolebindings
-          verbs:
-          - get
-          - create
-          - delete
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - storage.k8s.io
-          resources:
-          - storageclasses
-          verbs:
-          - get
-        - apiGroups:
-          - ''
-          resources:
-          - nodes
-          verbs:
-          - get
-        - apiGroups:
           - kafka.strimzi.io
           resources:
           - kafkatopics
@@ -784,10 +761,13 @@ spec:
           - patch
           - update
           - delete
+        serviceAccountName: strimzi-cluster-operator
+      clusterPermissions:
+      - rules:
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
-          - clusterroles
+          - clusterrolebindings
           verbs:
           - get
           - create
@@ -795,6 +775,26 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - nodes
+          verbs:
+          - get
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - get
+          - create
+          - patch
         serviceAccountName: strimzi-cluster-operator
       deployments:
       - name: strimzi-cluster-operator-v0.14.0


### PR DESCRIPTION
The current version of the Strimzi Kafka operator has all the permissions it uses as `clusterPermissions`. That means that even when installed into only a single namespace, it will get all permissions cluster wide. This is a blocker for deploying it in some environments. This Pr splits the permissions as they should have been originally, so only the permissions actually needed as clusterwide are granted as clusterwide (such as reading nodes). The rest is done only as permissions, so a single namespace install doesn't give the operator more rights than needed.

PS: The latest version is still using the Fabric8 version which failes to authenticte on the test framework here. But the changes has been tested manually. (hopefully this is the last update on 0.14.0 - the next version of Strimzi should have this already fixed.)

### Updates to existing Operators

* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?