### PR TITLE
Build catalog & simplify pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 - "3.6"
 
 env:
-- CHANGE_MINIKUBE_NONE_USER=true DISTRO_TYPE=upstream
+- CHANGE_MINIKUBE_NONE_USER=true DISTRO_TYPE=upstream KUBE_VER=v1.17.0
 
 before_install:
 # check-pr needs to be sourced so it can pass the test early.
@@ -18,24 +18,14 @@ before_install:
 install:
 - scripts/ci/install-deps $DISTRO_TYPE
 
-before_script:
-- eval $(scripts/ci/operators-env) && scripts/ci/verify-operator
-- sudo minikube start --memory=4096 --vm-driver=none  --kubernetes-version="v1.17.0" --extra-config=apiserver.v=4
-- sudo chown -R $USER ${HOME}/.{mini,}kube
-- kubectl config use-context minikube
-
 jobs:
   include:
-  - name: Scorecard on minikube
+  - stage: catalog build
+    name: Test loading the Operator into the Community Catalog
+    install: skip
     script:
-    # Since travis conditionals can't operate on bash scripts, the first script
-    # line will check whether only scripts have been updated, and if so use
-    # the ripsaw operator as an operator to test script correctness.
-    - |-
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -q '\.yaml'; then \
-        OPERATORS_UPSTREAM="upstream-community-operators/ripsaw:$(yq r --tojson upstream-community-operators/ripsaw/ripsaw.package.yaml "channels" \
-        | jq ".[] | .currentCSV" | sort -V | tail -1 | sed -E 's/"[a-zA-Z\-]+\.?v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?)"/\1/')" \
-        docker run -v ${HOME}/.kube/config:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators quay.io/operator-framework/operator-testing  operator.test --no-print-directory OP_PATH="/upstream-community-operators/ripsaw" CLEAN_MODE=NORMAL INSTALL_MODE='' VERBOSE=1
-      fi
-    - docker pull quay.io/operator-framework/operator-testing
-    - eval $(scripts/ci/operators-env) && echo "${OP_PATH}" && docker run -v ${HOME}/.kube/config:/root/.kube/config -v ${HOME}/.minikube:${HOME}/.minikube -v ${PWD}/community-operators:/community-operators -v ${PWD}/upstream-community-operators:/upstream-community-operators quay.io/operator-framework/operator-testing  operator.test --no-print-directory OP_PATH="${OP_PATH}" CLEAN_MODE=NORMAL INSTALL_MODE='' VERBOSE=1
+    - docker build --build-arg PERMISSIVE_LOAD=false -f upstream.Dockerfile -t operatorhub-catalog:dev . 
+  - stage: operator test
+    name: Test the Operator using operator-sdk running on minikube
+    script: scripts/ci/run-tests.sh
+

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OP_PATH=''
 CLEAN_MODE=NORMAL
 VM_DRIVER=none
 KUBECONFIG?="${HOME}/.kube/config"
-export KUBE_VER := v1.14.0
+export KUBE_VER := v1.17.0
 
 help:
 	@grep -E '^[a-zA-Z0-9/._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/scripts/ci/install-deps
+++ b/scripts/ci/install-deps
@@ -34,9 +34,6 @@ SDK_VER="v0.6.0"
 curl -Lo operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VER}/operator-sdk-${SDK_VER}-x86_64-linux-gnu"
 chmod +x operator-sdk
 $SUDO mv operator-sdk /usr/local/bin/
-# helm
-echo "Installing helm"
-curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
 # kubectl
 echo "Installing kubectl"
 KUBE_VER="v1.13.0"

--- a/scripts/ci/operators-env
+++ b/scripts/ci/operators-env
@@ -6,6 +6,9 @@ set -e
 # with changes in a PR and the latest CSV version for that operator in the form:
 # "xxxxx-operators/operator1:v0.0.1 xxxxx-operators/operator2:v0.0.1"
 
+unset OP_PATH
+unset OP_VER
+
 declare -A OP_TYPES
 OP_TYPES=(
   ["upstream"]="upstream-community-operators"
@@ -43,7 +46,7 @@ for op_distro in "${!OP_TYPES[@]}"; do
       fi
     done
   done
-  echo "export OP_PATH=/$OP_PATH"
+  echo "export OP_PATH=$OP_PATH"
   echo "export OP_VER=$OP_VER"
   echo "export $OP_TYPE_VAR=\"${!OP_TYPE_VAR}\";"
 done

--- a/scripts/ci/run-tests.sh
+++ b/scripts/ci/run-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ev
+
+eval $(scripts/ci/operators-env)
+      
+if [ -z "${OP_PATH}" ] ; 
+then 
+    echo "No operator modification detected. Exiting."
+    exit 0 
+else
+    echo "Detected modified Operator in ${OP_PATH}"
+    echo "Detected modified Operator version ${OP_VER}"
+fi
+      
+make operator.verify OP_PATH="${OP_PATH}" OP_VER="${OP_VER}"
+sudo make minikube.start VM_DRIVER=none 
+sudo chown -R $USER ${HOME}/.{mini,}kube
+kubectl config use-context minikube
+make operator.test OP_PATH="${OP_PATH}" OP_VER="${OP_VER}" CLEAN_MODE=NORMAL INSTALL_MODE='' VERBOSE=1

--- a/scripts/ci/run-tests.sh
+++ b/scripts/ci/run-tests.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -ev
 
 eval $(scripts/ci/operators-env)
       
@@ -12,8 +11,4 @@ else
     echo "Detected modified Operator version ${OP_VER}"
 fi
       
-make operator.verify OP_PATH="${OP_PATH}" OP_VER="${OP_VER}"
-sudo make minikube.start VM_DRIVER=none 
-sudo chown -R $USER ${HOME}/.{mini,}kube
-kubectl config use-context minikube
-make operator.test OP_PATH="${OP_PATH}" OP_VER="${OP_VER}" CLEAN_MODE=NORMAL INSTALL_MODE='' VERBOSE=1
+sudo make operator.test OP_PATH="${OP_PATH}" OP_VER="${OP_VER}" VM_DRIVER=none CLEAN_MODE=NORMAL INSTALL_MODE='' VERBOSE=1

--- a/scripts/ci/start-minikube
+++ b/scripts/ci/start-minikube
@@ -10,4 +10,4 @@ if [[ -n "${KUBE_VER}" ]]; then
     MINIKUBE_KUBE_VERSION="--kubernetes-version="${KUBE_VER}""
 fi
 
-minikube start --vm-driver=${VM_DRIVER} ${MINIKUBE_KUBE_VERSION} --extra-config=apiserver.v=4 -p operators
+minikube start --vm-driver=${VM_DRIVER} ${MINIKUBE_KUBE_VERSION} --extra-config=apiserver.v=4

--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/operator-framework/upstream-registry-builder:v1.5.6 as builder
+ARG PERMISSIVE_LOAD=true
 COPY upstream-community-operators manifests
-RUN ./bin/initializer --permissive true -o ./bundles.db
+RUN if [ $PERMISSIVE_LOAD = "true" ] ; then ./bin/initializer --permissive -o ./bundles.db ; else ./bin/initializer -o ./bundles.db ; fi 
 
 FROM scratch
 COPY --from=builder /build/bundles.db /bundles.db


### PR DESCRIPTION
This adds a test that tries to build a new catalog using `operator-registry`. This is a pre-requisite to merge. If the contribution is malformed it will be detected early on here and safe time in debugging the operator verification using Operator-SDKs `scorecard`.

It also cleans up the test suite execution itself by delegating it entirely to the makefile.