### PR TITLE
Sets booleanSwitch values from defaults

### DIFF
--- a/upstream-community-operators/couchbase-enterprise/1.0.0/couchbase-v1.0.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.0.0/couchbase-v1.0.0.clusterserviceversion.yaml
@@ -11,8 +11,69 @@ metadata:
     createdAt: 2019-02-25T12:24:59Z
     description: The Couchbase Autonomous Operator allows users to easily deploy, manage, and maintain Couchbase deployments
     support: Couchbase
-    alm-examples: '[{"apiVersion":"couchbase.com/v1","kind":"CouchbaseCluster","metadata":{"name":"cb-example","namespace":"default"},"spec":{"authSecret":"cb-example-auth","baseImage":"couchbase/server","buckets":[{"conflictResolution":"seqno","enableFlush":true,"evictionPolicy":"fullEviction","ioPriority":"high","memoryQuota":128,"name":"default","replicas":1,"type":"couchbase"}],"cluster":{"analyticsServiceMemoryQuota":1024,"autoFailoverMaxCount":3,"autoFailoverOnDataDiskIssues":true,"autoFailoverOnDataDiskIssuesTimePeriod":120,"autoFailoverServerGroup":false,"autoFailoverTimeout":120,"clusterName":"cb-example","dataServiceMemoryQuota":256,"eventingServiceMemoryQuota":256,"indexServiceMemoryQuota":256,"indexStorageSetting":"memory_optimized","searchServiceMemoryQuota":256},"servers":[{"name":"all_services","services":["data","index","query","search","eventing","analytics"],"size":3}],"version":"5.5.3"}}]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "couchbase.com/v1",
+          "kind": "CouchbaseCluster",
+          "metadata": {
+            "name": "cb-example",
+            "namespace": "default"
+          },
+          "spec": {
+            "authSecret": "cb-example-auth",
+            "baseImage": "couchbase/server",
+            "buckets": [
+              {
+                "conflictResolution": "seqno",
+                "enableFlush": true,
+                "evictionPolicy": "fullEviction",
+                "ioPriority": "high",
+                "memoryQuota": 128,
+                "name": "default",
+                "replicas": 1,
+                "type": "couchbase"
+              }
+            ],
+            "cluster": {
+              "analyticsServiceMemoryQuota": 1024,
+              "autoFailoverMaxCount": 3,
+              "autoFailoverOnDataDiskIssues": true,
+              "autoFailoverOnDataDiskIssuesTimePeriod": 120,
+              "autoFailoverServerGroup": false,
+              "autoFailoverTimeout": 120,
+              "clusterName": "cb-example",
+              "dataServiceMemoryQuota": 256,
+              "eventingServiceMemoryQuota": 256,
+              "indexServiceMemoryQuota": 256,
+              "indexStorageSetting": "memory_optimized",
+              "searchServiceMemoryQuota": 256
+            },
+            "exposeAdminConsole": true,
+            "antiAffinity": false,
+            "softwareUpdateNotifications": false,
+            "disableBucketManagement": false,
+            "paused": false,
+            "servers": [
+              {
+                "name": "all_services",
+                "services": [
+                  "data",
+                  "index",
+                  "query",
+                  "search",
+                  "eventing",
+                  "analytics"
+                ],
+                "size": 3
+              }
+            ],
+            "version": "5.5.3"
+          }
+        }
+      ]
 spec:
+
   customresourcedefinitions:
     owned:
     - description: Manages Couchbase clusters
@@ -47,34 +108,29 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.1.0/couchbase-v1.1.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.1.0/couchbase-v1.1.0.clusterserviceversion.yaml
@@ -11,7 +11,67 @@ metadata:
     createdAt: 2019-02-25T12:24:59Z
     description: The Couchbase Autonomous Operator allows users to easily deploy, manage, and maintain Couchbase deployments
     support: Couchbase
-    alm-examples: '[{"apiVersion":"couchbase.com/v1","kind":"CouchbaseCluster","metadata":{"name":"cb-example","namespace":"default"},"spec":{"authSecret":"cb-example-auth","baseImage":"couchbase/server","buckets":[{"conflictResolution":"seqno","enableFlush":true,"evictionPolicy":"fullEviction","ioPriority":"high","memoryQuota":128,"name":"default","replicas":1,"type":"couchbase"}],"cluster":{"analyticsServiceMemoryQuota":1024,"autoFailoverMaxCount":3,"autoFailoverOnDataDiskIssues":true,"autoFailoverOnDataDiskIssuesTimePeriod":120,"autoFailoverServerGroup":false,"autoFailoverTimeout":120,"clusterName":"cb-example","dataServiceMemoryQuota":256,"eventingServiceMemoryQuota":256,"indexServiceMemoryQuota":256,"indexStorageSetting":"memory_optimized","searchServiceMemoryQuota":256},"servers":[{"name":"all_services","services":["data","index","query","search","eventing","analytics"],"size":3}],"version":"5.5.3"}}]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "couchbase.com/v1",
+          "kind": "CouchbaseCluster",
+          "metadata": {
+            "name": "cb-example",
+            "namespace": "default"
+          },
+          "spec": {
+            "authSecret": "cb-example-auth",
+            "baseImage": "couchbase/server",
+            "buckets": [
+              {
+                "conflictResolution": "seqno",
+                "enableFlush": true,
+                "evictionPolicy": "fullEviction",
+                "ioPriority": "high",
+                "memoryQuota": 128,
+                "name": "default",
+                "replicas": 1,
+                "type": "couchbase"
+              }
+            ],
+            "cluster": {
+              "analyticsServiceMemoryQuota": 1024,
+              "autoFailoverMaxCount": 3,
+              "autoFailoverOnDataDiskIssues": true,
+              "autoFailoverOnDataDiskIssuesTimePeriod": 120,
+              "autoFailoverServerGroup": false,
+              "autoFailoverTimeout": 120,
+              "clusterName": "cb-example",
+              "dataServiceMemoryQuota": 256,
+              "eventingServiceMemoryQuota": 256,
+              "indexServiceMemoryQuota": 256,
+              "indexStorageSetting": "memory_optimized",
+              "searchServiceMemoryQuota": 256
+            },
+            "exposeAdminConsole": true,
+            "antiAffinity": false,
+            "softwareUpdateNotifications": false,
+            "disableBucketManagement": false,
+            "paused": false,
+            "servers": [
+              {
+                "name": "all_services",
+                "services": [
+                  "data",
+                  "index",
+                  "query",
+                  "search",
+                  "eventing",
+                  "analytics"
+                ],
+                "size": 3
+              }
+            ],
+            "version": "5.5.3"
+          }
+        }
+      ]
 spec:
   customresourcedefinitions:
     owned:
@@ -47,34 +107,29 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.2.1/couchbase-v1.2.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.2.1/couchbase-v1.2.1.clusterserviceversion.yaml
@@ -46,6 +46,10 @@ metadata:
               "searchServiceMemoryQuota": 256
             },
             "exposeAdminConsole": true,
+            "antiAffinity": false,
+            "softwareUpdateNotifications": false,
+            "disableBucketManagement": false,
+            "paused": false,
             "servers": [
               {
                 "name": "all_services",
@@ -108,34 +112,29 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.

--- a/upstream-community-operators/couchbase-enterprise/1.2.2/couchbase-v1.2.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/couchbase-enterprise/1.2.2/couchbase-v1.2.2.clusterserviceversion.yaml
@@ -46,6 +46,10 @@ metadata:
               "searchServiceMemoryQuota": 256
             },
             "exposeAdminConsole": true,
+            "antiAffinity": false,
+            "softwareUpdateNotifications": false,
+            "disableBucketManagement": false,
+            "paused": false,
             "servers": [
               {
                 "name": "all_services",
@@ -108,34 +112,29 @@ spec:
       - description: Specifies if the Operator will manage this cluster.
         displayName: Paused
         path: paused
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Couchbase Server Web Console will be exposed
           externally.
         displayName: Expose Console
         path: exposeAdminConsole
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies whether or not two pods in this cluster can be deployed
           on the same Kubernetes node.
         displayName: Anti Affinity
         path: antiAffinity
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if update notifications will be displayed in the
           Couchbase UI.
         displayName: Show Update Notifications
         path: softwareUpdateNotifications
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Specifies if the Operator will create or delete buckets.
         displayName: Disable Bucket Management
         path: disableBucketManagement
-        value: false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The desired number of member Pods for the Couchbase cluster.


### PR DESCRIPTION
Values for ui switches are inherited from alm-example within the csv.
This allows for behavior of booleanSwitch to be backwards compatible as
schema changes are enforced within 1.17.

Signed-off-by: Tommie McAfee tommie@couchbase.com

Thanks submitting your Operator. Please check below list before you create your Pull Request.
*************************************************
**Flat operator directory structure is obsolete from 23-rd of October 2019, only nested directory structure will be accepted.**
*************************************************

### Updates to existing Operators

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?