### PR TITLE
Disable scorecard test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,4 @@ jobs:
   - stage: operator deployment test
     name: Test Operator deployment using OLM running on KIND
     script: scripts/ci/run-deployment-tests.sh
-  - stage: operator scorecard test
-    name: Test the Operator using Operator-SDK scorecard running on KIND
-    script: scripts/ci/run-scorecard-tests.sh
 


### PR DESCRIPTION
In its current form, the scorecard test configuration is often a barrier to passing the validation pipeline. Though that is usually not because the Operator is lacking but because scorecard makes some assumptions that do not apply to every Operator.
We need to make scorecard more permissive and configurable for these use cases. Until this is achieved, scorecard will be disabled for the community pipeline.