### PR TITLE
making catalog build permissive to errors

### DIFF
--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/operator-framework/upstream-registry-builder:v1.3.0 as builder
+FROM quay.io/operator-framework/upstream-registry-builder:v1.5.6 as builder
 COPY upstream-community-operators manifests
-RUN ./bin/initializer -o ./bundles.db
+RUN ./bin/initializer --permissive true -o ./bundles.db
 
 FROM scratch
 COPY --from=builder /build/bundles.db /bundles.db


### PR DESCRIPTION
Signed-off-by: dmesser <dmesser@redhat.com>

This is in order to prevent the catalog being build completely just because a single Operator package fails to load.