### PR TITLE
Cluster selection logic fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,11 @@ help:
 check_path:
 	@if [ ! -d ${OP_PATH} ]; then echo "Operator path not found you need set it with OP_PATH=upstream-community-operators/your-operator"; exit 1; fi
 
-check_kind :
-	@if [ ${NO_KIND} == true ] && [ -z ${CATALOG_IMAGE+x} ] ; then echo "You specified NO_KIND but did not specify CATALOG_IMAGE"; exit 1; fi
+check_no_kind :
+	@if [ ${NO_KIND} != "0" ] && [ -z "${CATALOG_IMAGE}" ] ; then echo "You specified NO_KIND but did not specify CATALOG_IMAGE"; exit 1; elif [ ${NO_KIND} == "0" ] && [ ! -z "${CATALOG_IMAGE}" ] ; then echo "You specified CATALOG_IMAGE but it will be ignore until you set NO_KIND to 1" ; fi
+
+check_kind_install :
+	@if [ ${NO_KIND} == "0" ] && [ $(command -v kind) == "" ] ; then echo "KIND (https://kind.sigs.k8s.io) is not installed and NO_KIND is not set." ; exit 1 ; fi
 
 minikube.install: ## Install the local minikube
 	@./scripts/ci/install-minikube
@@ -37,16 +40,16 @@ olm.install: ## Install OLM to your cluster
 	@python3 scripts/utils/check-kube-config.py
 	@docker run --network=host -v ${KUBECONFIG}:/root/.kube/config:z -v ${PWD}/community-operators:/community-operators:z -v ${PWD}/upstream-community-operators:/upstream-community-operators:z -it ${OPERATOR_TESTING_IMAGE} olm.install --no-print-directory VERBOSE=${VERBOSE}
 
-operator.install: check_path check_kind 
+operator.install: check_path check_no_kind 
 	@scripts/ci/run-script "docker pull ${OPERATOR_TESTING_IMAGE}" "Pulling docker image"
 	@python3 scripts/utils/check-kube-config.py
 	@scripts/ci/run-script "scripts/ci/build-catalog-image" "Building catalog image"
 	@docker run --network=host -v ${KUBECONFIG}:/root/.kube/config:z -v ${PWD}/community-operators:/community-operators:z -v ${PWD}/upstream-community-operators:/upstream-community-operators:z -ti ${OPERATOR_TESTING_IMAGE} operator.install --no-print-directory OP_PATH=${OP_PATH} VERBOSE=${VERBOSE} OP_VER=${OP_VER} OP_CHANNEL=${OP_CHANNEL} INSTALL_MODE=${INSTALL_MODE} CLEAN_MODE=${CLEAN_MODE} CATALOG_IMAGE=${CATALOG_IMAGE} NO_KIND=${NO_KIND}
 
-operator.cleanup: check_path check_kind 
+operator.cleanup: check_path check_no_kind 
 	@scripts/ci/run-script "scripts/ci/cleanup" "Cleaning"
 
-operator.test: check_path check_kind ## Operator test which run courier and scorecard
+operator.test: check_path check_no_kind ## Operator test which run courier and scorecard
 	@scripts/ci/run-script "docker pull ${OPERATOR_TESTING_IMAGE}" "Pulling docker image"
 	@python3 scripts/utils/check-kube-config.py
 	@scripts/ci/run-script "scripts/ci/build-catalog-image" "Building catalog image"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --no-print-directory
 export OP_PATH=''
 export CLEAN_MODE=NORMAL
-export KUBECONFIG := ${HOME}/.kube/config
+export KUBECONFIG ?= ${KUBECONFIG:-${HOME}/.kube/config}
 export KUBE_VER ?= v1.17.0
 export OLM_VER ?= 0.14.1
 export SDK_VER ?= v0.16.0


### PR DESCRIPTION
This correctly treats NO_KIND as the intent to skip automatic creation of a KIND cluster named "operator-test". We will only prompt for a list of cluster context with NO_KIND is specified.