### PR TITLE
change specDescriptors.value to type byte

### DIFF
--- a/upstream-community-operators/couchbase-enterprise/1.0.0/couchbase-v1.0.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.0.0/couchbase-v1.0.0.clusterserviceversion.yaml
@@ -47,34 +47,34 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.0.0/couchbase-v1.0.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.0.0/couchbase-v1.0.0.clusterserviceversion.yaml
@@ -291,4 +291,3 @@ spec:
       alm-owner-etcd: couchbaseoperator
       operated-by: couchbaseoperator
   version: 1.0.0
-  

--- a/upstream-community-operators/couchbase-enterprise/1.0.0/couchbase-v1.0.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.0.0/couchbase-v1.0.0.clusterserviceversion.yaml
@@ -47,34 +47,29 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.1.0/couchbase-v1.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.1.0/couchbase-v1.1.0.clusterserviceversion.yaml
@@ -47,34 +47,34 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.1.0/couchbase-v1.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.1.0/couchbase-v1.1.0.clusterserviceversion.yaml
@@ -47,34 +47,29 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.2.1/couchbase-v1.2.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.2.1/couchbase-v1.2.1.clusterserviceversion.yaml
@@ -108,34 +108,34 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.2.1/couchbase-v1.2.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.2.1/couchbase-v1.2.1.clusterserviceversion.yaml
@@ -108,34 +108,29 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.2.2/couchbase-v1.2.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.2.2/couchbase-v1.2.2.clusterserviceversion.yaml
@@ -108,34 +108,34 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.2.2/couchbase-v1.2.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.2.2/couchbase-v1.2.2.clusterserviceversion.yaml
@@ -108,34 +108,29 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.


### PR DESCRIPTION
Update `spec.customresourcedefinitions.owned.specDescriptors.value` value to type byte. This will prevent installation issues once Structural Schemas are enforced in 1.17.

See https://github.com/operator-framework/operator-lifecycle-manager/blob/master/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go#L94

@Bowenislandsong 
@tlwu2013 
