### PR TITLE
remove spec.customresourcedefinitions.owned.specDescriptors.value fro…

### DIFF
--- a/community-operators/teiid/0.1.0/teiid.0.1.0.clusterserviceversion.yaml
+++ b/community-operators/teiid/0.1.0/teiid.0.1.0.clusterserviceversion.yaml
@@ -142,7 +142,6 @@ spec:
       - description: Expose Via 3 Scale
         displayName: Expose Via 3 Scale
         path: exposeVia3scale
-        value: false
         x-descriptors:
         - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
       - description:  Desired number of Pods for the cluster


### PR DESCRIPTION
no need for this value. booleanswitch defaults to false, explicitly setting this value to a string will prevent Operator installation in OCP 4.4/Kube 1.17 (due to structural schema enforcement).