### PR TITLE
Update Elastic Cloud on K8S to 1.0.1

### DIFF
--- a/upstream-community-operators/elastic-cloud/1.0.1/apmservers.apm.k8s.elastic.co.crd.yaml
+++ b/upstream-community-operators/elastic-cloud/1.0.1/apmservers.apm.k8s.elastic.co.crd.yaml
@@ -1,0 +1,410 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: apmservers.apm.k8s.elastic.co
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .spec.version
+    description: APM version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  group: apm.k8s.elastic.co
+  names:
+    categories:
+    - elastic
+    kind: ApmServer
+    listKind: ApmServerList
+    plural: apmservers
+    shortNames:
+    - apm
+    singular: apmserver
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ApmServer represents an APM Server resource in a Kubernetes cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ApmServerSpec holds the specification of an APM Server.
+          properties:
+            config:
+              description: 'Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html'
+              type: object
+            count:
+              description: Count of APM Server instances to deploy.
+              format: int32
+              type: integer
+            elasticsearchRef:
+              description: ElasticsearchRef is a reference to the output Elasticsearch
+                cluster running in the same Kubernetes cluster.
+              properties:
+                name:
+                  description: Name of the Kubernetes object.
+                  type: string
+                namespace:
+                  description: Namespace of the Kubernetes object. If empty, defaults
+                    to the current namespace.
+                  type: string
+              required:
+              - name
+              type: object
+            http:
+              description: HTTP holds the HTTP layer configuration for the APM Server
+                resource.
+              properties:
+                service:
+                  description: Service defines the template for the associated Kubernetes
+                    Service object.
+                  properties:
+                    metadata:
+                      description: ObjectMeta is the metadata of the service. The
+                        name and namespace provided here are managed by ECK and will
+                        be ignored.
+                      type: object
+                    spec:
+                      description: Spec is the specification of the service.
+                      properties:
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly by the master. If an
+                            address is specified manually and is not in use by others,
+                            it will be allocated to the service; otherwise, creation
+                            of the service will fail. This field can not be changed
+                            through updates. Valid values are "None", empty string
+                            (""), or a valid IP address. "None" can be specified for
+                            headless services when proxying is not required. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            kubedns or equivalent will return as a CNAME record for
+                            this service. No proxying will be involved. Must be a
+                            valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires Type to be ExternalName.
+                          type: string
+                        externalTrafficPolicy:
+                          description: externalTrafficPolicy denotes if this Service
+                            desires to route external traffic to node-local or cluster-wide
+                            endpoints. "Local" preserves the client source IP and
+                            avoids a second hop for LoadBalancer and Nodeport type
+                            services, but risks potentially imbalanced traffic spreading.
+                            "Cluster" obscures the client source IP and may cause
+                            a second hop to another node, but should have good overall
+                            load-spreading.
+                          type: string
+                        healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. If not specified, HealthCheckNodePort
+                            is created by the service api backend with the allocated
+                            nodePort. Will use user-specified nodePort value if specified
+                            by the client. Only effects when Type is set to LoadBalancer
+                            and ExternalTrafficPolicy is set to Local.
+                          format: int32
+                          type: integer
+                        ipFamily:
+                          description: ipFamily specifies whether this Service has
+                            a preference for a particular IP family (e.g. IPv4 vs.
+                            IPv6).  If a specific IP family is requested, the clusterIP
+                            field will be allocated from that family, if it is available
+                            in the cluster.  If no IP family is requested, the cluster's
+                            primary IP family will be used. Other IP fields (loadBalancerIP,
+                            loadBalancerSourceRanges, externalIPs) and controllers
+                            which allocate external load-balancers should use the
+                            same IP family.  Endpoints for this Service will be of
+                            this family.  This field is immutable after creation.
+                            Assigning a ServiceIPFamily not available in the cluster
+                            (e.g. IPv6 in IPv4 only cluster) is an error condition
+                            and will fail during clusterIP assignment.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer
+                            LoadBalancer will get created with the IP specified in
+                            this field. This feature depends on whether the underlying
+                            cloud-provider supports specifying the loadBalancerIP
+                            when a load balancer is created. This field will be ignored
+                            if the cloud-provider does not support the feature.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          items:
+                            type: string
+                          type: array
+                        ports:
+                          description: 'The list of ports that are exposed by this
+                            service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          items:
+                            description: ServicePort contains information on service's
+                              port.
+                            properties:
+                              name:
+                                description: The name of this port within the service.
+                                  This must be a DNS_LABEL. All ports within a ServiceSpec
+                                  must have unique names. When considering the endpoints
+                                  for a Service, this must match the 'name' field
+                                  in the EndpointPort. Optional if only one ServicePort
+                                  is defined on this service.
+                                type: string
+                              nodePort:
+                                description: 'The port on each node on which this
+                                  service is exposed when type=NodePort or LoadBalancer.
+                                  Usually assigned by the system. If specified, it
+                                  will be allocated to the service if unused or else
+                                  creation of the service will fail. Default is to
+                                  auto-allocate a port if the ServiceType of this
+                                  Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                format: int32
+                                type: integer
+                              port:
+                                description: The port that will be exposed by this
+                                  service.
+                                format: int32
+                                type: integer
+                              protocol:
+                                description: The IP protocol for this port. Supports
+                                  "TCP", "UDP", and "SCTP". Default is TCP.
+                                type: string
+                              targetPort:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: 'Number or name of the port to access
+                                  on the pods targeted by the service. Number must
+                                  be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  If this is a string, it will be looked up as a named
+                                  port in the target Pod''s container ports. If this
+                                  is not specified, the value of the ''port'' field
+                                  is used (an identity map). This field is ignored
+                                  for services with clusterIP=None, and should be
+                                  omitted or set equal to the ''port'' field. More
+                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            required:
+                            - port
+                            type: object
+                          type: array
+                        publishNotReadyAddresses:
+                          description: publishNotReadyAddresses, when set to true,
+                            indicates that DNS implementations must publish the notReadyAddresses
+                            of subsets for the Endpoints associated with the Service.
+                            The default value is false. The primary use case for setting
+                            this field is to use a StatefulSet's Headless Service
+                            to propagate SRV records for its Pods without respect
+                            to their readiness for purpose of peer discovery.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                          type: object
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ExternalName"
+                            maps to the specified externalName. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object. If clusterIP is "None", no virtual IP is allocated
+                            and the endpoints are published as a set of endpoints
+                            rather than a stable IP. "NodePort" builds on ClusterIP
+                            and allocates a port on every node which routes to the
+                            clusterIP. "LoadBalancer" builds on NodePort and creates
+                            an external load-balancer (if supported in the current
+                            cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      type: object
+                  type: object
+                tls:
+                  description: TLS defines options for configuring TLS for HTTP.
+                  properties:
+                    certificate:
+                      description: "Certificate is a reference to a Kubernetes secret
+                        that contains the certificate and private key for enabling
+                        TLS. The referenced secret should contain the following: \n
+                        - `ca.crt`: The certificate authority (optional). - `tls.crt`:
+                        The certificate (or a chain). - `tls.key`: The private key
+                        to the first certificate in the certificate chain."
+                      properties:
+                        secretName:
+                          description: SecretName is the name of the secret.
+                          type: string
+                      type: object
+                    selfSignedCertificate:
+                      description: SelfSignedCertificate allows configuring the self-signed
+                        certificate generated by the operator.
+                      properties:
+                        disabled:
+                          description: Disabled indicates that the provisioning of
+                            the self-signed certifcate should be disabled.
+                          type: boolean
+                        subjectAltNames:
+                          description: SubjectAlternativeNames is a list of SANs to
+                            include in the generated HTTP TLS certificate.
+                          items:
+                            description: SubjectAlternativeName represents a SAN entry
+                              in a x509 certificate.
+                            properties:
+                              dns:
+                                description: DNS is the DNS name of the subject.
+                                type: string
+                              ip:
+                                description: IP is the IP address of the subject.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            image:
+              description: Image is the APM Server Docker image to deploy.
+              type: string
+            podTemplate:
+              description: PodTemplate provides customisation options (labels, annotations,
+                affinity rules, resource requests, and so on) for the APM Server pods.
+              type: object
+            secureSettings:
+              description: 'SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for APM Server. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings'
+              items:
+                description: SecretSource defines a data source based on a Kubernetes
+                  Secret.
+                properties:
+                  entries:
+                    description: Entries define how to project each key-value pair
+                      in the secret to filesystem paths. If not defined, all keys
+                      will be projected to similarly named paths in the filesystem.
+                      If defined, only the specified keys will be projected to the
+                      corresponding paths.
+                    items:
+                      description: KeyToPath defines how to map a key in a Secret
+                        object to a filesystem path.
+                      properties:
+                        key:
+                          description: Key is the key contained in the secret.
+                          type: string
+                        path:
+                          description: Path is the relative file path to map the key
+                            to. Path must not be an absolute file path and must not
+                            contain any ".." components.
+                          type: string
+                      required:
+                      - key
+                      type: object
+                    type: array
+                  secretName:
+                    description: SecretName is the name of the secret.
+                    type: string
+                required:
+                - secretName
+                type: object
+              type: array
+            version:
+              description: Version of the APM Server.
+              type: string
+          type: object
+        status:
+          description: ApmServerStatus defines the observed state of ApmServer
+          properties:
+            associationStatus:
+              description: Association is the status of any auto-linking to Elasticsearch
+                clusters.
+              type: string
+            availableNodes:
+              format: int32
+              type: integer
+            health:
+              description: ApmServerHealth expresses the status of the Apm Server
+                instances.
+              type: string
+            secretTokenSecret:
+              description: SecretTokenSecretName is the name of the Secret that contains
+                the secret token
+              type: string
+            service:
+              description: ExternalService is the name of the service the agents should
+                connect to.
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1alpha1
+    served: false
+    storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/upstream-community-operators/elastic-cloud/1.0.1/elastic-cloud-eck.v1.0.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/elastic-cloud/1.0.1/elastic-cloud-eck.v1.0.1.clusterserviceversion.yaml
@@ -1,0 +1,298 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: "[\n  {\n    \"apiVersion\": \"elasticsearch.k8s.elastic.co\\/v1\"\
+      ,\n    \"kind\": \"Elasticsearch\",\n    \"metadata\": {\n      \"name\": \"\
+      elasticsearch-sample\"\n    },\n    \"spec\": {\n      \"version\": \"7.6.0\"\
+      ,\n      \"nodeSets\": [{\n        \"name\": \"default\",\n        \"config\"\
+      : {\n          \"node.master\": true,\n          \"node.data\": true,\n    \
+      \      \"node.attr.attr_name\": \"attr_value\",      \"node.store.allow_mmap\": false\n        },\n        \"podTemplate\"\
+      : {\n          \"metadata\": {\n            \"labels\": {\n              \"\
+      foo\": \"bar\"\n            }\n          },\n          \"spec\": {\n       \
+      \     \"containers\": [{\n              \"name\": \"elasticsearch\",\n     \
+      \         \"resources\": {\n                \"requests\": {\n              \
+      \    \"memory\": \"4Gi\",\n                  \"cpu\": 1\n                },\n\
+      \                \"limits\": {\n                  \"memory\": \"4Gi\",\n   \
+      \               \"cpu\": 2\n                }\n              }\n           \
+      \ }]\n          }\n        },\n        \"count\": 3\n      }]\n    }\n  },\n\
+      \  {\n    \"apiVersion\": \"kibana.k8s.elastic.co\\/v1\",\n    \"kind\"\
+      : \"Kibana\",\n    \"metadata\": {\n      \"name\": \"kibana-sample\"\n    },\n\
+      \    \"spec\": {\n      \"version\": \"7.6.0\",\n      \"count\": 1,\n     \
+      \ \"elasticsearchRef\": {\n        \"name\": \"elasticsearch-sample\"\n    \
+      \  },\n      \"podTemplate\": {\n        \"metadata\": {\n          \"labels\"\
+      : {\n            \"foo\": \"bar\"\n          }\n        },\n        \"spec\"\
+      : {\n          \"containers\": [{\n            \"name\": \"kibana\",\n     \
+      \       \"resources\": {\n              \"requests\": {\n                \"\
+      memory\": \"1Gi\",\n                \"cpu\": 0.5\n              },\n       \
+      \       \"limits\": {\n                \"memory\": \"2Gi\",\n              \
+      \  \"cpu\": 2\n              }\n            }\n          }]\n        }\n   \
+      \   }\n    }\n  },\n  {\n    \"apiVersion\": \"apm.k8s.elastic.co\\/v1\"\
+      ,\n    \"kind\": \"ApmServer\",\n    \"metadata\": {\n      \"labels\": {\n\
+      \        \"controller-tools.k8s.io\": \"1.0\"\n      },\n      \"name\": \"\
+      apmserver-sample\"\n    },\n    \"spec\": {\n      \"version\": \"7.6.0\",\n\
+      \      \"count\": 1,\n      \"elasticsearchRef\": {\n        \"name\": \"elasticsearch-sample\"\
+      \n      }\n    }\n  }\n]\n"
+    capabilities: Full Lifecycle
+    categories: Database
+    certified: 'false'
+    containerImage: docker.elastic.co/eck/eck-operator:1.0.1
+    createdAt: 2019-10-11 12:13:14
+    description: Run Elasticsearch, Kibana and the APM Server on Kubernetes and OpenShift
+    repository: https://github.com/elastic/cloud-on-k8s
+    support: elastic.co
+  name: elastic-cloud-eck.v1.0.1
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: Instance of an Elasticsearch cluster
+      displayName: Elasticsearch Cluster
+      group: elasticsearch.k8s.elastic.co
+      kind: Elasticsearch
+      name: elasticsearches.elasticsearch.k8s.elastic.co
+      version: v1
+    - description: Kibana instance
+      displayName: Kibana
+      kind: Kibana
+      name: kibanas.kibana.k8s.elastic.co
+      version: v1
+    - description: APM server instance
+      displayName: APM server
+      kind: ApmServer
+      name: apmservers.apm.k8s.elastic.co
+      version: v1
+  description: 'Elastic Cloud on Kubernetes automates the deployment, provisioning,
+    management, and orchestration of Elasticsearch, Kibana and the APM Server on Kubernetes.
+
+
+    Current features:
+
+
+    *  Elasticsearch, Kibana and APM Server deployments
+
+    *  TLS Certificates management
+
+    *  Safe Elasticsearch cluster configuration & topology changes
+
+    *  Persistent volumes usage
+
+    *  Custom node configuration and attributes
+
+    *  Secure settings keystore updates
+
+
+    Supported versions:
+
+
+    * Kubernetes: 1.12+ or OpenShift 3.11+
+
+    * Elasticsearch: 6.8+, 7.1+
+
+
+    See the [Quickstart](https://www.elastic.co/guide/en/cloud-on-k8s/1.0/k8s-quickstart.html)
+    to get started with ECK.'
+  displayName: Elastic Cloud on Kubernetes
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgPHBhdGggZmlsbD0iIzM0Mzc0MSIgZD0iTTM3LjA2MjUsMzIgQzM3LjA2MjUsMzQuNzk2IDM0Ljc5NTUsMzcuMDYyIDMyLjAwMDUsMzcuMDYyIEMyOS4yMDQ1LDM3LjA2MiAyNi45Mzc1LDM0Ljc5NiAyNi45Mzc1LDMyIEMyNi45Mzc1LDI5LjIwNCAyOS4yMDQ1LDI2LjkzOCAzMi4wMDA1LDI2LjkzOCBDMzQuNzk1NSwyNi45MzggMzcuMDYyNSwyOS4yMDQgMzcuMDYyNSwzMiIvPgogICAgPHBhdGggZmlsbD0iI0YwNEU5OCIgZD0iTTM4LjIyMjcsMjQuMTA0NSBDMzguMjY1NywyNC4xMzg1IDM4LjMwOTcsMjQuMTczNSAzOC4zNTI3LDI0LjIwODUgQzM5LjI5MDcsMjQuOTcyNSA0MC41ODU3LDI1LjEyMDUgNDEuNjc3NywyNC41OTc1IEw1NS4xNzE3LDE4LjE0MTUgQzUxLjg3NDcsMTIuNjQwNSA0Ni42NzU3LDguNDE2NSA0MC40ODI3LDYuMzY3NSBMMzcuMTE4NywyMC45NDI1IEMzNi44NDU3LDIyLjEyMTUgMzcuMjcxNywyMy4zNTU1IDM4LjIyMjcsMjQuMTA0NSIvPgogICAgPHBhdGggZmlsbD0iIzA3QyIgZD0iTTMyLjE4NTUsNDQuMTgzNiBDMzEuOTE4NSw0My4wMDI2IDMwLjk5OTUsNDIuMDc1NiAyOS44MTg1LDQxLjgxMzYgQzI1LjMxNjUsNDAuODE1NiAyMS45Mzc1LDM2Ljc5ODYgMjEuOTM3NSwzMS45OTk2IEMyMS45Mzc1LDI3LjE4MjYgMjUuMzQxNSwyMy4xNTI2IDI5Ljg3MDUsMjIuMTczNiBDMzEuMDUyNSwyMS45MTg2IDMxLjk3NTUsMjAuOTk0NiAzMi4yNDc1LDE5LjgxNTYgTDM1LjYxMDUsNS4yNDc2IEMzNC40Mjg1LDUuMDg5NiAzMy4yMjQ1LDQuOTk5NiAzMS45OTk1LDQuOTk5NiBDMTcuMDg3NSw0Ljk5OTYgNC45OTk1LDE3LjA4ODYgNC45OTk1LDMxLjk5OTYgQzQuOTk5NSw0Ni45MTE2IDE3LjA4NzUsNTguOTk5NiAzMS45OTk1LDU4Ljk5OTYgQzMzLjE3ODUsNTguOTk5NiAzNC4zMzY1LDU4LjkxNTYgMzUuNDc0NSw1OC43Njk2IEwzMi4xODU1LDQ0LjE4MzYgWiIvPgogICAgPHBhdGggZmlsbD0iIzM0Mzc0MSIgZD0iTTU3LjI4NTIsNDEuNDc4IEM1OC4zOTAyLDM4LjUyOCA1OS4wMDAyLDM1LjMzNiA1OS4wMDAyLDMyIEM1OS4wMDAyLDI4LjcxMyA1OC40MTEyLDI1LjU2MyA1Ny4zMzUyLDIyLjY0OSBMNDMuNzUyMiwyOS4xNDggQzQyLjY1MzIsMjkuNjc0IDQxLjk2MjIsMzAuNzg2IDQxLjk2MTE5MDIsMzIuMDA0IEw0MS45NjExOTAyLDMyLjA1NCBDNDEuOTU4MiwzMy4yNyA0Mi42NDMyLDM0LjM4MSA0My43MzcyLDM0LjkxMSBMNTcuMjg1Miw0MS40NzggWiIvPgogICAgPHBhdGggZmlsbD0iI0YwNEU5OCIgZD0iTTM4LjMxMDUsMzkuODIzNyBDMzguMjY3NSwzOS44NTc3IDM4LjIyNDUsMzkuODkxNyAzOC4xODE1LDM5LjkyNTcgQzM3LjIyNzUsNDAuNjY5NyAzNi43OTU1LDQxLjkwMDcgMzcuMDYxNSw0My4wODE3IEw0MC4zNTM1LDU3LjY3NjcgQzQ2LjU1OTUsNTUuNjU3NyA1MS43ODE1LDUxLjQ1OTcgNTUuMTA0NSw0NS45Nzc3IEw0MS42Mzk1LDM5LjQ1MDcgQzQwLjU0OTUsMzguOTIyNyAzOS4yNTI1LDM5LjA2MzcgMzguMzEwNSwzOS44MjM3Ii8+CiAgPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  install:
+    spec:
+      deployments:
+      - name: elastic-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: elastic-operator
+          template:
+            metadata:
+              labels:
+                control-plane: elastic-operator
+            spec:
+              containers:
+              - args:
+                - manager
+                - --operator-roles
+                - global,namespace
+                - --log-verbosity=0
+                env:
+                - name: NAMESPACES
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.operatorNamespace']
+                - name: OPERATOR_IMAGE
+                  value: docker.elastic.co/eck/eck-operator:1.0.1
+                image: docker.elastic.co/eck/eck-operator:1.0.1
+                imagePullPolicy: Always
+                name: manager
+                resources:
+                  limits:
+                    cpu: 1
+                    memory: 150Mi
+                  requests:
+                    cpu: 100m
+                    memory: 50Mi
+              serviceAccount: elastic-operator
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - secrets
+          - services
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - elasticsearch.k8s.elastic.co
+          resources:
+          - elasticsearches
+          - elasticsearches/status
+          - elasticsearches/finalizers
+          - enterpriselicenses
+          - enterpriselicenses/status
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - kibana.k8s.elastic.co
+          resources:
+          - kibanas
+          - kibanas/status
+          - kibanas/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apm.k8s.elastic.co
+          resources:
+          - apmservers
+          - apmservers/status
+          - apmservers/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - associations.k8s.elastic.co
+          resources:
+          - apmserverelasticsearchassociations
+          - apmserverelasticsearchassociations/status
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: elastic-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - elasticsearch
+  - kibana
+  - analytics
+  - search
+  - database
+  - apm
+  links:
+  - name: Documentation
+    url: https://www.elastic.co/guide/en/cloud-on-k8s/1.0/index.html
+  maintainers:
+  - email: anurag.gupta@elastic.co
+    name: Elastic
+  maturity: stable
+  minKubeVersion: 1.11.0
+  provider:
+    name: Elastic
+  replaces: elastic-cloud-eck.v1.0.0
+  version: 1.0.1

--- a/upstream-community-operators/elastic-cloud/1.0.1/elasticsearches.elasticsearch.k8s.elastic.co.crd.yaml
+++ b/upstream-community-operators/elastic-cloud/1.0.1/elasticsearches.elasticsearch.k8s.elastic.co.crd.yaml
@@ -1,0 +1,727 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: elasticsearches.elasticsearch.k8s.elastic.co
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .spec.version
+    description: Elasticsearch version
+    name: version
+    type: string
+  - JSONPath: .status.phase
+    name: phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  group: elasticsearch.k8s.elastic.co
+  names:
+    categories:
+    - elastic
+    kind: Elasticsearch
+    listKind: ElasticsearchList
+    plural: elasticsearches
+    shortNames:
+    - es
+    singular: elasticsearch
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Elasticsearch represents an Elasticsearch resource in a Kubernetes
+        cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ElasticsearchSpec holds the specification of an Elasticsearch
+            cluster.
+          properties:
+            http:
+              description: HTTP holds HTTP layer settings for Elasticsearch.
+              properties:
+                service:
+                  description: Service defines the template for the associated Kubernetes
+                    Service object.
+                  properties:
+                    metadata:
+                      description: ObjectMeta is the metadata of the service. The
+                        name and namespace provided here are managed by ECK and will
+                        be ignored.
+                      type: object
+                    spec:
+                      description: Spec is the specification of the service.
+                      properties:
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly by the master. If an
+                            address is specified manually and is not in use by others,
+                            it will be allocated to the service; otherwise, creation
+                            of the service will fail. This field can not be changed
+                            through updates. Valid values are "None", empty string
+                            (""), or a valid IP address. "None" can be specified for
+                            headless services when proxying is not required. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            kubedns or equivalent will return as a CNAME record for
+                            this service. No proxying will be involved. Must be a
+                            valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires Type to be ExternalName.
+                          type: string
+                        externalTrafficPolicy:
+                          description: externalTrafficPolicy denotes if this Service
+                            desires to route external traffic to node-local or cluster-wide
+                            endpoints. "Local" preserves the client source IP and
+                            avoids a second hop for LoadBalancer and Nodeport type
+                            services, but risks potentially imbalanced traffic spreading.
+                            "Cluster" obscures the client source IP and may cause
+                            a second hop to another node, but should have good overall
+                            load-spreading.
+                          type: string
+                        healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. If not specified, HealthCheckNodePort
+                            is created by the service api backend with the allocated
+                            nodePort. Will use user-specified nodePort value if specified
+                            by the client. Only effects when Type is set to LoadBalancer
+                            and ExternalTrafficPolicy is set to Local.
+                          format: int32
+                          type: integer
+                        ipFamily:
+                          description: ipFamily specifies whether this Service has
+                            a preference for a particular IP family (e.g. IPv4 vs.
+                            IPv6).  If a specific IP family is requested, the clusterIP
+                            field will be allocated from that family, if it is available
+                            in the cluster.  If no IP family is requested, the cluster's
+                            primary IP family will be used. Other IP fields (loadBalancerIP,
+                            loadBalancerSourceRanges, externalIPs) and controllers
+                            which allocate external load-balancers should use the
+                            same IP family.  Endpoints for this Service will be of
+                            this family.  This field is immutable after creation.
+                            Assigning a ServiceIPFamily not available in the cluster
+                            (e.g. IPv6 in IPv4 only cluster) is an error condition
+                            and will fail during clusterIP assignment.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer
+                            LoadBalancer will get created with the IP specified in
+                            this field. This feature depends on whether the underlying
+                            cloud-provider supports specifying the loadBalancerIP
+                            when a load balancer is created. This field will be ignored
+                            if the cloud-provider does not support the feature.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          items:
+                            type: string
+                          type: array
+                        ports:
+                          description: 'The list of ports that are exposed by this
+                            service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          items:
+                            description: ServicePort contains information on service's
+                              port.
+                            properties:
+                              name:
+                                description: The name of this port within the service.
+                                  This must be a DNS_LABEL. All ports within a ServiceSpec
+                                  must have unique names. When considering the endpoints
+                                  for a Service, this must match the 'name' field
+                                  in the EndpointPort. Optional if only one ServicePort
+                                  is defined on this service.
+                                type: string
+                              nodePort:
+                                description: 'The port on each node on which this
+                                  service is exposed when type=NodePort or LoadBalancer.
+                                  Usually assigned by the system. If specified, it
+                                  will be allocated to the service if unused or else
+                                  creation of the service will fail. Default is to
+                                  auto-allocate a port if the ServiceType of this
+                                  Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                format: int32
+                                type: integer
+                              port:
+                                description: The port that will be exposed by this
+                                  service.
+                                format: int32
+                                type: integer
+                              protocol:
+                                description: The IP protocol for this port. Supports
+                                  "TCP", "UDP", and "SCTP". Default is TCP.
+                                type: string
+                              targetPort:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: 'Number or name of the port to access
+                                  on the pods targeted by the service. Number must
+                                  be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  If this is a string, it will be looked up as a named
+                                  port in the target Pod''s container ports. If this
+                                  is not specified, the value of the ''port'' field
+                                  is used (an identity map). This field is ignored
+                                  for services with clusterIP=None, and should be
+                                  omitted or set equal to the ''port'' field. More
+                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            required:
+                            - port
+                            type: object
+                          type: array
+                        publishNotReadyAddresses:
+                          description: publishNotReadyAddresses, when set to true,
+                            indicates that DNS implementations must publish the notReadyAddresses
+                            of subsets for the Endpoints associated with the Service.
+                            The default value is false. The primary use case for setting
+                            this field is to use a StatefulSet's Headless Service
+                            to propagate SRV records for its Pods without respect
+                            to their readiness for purpose of peer discovery.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                          type: object
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ExternalName"
+                            maps to the specified externalName. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object. If clusterIP is "None", no virtual IP is allocated
+                            and the endpoints are published as a set of endpoints
+                            rather than a stable IP. "NodePort" builds on ClusterIP
+                            and allocates a port on every node which routes to the
+                            clusterIP. "LoadBalancer" builds on NodePort and creates
+                            an external load-balancer (if supported in the current
+                            cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      type: object
+                  type: object
+                tls:
+                  description: TLS defines options for configuring TLS for HTTP.
+                  properties:
+                    certificate:
+                      description: "Certificate is a reference to a Kubernetes secret
+                        that contains the certificate and private key for enabling
+                        TLS. The referenced secret should contain the following: \n
+                        - `ca.crt`: The certificate authority (optional). - `tls.crt`:
+                        The certificate (or a chain). - `tls.key`: The private key
+                        to the first certificate in the certificate chain."
+                      properties:
+                        secretName:
+                          description: SecretName is the name of the secret.
+                          type: string
+                      type: object
+                    selfSignedCertificate:
+                      description: SelfSignedCertificate allows configuring the self-signed
+                        certificate generated by the operator.
+                      properties:
+                        disabled:
+                          description: Disabled indicates that the provisioning of
+                            the self-signed certifcate should be disabled.
+                          type: boolean
+                        subjectAltNames:
+                          description: SubjectAlternativeNames is a list of SANs to
+                            include in the generated HTTP TLS certificate.
+                          items:
+                            description: SubjectAlternativeName represents a SAN entry
+                              in a x509 certificate.
+                            properties:
+                              dns:
+                                description: DNS is the DNS name of the subject.
+                                type: string
+                              ip:
+                                description: IP is the IP address of the subject.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            image:
+              description: Image is the Elasticsearch Docker image to deploy.
+              type: string
+            nodeSets:
+              description: 'NodeSets allow specifying groups of Elasticsearch nodes
+                sharing the same configuration and Pod templates. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-orchestration.html'
+              items:
+                description: NodeSet is the specification for a group of Elasticsearch
+                  nodes sharing the same configuration and a Pod template.
+                properties:
+                  config:
+                    description: Config holds the Elasticsearch configuration.
+                    type: object
+                  count:
+                    description: Count of Elasticsearch nodes to deploy.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  name:
+                    description: Name of this set of nodes. Becomes a part of the
+                      Elasticsearch node.name setting.
+                    maxLength: 23
+                    pattern: '[a-zA-Z0-9-]+'
+                    type: string
+                  podTemplate:
+                    description: PodTemplate provides customisation options (labels,
+                      annotations, affinity rules, resource requests, and so on) for
+                      the Pods belonging to this NodeSet.
+                    type: object
+                  volumeClaimTemplates:
+                    description: 'VolumeClaimTemplates is a list of persistent volume
+                      claims to be used by each Pod in this NodeSet. Every claim in
+                      this list must have a matching volumeMount in one of the containers
+                      defined in the PodTemplate. Items defined here take precedence
+                      over any default claims added by the operator with the same
+                      name. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html'
+                    items:
+                      description: PersistentVolumeClaim is a user's request for and
+                        claim to a persistent volume
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          type: object
+                        spec:
+                          description: 'Spec defines the desired characteristics of
+                            a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: This field requires the VolumeSnapshotDataSource
+                                alpha feature gate to be enabled and currently VolumeSnapshot
+                                is the only supported data source. If the provisioner
+                                can support VolumeSnapshot data source, it will create
+                                a new volume and data will be restored to the volume
+                                at the same time. If the provisioner does not support
+                                VolumeSnapshot data source, volume will not be created
+                                and the failure will be reported as an event. In the
+                                future, we plan to support more data source types
+                                and the behavior of the provisioner may change.
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'Resources represents the minimum resources
+                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: A label query over volumes to consider
+                                for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'Name of the StorageClass required by the
+                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec. This is a beta feature.
+                              type: string
+                            volumeName:
+                              description: VolumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                        status:
+                          description: 'Status represents the current information/status
+                            of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the actual access
+                                modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            capacity:
+                              additionalProperties:
+                                type: string
+                              description: Represents the actual resources of the
+                                underlying volume.
+                              type: object
+                            conditions:
+                              description: Current Condition of persistent volume
+                                claim. If underlying persistent volume is being resized
+                                then the Condition will be set to 'ResizeStarted'.
+                              items:
+                                description: PersistentVolumeClaimCondition contails
+                                  details about state of pvc
+                                properties:
+                                  lastProbeTime:
+                                    description: Last time we probed the condition.
+                                    format: date-time
+                                    type: string
+                                  lastTransitionTime:
+                                    description: Last time the condition transitioned
+                                      from one status to another.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: Human-readable message indicating
+                                      details about last transition.
+                                    type: string
+                                  reason:
+                                    description: Unique, this should be a short, machine
+                                      understandable string that gives the reason
+                                      for condition's last transition. If it reports
+                                      "ResizeStarted" that means the underlying persistent
+                                      volume is being resized.
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    description: PersistentVolumeClaimConditionType
+                                      is a valid value of PersistentVolumeClaimCondition.Type
+                                    type: string
+                                required:
+                                - status
+                                - type
+                                type: object
+                              type: array
+                            phase:
+                              description: Phase represents the current phase of PersistentVolumeClaim.
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - count
+                - name
+                type: object
+              minItems: 1
+              type: array
+            podDisruptionBudget:
+              description: PodDisruptionBudget provides access to the default pod
+                disruption budget for the Elasticsearch cluster. The default budget
+                selects all cluster pods and sets `maxUnavailable` to 1. To disable,
+                set `PodDisruptionBudget` to the empty value (`{}` in YAML).
+              properties:
+                metadata:
+                  description: ObjectMeta is the metadata of the PDB. The name and
+                    namespace provided here are managed by ECK and will be ignored.
+                  type: object
+                spec:
+                  description: Spec is the specification of the PDB.
+                  properties:
+                    maxUnavailable:
+                      anyOf:
+                      - type: string
+                      - type: integer
+                      description: An eviction is allowed if at most "maxUnavailable"
+                        pods selected by "selector" are unavailable after the eviction,
+                        i.e. even in absence of the evicted pod. For example, one
+                        can prevent all voluntary evictions by specifying 0. This
+                        is a mutually exclusive setting with "minAvailable".
+                    minAvailable:
+                      anyOf:
+                      - type: string
+                      - type: integer
+                      description: An eviction is allowed if at least "minAvailable"
+                        pods selected by "selector" will still be available after
+                        the eviction, i.e. even in the absence of the evicted pod.  So
+                        for example you can prevent all voluntary evictions by specifying
+                        "100%".
+                    selector:
+                      description: Label query over pods whose evictions are managed
+                        by the disruption budget.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                  type: object
+              type: object
+            secureSettings:
+              description: 'SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for Elasticsearch. See:
+                https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html'
+              items:
+                description: SecretSource defines a data source based on a Kubernetes
+                  Secret.
+                properties:
+                  entries:
+                    description: Entries define how to project each key-value pair
+                      in the secret to filesystem paths. If not defined, all keys
+                      will be projected to similarly named paths in the filesystem.
+                      If defined, only the specified keys will be projected to the
+                      corresponding paths.
+                    items:
+                      description: KeyToPath defines how to map a key in a Secret
+                        object to a filesystem path.
+                      properties:
+                        key:
+                          description: Key is the key contained in the secret.
+                          type: string
+                        path:
+                          description: Path is the relative file path to map the key
+                            to. Path must not be an absolute file path and must not
+                            contain any ".." components.
+                          type: string
+                      required:
+                      - key
+                      type: object
+                    type: array
+                  secretName:
+                    description: SecretName is the name of the secret.
+                    type: string
+                required:
+                - secretName
+                type: object
+              type: array
+            updateStrategy:
+              description: UpdateStrategy specifies how updates to the cluster should
+                be performed.
+              properties:
+                changeBudget:
+                  description: ChangeBudget defines the constraints to consider when
+                    applying changes to the Elasticsearch cluster.
+                  properties:
+                    maxSurge:
+                      description: MaxSurge is the maximum number of new pods that
+                        can be created exceeding the original number of pods defined
+                        in the specification. MaxSurge is only taken into consideration
+                        when scaling up. Setting a negative value will disable the
+                        restriction. Defaults to unbounded if not specified.
+                      format: int32
+                      type: integer
+                    maxUnavailable:
+                      description: MaxUnavailable is the maximum number of pods that
+                        can be unavailable (not ready) during the update due to circumstances
+                        under the control of the operator. Setting a negative value
+                        will disable this restriction. Defaults to 1 if not specified.
+                      format: int32
+                      type: integer
+                  type: object
+              type: object
+            version:
+              description: Version of Elasticsearch.
+              type: string
+          required:
+          - nodeSets
+          type: object
+        status:
+          description: ElasticsearchStatus defines the observed state of Elasticsearch
+          properties:
+            availableNodes:
+              format: int32
+              type: integer
+            health:
+              description: ElasticsearchHealth is the health of the cluster as returned
+                by the health API.
+              type: string
+            phase:
+              description: ElasticsearchOrchestrationPhase is the phase Elasticsearch
+                is in from the controller point of view.
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1alpha1
+    served: false
+    storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/upstream-community-operators/elastic-cloud/1.0.1/kibanas.kibana.k8s.elastic.co.crd.yaml
+++ b/upstream-community-operators/elastic-cloud/1.0.1/kibanas.kibana.k8s.elastic.co.crd.yaml
@@ -1,0 +1,399 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: kibanas.kibana.k8s.elastic.co
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .spec.version
+    description: Kibana version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  group: kibana.k8s.elastic.co
+  names:
+    categories:
+    - elastic
+    kind: Kibana
+    listKind: KibanaList
+    plural: kibanas
+    shortNames:
+    - kb
+    singular: kibana
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Kibana represents a Kibana resource in a Kubernetes cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KibanaSpec holds the specification of a Kibana instance.
+          properties:
+            config:
+              description: 'Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html'
+              type: object
+            count:
+              description: Count of Kibana instances to deploy.
+              format: int32
+              type: integer
+            elasticsearchRef:
+              description: ElasticsearchRef is a reference to an Elasticsearch cluster
+                running in the same Kubernetes cluster.
+              properties:
+                name:
+                  description: Name of the Kubernetes object.
+                  type: string
+                namespace:
+                  description: Namespace of the Kubernetes object. If empty, defaults
+                    to the current namespace.
+                  type: string
+              required:
+              - name
+              type: object
+            http:
+              description: HTTP holds the HTTP layer configuration for Kibana.
+              properties:
+                service:
+                  description: Service defines the template for the associated Kubernetes
+                    Service object.
+                  properties:
+                    metadata:
+                      description: ObjectMeta is the metadata of the service. The
+                        name and namespace provided here are managed by ECK and will
+                        be ignored.
+                      type: object
+                    spec:
+                      description: Spec is the specification of the service.
+                      properties:
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly by the master. If an
+                            address is specified manually and is not in use by others,
+                            it will be allocated to the service; otherwise, creation
+                            of the service will fail. This field can not be changed
+                            through updates. Valid values are "None", empty string
+                            (""), or a valid IP address. "None" can be specified for
+                            headless services when proxying is not required. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            kubedns or equivalent will return as a CNAME record for
+                            this service. No proxying will be involved. Must be a
+                            valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires Type to be ExternalName.
+                          type: string
+                        externalTrafficPolicy:
+                          description: externalTrafficPolicy denotes if this Service
+                            desires to route external traffic to node-local or cluster-wide
+                            endpoints. "Local" preserves the client source IP and
+                            avoids a second hop for LoadBalancer and Nodeport type
+                            services, but risks potentially imbalanced traffic spreading.
+                            "Cluster" obscures the client source IP and may cause
+                            a second hop to another node, but should have good overall
+                            load-spreading.
+                          type: string
+                        healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. If not specified, HealthCheckNodePort
+                            is created by the service api backend with the allocated
+                            nodePort. Will use user-specified nodePort value if specified
+                            by the client. Only effects when Type is set to LoadBalancer
+                            and ExternalTrafficPolicy is set to Local.
+                          format: int32
+                          type: integer
+                        ipFamily:
+                          description: ipFamily specifies whether this Service has
+                            a preference for a particular IP family (e.g. IPv4 vs.
+                            IPv6).  If a specific IP family is requested, the clusterIP
+                            field will be allocated from that family, if it is available
+                            in the cluster.  If no IP family is requested, the cluster's
+                            primary IP family will be used. Other IP fields (loadBalancerIP,
+                            loadBalancerSourceRanges, externalIPs) and controllers
+                            which allocate external load-balancers should use the
+                            same IP family.  Endpoints for this Service will be of
+                            this family.  This field is immutable after creation.
+                            Assigning a ServiceIPFamily not available in the cluster
+                            (e.g. IPv6 in IPv4 only cluster) is an error condition
+                            and will fail during clusterIP assignment.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer
+                            LoadBalancer will get created with the IP specified in
+                            this field. This feature depends on whether the underlying
+                            cloud-provider supports specifying the loadBalancerIP
+                            when a load balancer is created. This field will be ignored
+                            if the cloud-provider does not support the feature.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          items:
+                            type: string
+                          type: array
+                        ports:
+                          description: 'The list of ports that are exposed by this
+                            service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          items:
+                            description: ServicePort contains information on service's
+                              port.
+                            properties:
+                              name:
+                                description: The name of this port within the service.
+                                  This must be a DNS_LABEL. All ports within a ServiceSpec
+                                  must have unique names. When considering the endpoints
+                                  for a Service, this must match the 'name' field
+                                  in the EndpointPort. Optional if only one ServicePort
+                                  is defined on this service.
+                                type: string
+                              nodePort:
+                                description: 'The port on each node on which this
+                                  service is exposed when type=NodePort or LoadBalancer.
+                                  Usually assigned by the system. If specified, it
+                                  will be allocated to the service if unused or else
+                                  creation of the service will fail. Default is to
+                                  auto-allocate a port if the ServiceType of this
+                                  Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                format: int32
+                                type: integer
+                              port:
+                                description: The port that will be exposed by this
+                                  service.
+                                format: int32
+                                type: integer
+                              protocol:
+                                description: The IP protocol for this port. Supports
+                                  "TCP", "UDP", and "SCTP". Default is TCP.
+                                type: string
+                              targetPort:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                                description: 'Number or name of the port to access
+                                  on the pods targeted by the service. Number must
+                                  be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  If this is a string, it will be looked up as a named
+                                  port in the target Pod''s container ports. If this
+                                  is not specified, the value of the ''port'' field
+                                  is used (an identity map). This field is ignored
+                                  for services with clusterIP=None, and should be
+                                  omitted or set equal to the ''port'' field. More
+                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            required:
+                            - port
+                            type: object
+                          type: array
+                        publishNotReadyAddresses:
+                          description: publishNotReadyAddresses, when set to true,
+                            indicates that DNS implementations must publish the notReadyAddresses
+                            of subsets for the Endpoints associated with the Service.
+                            The default value is false. The primary use case for setting
+                            this field is to use a StatefulSet's Headless Service
+                            to propagate SRV records for its Pods without respect
+                            to their readiness for purpose of peer discovery.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                          type: object
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ExternalName"
+                            maps to the specified externalName. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object. If clusterIP is "None", no virtual IP is allocated
+                            and the endpoints are published as a set of endpoints
+                            rather than a stable IP. "NodePort" builds on ClusterIP
+                            and allocates a port on every node which routes to the
+                            clusterIP. "LoadBalancer" builds on NodePort and creates
+                            an external load-balancer (if supported in the current
+                            cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      type: object
+                  type: object
+                tls:
+                  description: TLS defines options for configuring TLS for HTTP.
+                  properties:
+                    certificate:
+                      description: "Certificate is a reference to a Kubernetes secret
+                        that contains the certificate and private key for enabling
+                        TLS. The referenced secret should contain the following: \n
+                        - `ca.crt`: The certificate authority (optional). - `tls.crt`:
+                        The certificate (or a chain). - `tls.key`: The private key
+                        to the first certificate in the certificate chain."
+                      properties:
+                        secretName:
+                          description: SecretName is the name of the secret.
+                          type: string
+                      type: object
+                    selfSignedCertificate:
+                      description: SelfSignedCertificate allows configuring the self-signed
+                        certificate generated by the operator.
+                      properties:
+                        disabled:
+                          description: Disabled indicates that the provisioning of
+                            the self-signed certifcate should be disabled.
+                          type: boolean
+                        subjectAltNames:
+                          description: SubjectAlternativeNames is a list of SANs to
+                            include in the generated HTTP TLS certificate.
+                          items:
+                            description: SubjectAlternativeName represents a SAN entry
+                              in a x509 certificate.
+                            properties:
+                              dns:
+                                description: DNS is the DNS name of the subject.
+                                type: string
+                              ip:
+                                description: IP is the IP address of the subject.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            image:
+              description: Image is the Kibana Docker image to deploy.
+              type: string
+            podTemplate:
+              description: PodTemplate provides customisation options (labels, annotations,
+                affinity rules, resource requests, and so on) for the Kibana pods
+              type: object
+            secureSettings:
+              description: 'SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for Kibana. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana.html#k8s-kibana-secure-settings'
+              items:
+                description: SecretSource defines a data source based on a Kubernetes
+                  Secret.
+                properties:
+                  entries:
+                    description: Entries define how to project each key-value pair
+                      in the secret to filesystem paths. If not defined, all keys
+                      will be projected to similarly named paths in the filesystem.
+                      If defined, only the specified keys will be projected to the
+                      corresponding paths.
+                    items:
+                      description: KeyToPath defines how to map a key in a Secret
+                        object to a filesystem path.
+                      properties:
+                        key:
+                          description: Key is the key contained in the secret.
+                          type: string
+                        path:
+                          description: Path is the relative file path to map the key
+                            to. Path must not be an absolute file path and must not
+                            contain any ".." components.
+                          type: string
+                      required:
+                      - key
+                      type: object
+                    type: array
+                  secretName:
+                    description: SecretName is the name of the secret.
+                    type: string
+                required:
+                - secretName
+                type: object
+              type: array
+            version:
+              description: Version of Kibana.
+              type: string
+          type: object
+        status:
+          description: KibanaStatus defines the observed state of Kibana
+          properties:
+            associationStatus:
+              description: AssociationStatus is the status of an association resource.
+              type: string
+            availableNodes:
+              format: int32
+              type: integer
+            health:
+              description: KibanaHealth expresses the status of the Kibana instances.
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1alpha1
+    served: false
+    storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/upstream-community-operators/elastic-cloud/elastic-cloud-eck.package.yaml
+++ b/upstream-community-operators/elastic-cloud/elastic-cloud-eck.package.yaml
@@ -1,7 +1,7 @@
 channels:
-- currentCSV: elastic-cloud-eck.v1.0.0
+- currentCSV: elastic-cloud-eck.v1.0.1
   name: beta
-- currentCSV: elastic-cloud-eck.v1.0.0
+- currentCSV: elastic-cloud-eck.v1.0.1
   name: stable
 defaultChannel: stable
 packageName: elastic-cloud-eck


### PR DESCRIPTION
This PR updates Elastic Cloud on K8S to 1.0.1

### Updates to existing Operators

* [X] Is your new CSV pointing to the previous version with the `replaces` property?
* [X] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [X] Have you tested an update to your Operator when deployed via OLM?
* [X] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?

### Your submission should not

* [X] Modify more than one operator
* [X] Modify an Operator you don't own
* [X] Rename an operator - please remove and add with a different name instead
* [X] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [X] Modify any files outside the above mentioned folders
* [X] Contain more than one commit. **Please squash your commits.**
