### PR TITLE
Fix out-of-date x-descriptor for PostgreSQL Operator

### DIFF
--- a/community-operators/postgresql/4.2.1/postgresoperator.v4.2.1.clusterserviceversion.yaml
+++ b/community-operators/postgresql/4.2.1/postgresoperator.v4.2.1.clusterserviceversion.yaml
@@ -402,7 +402,6 @@ spec:
         path: PrimaryStorage
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:PrimaryStorage
-        - urn:alm:descriptor:com.tectonic.ui:label
       - description: Contains the name of the PostgreSQL cluster to associate with
           this storage. Should match the Cluster name
         displayName: PostgreSQL Primary Storage Name


### PR DESCRIPTION
As reported CrunchyData/postgres-operator#1262 the PostgreSQL
Operator OLM was using a deprecated x-descriptor for "label",
which in turn caused issues. This commit removes it from the
community operator.

Signed-off-by: Jonathan S. Katz <jonathan.katz@crunchydata.com>

Thanks submitting your Operator. Please check below list before you create your Pull Request.
*************************************************
**Flat operator directory structure is obsolete from 23-rd of October 2019, only nested directory structure will be accepted.**
*************************************************

### Updates to existing Operators

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [ ] Description about the managed Application and where to find more information
2. [ ] Features and capabilities of your Operator and how to use it
3. [ ] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo

Remember that you can preview your CSV [here](https://operatorhub.io/preview).

--

<sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file a PR against this repo and explain your need

<sup>2</sup> For more information see [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.svg)
