### PR TITLE
Update README.md TOC links with doctoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@
 
 - [About this repository](#about-this-repository)
 - [Add your Operator](#add-your-operator)
+- [Test your Operator before submitting a PR](#test-your-operator-before-submitting-a-pr)
+- [Preview your Operator on OperatorHub.io](#preview-your-operator-on-operatorhubio)
 - [Submitting your PR](#submitting-your-pr)
 - [Update your Operator](#update-your-operator)
-- [Test your Operator](#test-your-operator)
-- [Preview your Operator on OperatorHub.io](#preview-your-operator-on-operatorhubio)
+- [CI Tests your Operator](#ci-tests-your-operator)
 - [Reporting Bugs](#reporting-bugs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
This short PR simply updates the table of contents for the main README.md. As the comments in the file indicated, I ran the [doctoc](https://github.com/thlorenz/doctoc) tool to perform this update, so none of the changes were manual.

I have tested by viewing the file in my fork and manually clicking/testing all the links: https://github.com/jbw976/community-operators/blob/readme-toc-links/README.md
