### PR TITLE
remove erroneous package definition

### DIFF
--- a/upstream-community-operators/grafana-operator/3.0.2/grafana-operator.package.yaml
+++ b/upstream-community-operators/grafana-operator/3.0.2/grafana-operator.package.yaml
@@ -1,4 +1,0 @@
-packageName: grafana-operator
-channels:
-  - name: alpha
-    currentCSV: grafana-operator.v3.0.2


### PR DESCRIPTION
Signed-off-by: dmesser <dmesser@redhat.com>

@pb82 looks like our test suite failed to detect this: you placed a second package.yaml into a subdirectory which prevents the catalog to build correctly for upstream-community. This PR fixes it. Just FYI.