### PR TITLE
KEYCLOAK-13333 Prevent Keycloak Operator 9.0.0 from installing

### DIFF
--- a/community-operators/keycloak/keycloak.package.yaml
+++ b/community-operators/keycloak/keycloak.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: keycloak-operator.9.0.0
+- currentCSV: keycloak-operator.8.0.2
   name: alpha
 defaultChannel: alpha
 packageName: keycloak-operator


### PR DESCRIPTION
Signed-off-by: Sebastian Laskawiec <slaskawi@redhat.com>

This Pull Request prevents Keycloak Operator 9.0.0 from installing. Unfortunately, we discovered a critical issue ([KEYCLOAK-13333](https://issues.redhat.com/browse/KEYCLOAK-13333)) and this Operator won't run successfully in OpenShift. 

The issue will be fixed in `9.0.1`, which will be released shortly.