### PR TITLE
bump sdk version and use different proxy port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 - "3.6"
 
 env:
-- CHANGE_MINIKUBE_NONE_USER=true DISTRO_TYPE=upstream
+- CHANGE_MINIKUBE_NONE_USER=true DISTRO_TYPE=upstream KUBE_VER=v1.17.0 SDK_VER=0.16.0 OLM_VER=v0.14.1
 
 before_install:
 # check-pr needs to be sourced so it can pass the test early.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ OP_PATH=''
 CLEAN_MODE=NORMAL
 VM_DRIVER=none
 KUBECONFIG?="${HOME}/.kube/config"
-export KUBE_VER := v1.14.0
+export KUBE_VER := v1.17.0
+export OLM_VER := v0.14.1
+export SDK_VER := v0.16.0
 
 help:
 	@grep -E '^[a-zA-Z0-9/._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/scripts/ci/install-deps
+++ b/scripts/ci/install-deps
@@ -30,7 +30,6 @@ echo "Installing operator-courier"
 python3 -m pip install operator-courier
 # SDK
 echo "Installing operator-sdk"
-SDK_VER="v0.6.0"
 curl -Lo operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VER}/operator-sdk-${SDK_VER}-x86_64-linux-gnu"
 chmod +x operator-sdk
 $SUDO mv operator-sdk /usr/local/bin/
@@ -39,7 +38,6 @@ echo "Installing helm"
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
 # kubectl
 echo "Installing kubectl"
-KUBE_VER="v1.13.0"
 curl -Lo kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBE_VER}/bin/linux/amd64/kubectl"
 chmod +x kubectl
 $SUDO mv kubectl /usr/local/bin/

--- a/scripts/ci/install-olm
+++ b/scripts/ci/install-olm
@@ -2,7 +2,7 @@
 
 
 if [[ "$(kubectl api-resources | grep -o operatorgroup)" != "operatorgroup" ]]; then
-  operator-sdk alpha olm install > /dev/null 2>&1
+  operator-sdk olm install --version ${OLM_VER} > /dev/null 2>&1
 
   # Delete "operatorhubio-catalog"
   # kubectl delete catalogsource operatorhubio-catalog -n olm > /dev/null

--- a/scripts/ci/scorecard
+++ b/scripts/ci/scorecard
@@ -24,11 +24,11 @@ fi
 for config_file in $(find "/tmp/scorecard-bundles" -name "*.bundle.yaml" -print); do
   >&2 echo -e "\n\nRunning operator-sdk scorecard against "$CSV_FILE" with "$config_file""
 
-  if ! $(>&2 operator-sdk scorecard -o text --config "$config_file" --kubeconfig "$KUBECONFIG" --verbose --selector="test in (checkspectest,writingintocrshaseffecttest)"); then
+  if ! $(>&2 operator-sdk scorecard --proxy-port 8890 -o text --config "$config_file" --kubeconfig "$KUBECONFIG" --verbose --selector="test in (checkspectest,writingintocrshaseffecttest)"); then
     echo "FATAL ERROR"
     exit 1
   fi
-  if ! $(>&2 operator-sdk scorecard -o text --config "$config_file" --kubeconfig "$KUBECONFIG" --verbose --selector="test in (checkstatustest)"); then
+  if ! $(>&2 operator-sdk scorecard --proxy-port 8890 -o text --config "$config_file" --kubeconfig "$KUBECONFIG" --verbose --selector="test in (checkstatustest)"); then
     echo "WARNING"
   fi 
   # If scorecard errors out, print out operator logs

--- a/scripts/utils/Makefile
+++ b/scripts/utils/Makefile
@@ -1,6 +1,7 @@
 .PHONY: help
-SDK_VER="v0.14.0"
+SDK_VER="v0.16.0"
 KUBE_VER="v1.14.0"
+OLM_VER="v1.14.1"
 MAKEFLAGS+ = --no-print-directory
 OP_PATH=''
 OP_CHANNEL=''


### PR DESCRIPTION
Signed-off-by: dmesser <dmesser@redhat.com>

This bumps the SDK version used to conduct tests to `0.16.0` which allows to set the scorecard proxy port to a user defined port. This unblocks operators that use port 8080 which then conflicts with the scorecard proxy.