### PR TITLE
Modify CRD to apiextensions.k8s.io/v1beta1 schema

### DIFF
--- a/community-operators/submariner/0.0.1/clusters.submariner.io.crd.yaml
+++ b/community-operators/submariner/0.0.1/clusters.submariner.io.crd.yaml
@@ -9,3 +9,5 @@ spec:
     kind: Cluster
     plural: clusters
   scope: Namespaced
+  subresources:
+    status: {}

--- a/community-operators/submariner/0.0.1/endpoints.submariner.io.crd.yaml
+++ b/community-operators/submariner/0.0.1/endpoints.submariner.io.crd.yaml
@@ -10,3 +10,5 @@ spec:
     kind: Endpoint
     plural: endpoints
   scope: Namespaced
+  subresources:
+    status: {}

--- a/community-operators/submariner/0.0.1/submariners.submariner.io.crd.yaml
+++ b/community-operators/submariner/0.0.1/submariners.submariner.io.crd.yaml
@@ -10,97 +10,88 @@ spec:
     plural: submariners
     singular: submariner
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Submariner is the Schema for the submariners API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SubmarinerSpec defines the desired state of Submariner
+          properties:
+            broker:
+              type: string
+            brokerK8sApiServer:
+              type: string
+            brokerK8sApiServerToken:
+              type: string
+            brokerK8sCA:
+              type: string
+            brokerK8sRemoteNamespace:
+              type: string
+            ceIPSecDebug:
+              type: boolean
+            ceIPSecIKEPort:
+              type: integer
+            ceIPSecNATTPort:
+              type: integer
+            ceIPSecPSK:
+              type: string
+            clusterCIDR:
+              type: string
+            clusterID:
+              type: string
+            colorCodes:
+              type: string
+            debug:
+              type: boolean
+            namespace:
+              type: string
+            natEnabled:
+              type: boolean
+            repository:
+              type: string
+            serviceCIDR:
+              type: string
+            size:
+              format: int32
+              type: integer
+            version:
+              type: string
+          required:
+          - broker
+          - brokerK8sApiServer
+          - brokerK8sApiServerToken
+          - brokerK8sCA
+          - brokerK8sRemoteNamespace
+          - ceIPSecDebug
+          - ceIPSecPSK
+          - clusterCIDR
+          - clusterID
+          - debug
+          - namespace
+          - natEnabled
+          - serviceCIDR
+          - size
+          type: object
+        status:
+          description: SubmarinerStatus defines the observed state of Submariner
+          type: object
+      type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Submariner is the Schema for the submariners API
-          properties:
-            apiVersion:
-              description: >-
-                APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
-              type: string
-            kind:
-              description: >-
-                Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SubmarinerSpec defines the desired state of Submariner
-              properties:
-                broker:
-                  type: string
-                brokerK8sApiServer:
-                  type: string
-                brokerK8sApiServerToken:
-                  type: string
-                brokerK8sCA:
-                  type: string
-                brokerK8sRemoteNamespace:
-                  type: string
-                ceIPSecDebug:
-                  type: boolean
-                ceIPSecIKEPort:
-                  type: integer
-                ceIPSecNATTPort:
-                  type: integer
-                ceIPSecPSK:
-                  type: string
-                clusterCIDR:
-                  type: string
-                clusterID:
-                  type: string
-                colorCodes:
-                  type: string
-                count:
-                  format: int32
-                  type: integer
-                debug:
-                  type: boolean
-                namespace:
-                  type: string
-                natEnabled:
-                  type: boolean
-                repository:
-                  type: string
-                serviceCIDR:
-                  type: string
-                token:
-                  type: string
-                version:
-                  type: string
-              required:
-                - broker
-                - brokerK8sApiServer
-                - brokerK8sApiServerToken
-                - brokerK8sCA
-                - brokerK8sRemoteNamespace
-                - ceIPSecDebug
-                - ceIPSecPSK
-                - clusterCIDR
-                - clusterID
-                - count
-                - debug
-                - namespace
-                - natEnabled
-                - serviceCIDR
-                - token
-              type: object
-            status:
-              description: SubmarinerStatus defines the observed state of Submariner
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
Issue is that CRD is trying to use feature(s) of apiextensions.k8s.io/v1 (per-version openapi validation) but having the CRD set to apiextensions.k8s.io/v1beta1; so basically the CRD's group/version is apiextensions.k8s.io/v1beta1 while the spec is for apiextensions.k8s.io/v1. I was able to resolve this by pulling in the CRD from their github repo tag 0.0.3 as suggested at the following issue - https://github.com/submariner-io/submariner-operator/issues/95

Signed-off-by: Melvin Hillsman <mrhillsman@redhat.com>

### Updates to existing Operators

* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?