### PR TITLE
Fix doc semantic issue with subscription#spec#name

### DIFF
--- a/docs/testing-operators.md
+++ b/docs/testing-operators.md
@@ -227,7 +227,7 @@ metadata:
   namespace: marketplace
 spec:
   channel: <channel-name>
-  name: my-operator
+  name: my-operator-package-name
   source: johndoe-operators
   sourceNamespace: marketplace
 ```


### PR DESCRIPTION
In the documentation subscription#spec#name should points to the `operator package name` instead of `operator name`. With wrong hints user can think about operator name from operator.yaml instead of operator package yaml definition.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>