### PR TITLE
remove trailing whitespace from YAML

### DIFF
--- a/upstream-community-operators/prometheus/0.37.0/alertmanagers.monitoring.coreos.com.crd.yaml
+++ b/upstream-community-operators/prometheus/0.37.0/alertmanagers.monitoring.coreos.com.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/upstream-community-operators/prometheus/0.37.0/podmonitors.monitoring.coreos.com.crd.yaml
+++ b/upstream-community-operators/prometheus/0.37.0/podmonitors.monitoring.coreos.com.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/upstream-community-operators/prometheus/0.37.0/prometheuses.monitoring.coreos.com.crd.yaml
+++ b/upstream-community-operators/prometheus/0.37.0/prometheuses.monitoring.coreos.com.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/upstream-community-operators/prometheus/0.37.0/prometheusrules.monitoring.coreos.com.crd.yaml
+++ b/upstream-community-operators/prometheus/0.37.0/prometheusrules.monitoring.coreos.com.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/upstream-community-operators/prometheus/0.37.0/servicemonitors.monitoring.coreos.com.crd.yaml
+++ b/upstream-community-operators/prometheus/0.37.0/servicemonitors.monitoring.coreos.com.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/upstream-community-operators/prometheus/0.37.0/thanosrulers.monitoring.coreos.com.crd.yaml
+++ b/upstream-community-operators/prometheus/0.37.0/thanosrulers.monitoring.coreos.com.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Signed-off-by: dmesser <dmesser@redhat.com>

This removes the trailing whitespace and YAML multi-doc splitter that prevent the operator-registry catalog from loading correctly.