### PR TITLE
remove incorrect flags

### DIFF
--- a/scripts/ci/scorecard
+++ b/scripts/ci/scorecard
@@ -24,11 +24,11 @@ fi
 for config_file in $(find "/tmp/scorecard-bundles" -name "*.bundle.yaml" -print); do
   >&2 echo -e "\n\nRunning operator-sdk scorecard against "$CSV_FILE" with "$config_file""
 
-  if ! $(>&2 operator-sdk scorecard --proxy-port 8890 -o text --config "$config_file" --kubeconfig "$KUBECONFIG" --verbose --selector="test in (checkspectest,writingintocrshaseffecttest)"); then
+  if ! $(>&2 operator-sdk scorecard -o text --config "$config_file" --kubeconfig "$KUBECONFIG" --verbose --selector="test in (checkspectest,writingintocrshaseffecttest)"); then
     echo "FATAL ERROR"
     exit 1
   fi
-  if ! $(>&2 operator-sdk scorecard --proxy-port 8890 -o text --config "$config_file" --kubeconfig "$KUBECONFIG" --verbose --selector="test in (checkstatustest)"); then
+  if ! $(>&2 operator-sdk scorecard -o text --config "$config_file" --kubeconfig "$KUBECONFIG" --verbose --selector="test in (checkstatustest)"); then
     echo "WARNING"
   fi 
   # If scorecard errors out, print out operator logs


### PR DESCRIPTION
This removes incorrect usage of flags to set the scorecard proxy, should be done via config file

Signed-off-by: dmesser <dmesser@redhat.com>