### PR TITLE
[Strimzi Kafka Operator] Use separate cluster roles to reduce the RBAC footprint

### DIFF
--- a/community-operators/strimzi-kafka-operator/0.14.0/strimzi-cluster-operator.v0.14.0.clusterserviceversion.yaml
+++ b/community-operators/strimzi-kafka-operator/0.14.0/strimzi-cluster-operator.v0.14.0.clusterserviceversion.yaml
@@ -787,14 +787,6 @@ spec:
           - nodes
           verbs:
           - get
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterroles
-          verbs:
-          - get
-          - create
-          - patch
         serviceAccountName: strimzi-cluster-operator
       deployments:
       - name: strimzi-cluster-operator-v0.14.0
@@ -889,7 +881,7 @@ spec:
                 - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
                   value: strimzi/kafka-bridge:0.14.0
                 - name: STRIMZI_CREATE_CLUSTER_ROLES
-                  value: 'TRUE'
+                  value: 'FALSE'
                 - name: STRIMZI_LOG_LEVEL
                   value: INFO
                 image: strimzi/operator:0.14.0

--- a/community-operators/strimzi-kafka-operator/0.14.0/strimzientityoperator.clusterrole.yaml
+++ b/community-operators/strimzi-kafka-operator/0.14.0/strimzientityoperator.clusterrole.yaml
@@ -1,0 +1,50 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-entity-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkatopics
+  - kafkatopics/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkausers
+  - kafkausers/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+  - delete

--- a/community-operators/strimzi-kafka-operator/0.14.0/strimzikafkabroker.clusterrole.yaml
+++ b/community-operators/strimzi-kafka-operator/0.14.0/strimzikafkabroker.clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-broker
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/community-operators/strimzi-kafka-operator/0.14.0/strimzitopicoperator.clusterrole.yaml
+++ b/community-operators/strimzi-kafka-operator/0.14.0/strimzitopicoperator.clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create


### PR DESCRIPTION
As part of trying to get Strimzi working on OpenShift Dedicated, I'm trying to minimize the RBAC footprint. This PR changes the way how the installation of the Strimzi operator creates the cluster roles. Instead of being created by the operator, they are created together with the CSV. And therefore we do not ned the clusterrole RBAC rights anymore.

PS: The latest version is still using the Fabric8 version which failes to authenticte on the test framework here. But the changes has been tested manually. (hopefully this is really the last update on 0.14.0 - the next version of Strimzi should have this already fixed and I have done the first RC yesterday :-o)

### Updates to existing Operators

* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?