### PR TITLE
Update Kong operator to v0.2.2

### DIFF
--- a/upstream-community-operators/kong/0.2.0/kong.v0.2.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/kong/0.2.0/kong.v0.2.0.clusterserviceversion.yaml
@@ -1,0 +1,161 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"image":{"repository":"kong","tag":"2.0.0","pullPolicy":"Always"},"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}]'
+    capabilities: Basic Install
+    categories: Networking
+    certified: 'false'
+    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.0
+    createdAt: '2020-04-10T17:26:45Z'
+    description: Install and manage Kong clusters.
+    repository: https://github.com/kong/kong-operator
+    support: Harry Bagdi
+  name: kong.v0.2.0
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: A configuration file for a Kong cluster.
+      displayName: Kong
+      kind: Kong
+      name: kongs.charts.helm.k8s.io
+      version: v1alpha1
+  description: Install and manage Kong clusters.
+  displayName: Kong Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAI4AAACACAMAAADqKaFKAAAAnFBMVEUAAAAANFoAUnIANl0ANFkANFkAOWEANFkANFkAOl8ANFoANFoAOF0AQGMANFoANVoANFkANVoANFkANFkANVoANlwANFkANVoANVoANVoANFoANloAN1sANlsAQ2oANFoANFoANVoAOF0ANFkANVoANVoANFoANVoANlsAQGIANVkANVkANVkANVoANVkANVoANlsANVoANFoANFnuMUUSAAAAM3RSTlMA0AUt+lIYkbMT9u8hDOJ23KOM5loz84Bk68A5J0kJ17qHHMStbJVOQg/MPp57qXBUmslOI9JhAAAEs0lEQVR42szZ226qUBSF4eESFVQqFs/nc7Vat+14/3fbCSVGUVirCWvid+vNTID8mVPYok41hZdR/SHXVbyIcUiS4REvYeAw4mxRPFXjVXuGgnkL3ig1UahywDuNKQpU6TGpj8L0+YR7QCF8l08FZRSgOWeKegfipg2mE09Gy2E66WSoNjXCMeT8o4ZoMg5DaogmY0kN0WSs6tQQTcaJGqLJKFNDNhkuNUSTsaeGbDI+qSGajA7/bAd7xpVbfeqdIOedOm1IcpnNVZDkl5gp8CFqFb7SwwK6moR1YE2/drXb7eJCXjQhbcKSCu/Uu4h8MdNawQoV8F5YRaRdSNdbTPqc/c45YhZnDAu8Bh9s4p8CZmnBgm8+sURk0pAep+xkfcd7R3icRfaLMZAdZ8oUw2ZcU8lx1JxpSj4iruA4W6ZzrzWVGscbMsN7dk3re+SsxkyDrJq+dZGzicNMzvEatQejKmJyu9WwmVbTb4WY5G41PyByErirlKi3UE9qOjwif4O/rFNeYPmk4oc0sk3WdOPDgiXNONP7mn7BhmadhhqTm4fb+4AVNRoLvLimFg8pq5DGRgoRd+Ehydoipb8PzBTs6dBcC/aoGSJ9mvuALYfFBr/ONNaz9g6Xrhvb7IfG3qqwoRveLArVNyYIL8HTXryHaz4vmRvKwEns4RWasJSH5cMejhbNXZAndeaNM0zuFMlTS3689dODiFrTWLiy+B/wRXunSDm15GD8v3YzW0oYCKJoJwyLYqIgpFgECQoquJT0//+bD1CWVePkzk0n55WXLDOd26eHefDZdwqN5rkh4XZdUdpWGk/Z4tT1tA783KoyTfegtHnOqU0Hlw1AafM0IOoFLfQOWkGX315JZmnEc62imHoaEDIwdL5DmBw8DQgZ02VmfGbvopPDTOOZkevlXuMZ8b2OOwpBYKOAYJ5umO3FDg/5YP7mi0ugWgBg9oOC+c1cPYBqwTwUypJf2suja3xynRGP3LS94hTYp9bh3c+vWLXQH2++7x2oEqoFsXRak5Vv2bFqYeofv7141cLWP/5el4xqoesfc6/Nqpau2viW5lQLziyYL4NqgfWP507OrA921TJSMysRXrWcUm5yxzsTu2pZOrUyP+90u2rBT5fv6D4Y1ULUP7pBsKuWUs0UW/nFqFpe1M7OtAAOa1D/SJ7Eo6ZqWSdqxnnZhX3qJV5zhjPItVXLTu0koeDyTqsWR9xAJ0Aw1vGqpdVT4bxq0Vg2wsOrFqK34+FVS+tSb0epFi7p9ZMQi6sGxspDoarmjFtbtGpZSFzsPAuQqSMdNqtaSiESwFVOj4hI1dIVQuY912gLONWyFSLNTvA7tZ2vyUUU8pjJhU19ZzyO3DCKKB4CB1O4D8kgrkemIvltnS43XrUcRSiJlyaERKK3l8vg5RxS+cuUWGl0L5eICHlkv2+YME4iFAi5FLLcMMAvcXljhysvcerABxfSjogAXwxUL/GnDKhaChBO571/feYwKmbyMnQBLue1dsH/DIdDkAj4CpsqphcUkGCwysepG8u8cw9ugY/qK4sQDSexXCouxx0NWTxPJcAWlU9eQPcNDeIEKW/48vmo4LYSYlT5ORf5AWrXrLl1P4wQAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - roles
+          - clusterrolebindings
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - charts.helm.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: kong-operator
+      deployments:
+      - name: kong-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kong-operator
+          template:
+            metadata:
+              labels:
+                name: kong-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: kong-operator
+                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.0
+                imagePullPolicy: Always
+                name: kong-operator
+              serviceAccountName: kong-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - kong
+  - ingress
+  - proxy
+  - microservices
+  links:
+  - name: Kong
+    url: https://konghq.com/kong
+  - name: Helm Chart Source
+    url: https://github.com/kong/charts/tree/master/charts/kong
+  - name: Configuration Options
+    url: https://github.com/kong/charts/tree/master/charts/kong#configuration
+  - name: Kong Operator
+    url: https://github.com/kong/kong-operator
+  maintainers:
+  - email: harry@konghq.com
+    name: Harry
+  maturity: alpha
+  provider:
+    name: Kong Inc
+  version: 0.2.0
+  replaces: 0.1.0

--- a/upstream-community-operators/kong/0.2.0/kongs.charts.helm.k8s.io.crd.yaml
+++ b/upstream-community-operators/kong/0.2.0/kongs.charts.helm.k8s.io.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongs.charts.helm.k8s.io
+spec:
+  group: charts.helm.k8s.io
+  names:
+    kind: Kong
+    listKind: KongList
+    plural: kongs
+    singular: kong
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/upstream-community-operators/kong/0.2.1/kong.v0.2.1.clusterserviceversion.yaml
+++ b/upstream-community-operators/kong/0.2.1/kong.v0.2.1.clusterserviceversion.yaml
@@ -1,0 +1,161 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"image":{"repository":"kong","tag":"2.0.0","pullPolicy":"Always"},"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}]'
+    capabilities: Basic Install
+    categories: Networking
+    certified: 'false'
+    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.1
+    createdAt: '2020-04-10T17:26:45Z'
+    description: Install and manage Kong clusters.
+    repository: https://github.com/kong/kong-operator
+    support: Harry Bagdi
+  name: kong.v0.2.1
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: A configuration file for a Kong cluster.
+      displayName: Kong
+      kind: Kong
+      name: kongs.charts.helm.k8s.io
+      version: v1alpha1
+  description: Install and manage Kong clusters.
+  displayName: Kong Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAI4AAACACAMAAADqKaFKAAAAnFBMVEUAAAAANFoAUnIANl0ANFkANFkAOWEANFkANFkAOl8ANFoANFoAOF0AQGMANFoANVoANFkANVoANFkANFkANVoANlwANFkANVoANVoANVoANFoANloAN1sANlsAQ2oANFoANFoANVoAOF0ANFkANVoANVoANFoANVoANlsAQGIANVkANVkANVkANVoANVkANVoANlsANVoANFoANFnuMUUSAAAAM3RSTlMA0AUt+lIYkbMT9u8hDOJ23KOM5loz84Bk68A5J0kJ17qHHMStbJVOQg/MPp57qXBUmslOI9JhAAAEs0lEQVR42szZ226qUBSF4eESFVQqFs/nc7Vat+14/3fbCSVGUVirCWvid+vNTID8mVPYok41hZdR/SHXVbyIcUiS4REvYeAw4mxRPFXjVXuGgnkL3ig1UahywDuNKQpU6TGpj8L0+YR7QCF8l08FZRSgOWeKegfipg2mE09Gy2E66WSoNjXCMeT8o4ZoMg5DaogmY0kN0WSs6tQQTcaJGqLJKFNDNhkuNUSTsaeGbDI+qSGajA7/bAd7xpVbfeqdIOedOm1IcpnNVZDkl5gp8CFqFb7SwwK6moR1YE2/drXb7eJCXjQhbcKSCu/Uu4h8MdNawQoV8F5YRaRdSNdbTPqc/c45YhZnDAu8Bh9s4p8CZmnBgm8+sURk0pAep+xkfcd7R3icRfaLMZAdZ8oUw2ZcU8lx1JxpSj4iruA4W6ZzrzWVGscbMsN7dk3re+SsxkyDrJq+dZGzicNMzvEatQejKmJyu9WwmVbTb4WY5G41PyByErirlKi3UE9qOjwif4O/rFNeYPmk4oc0sk3WdOPDgiXNONP7mn7BhmadhhqTm4fb+4AVNRoLvLimFg8pq5DGRgoRd+Ehydoipb8PzBTs6dBcC/aoGSJ9mvuALYfFBr/ONNaz9g6Xrhvb7IfG3qqwoRveLArVNyYIL8HTXryHaz4vmRvKwEns4RWasJSH5cMejhbNXZAndeaNM0zuFMlTS3689dODiFrTWLiy+B/wRXunSDm15GD8v3YzW0oYCKJoJwyLYqIgpFgECQoquJT0//+bD1CWVePkzk0n55WXLDOd26eHefDZdwqN5rkh4XZdUdpWGk/Z4tT1tA783KoyTfegtHnOqU0Hlw1AafM0IOoFLfQOWkGX315JZmnEc62imHoaEDIwdL5DmBw8DQgZ02VmfGbvopPDTOOZkevlXuMZ8b2OOwpBYKOAYJ5umO3FDg/5YP7mi0ugWgBg9oOC+c1cPYBqwTwUypJf2suja3xynRGP3LS94hTYp9bh3c+vWLXQH2++7x2oEqoFsXRak5Vv2bFqYeofv7141cLWP/5el4xqoesfc6/Nqpau2viW5lQLziyYL4NqgfWP507OrA921TJSMysRXrWcUm5yxzsTu2pZOrUyP+90u2rBT5fv6D4Y1ULUP7pBsKuWUs0UW/nFqFpe1M7OtAAOa1D/SJ7Eo6ZqWSdqxnnZhX3qJV5zhjPItVXLTu0koeDyTqsWR9xAJ0Aw1vGqpdVT4bxq0Vg2wsOrFqK34+FVS+tSb0epFi7p9ZMQi6sGxspDoarmjFtbtGpZSFzsPAuQqSMdNqtaSiESwFVOj4hI1dIVQuY912gLONWyFSLNTvA7tZ2vyUUU8pjJhU19ZzyO3DCKKB4CB1O4D8kgrkemIvltnS43XrUcRSiJlyaERKK3l8vg5RxS+cuUWGl0L5eICHlkv2+YME4iFAi5FLLcMMAvcXljhysvcerABxfSjogAXwxUL/GnDKhaChBO571/feYwKmbyMnQBLue1dsH/DIdDkAj4CpsqphcUkGCwysepG8u8cw9ugY/qK4sQDSexXCouxx0NWTxPJcAWlU9eQPcNDeIEKW/48vmo4LYSYlT5ORf5AWrXrLl1P4wQAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - roles
+          - clusterrolebindings
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - charts.helm.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: kong-operator
+      deployments:
+      - name: kong-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kong-operator
+          template:
+            metadata:
+              labels:
+                name: kong-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: kong-operator
+                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.1
+                imagePullPolicy: Always
+                name: kong-operator
+              serviceAccountName: kong-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - kong
+  - ingress
+  - proxy
+  - microservices
+  links:
+  - name: Kong
+    url: https://konghq.com/kong
+  - name: Helm Chart Source
+    url: https://github.com/kong/charts/tree/master/charts/kong
+  - name: Configuration Options
+    url: https://github.com/kong/charts/tree/master/charts/kong#configuration
+  - name: Kong Operator
+    url: https://github.com/kong/kong-operator
+  maintainers:
+  - email: harry@konghq.com
+    name: Harry
+  maturity: alpha
+  provider:
+    name: Kong Inc
+  version: 0.2.1
+  replaces: 0.2.0

--- a/upstream-community-operators/kong/0.2.1/kongs.charts.helm.k8s.io.crd.yaml
+++ b/upstream-community-operators/kong/0.2.1/kongs.charts.helm.k8s.io.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongs.charts.helm.k8s.io
+spec:
+  group: charts.helm.k8s.io
+  names:
+    kind: Kong
+    listKind: KongList
+    plural: kongs
+    singular: kong
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/upstream-community-operators/kong/0.2.2/kong.v0.2.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/kong/0.2.2/kong.v0.2.2.clusterserviceversion.yaml
@@ -1,0 +1,161 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"image":{"repository":"kong","tag":"2.0.0","pullPolicy":"Always"},"proxy":{"type":"NodePort"},"env":{"prefix":"/kong_prefix/"},"resources":{"limits":{"cpu":"500m","memory":"2G"},"requests":{"cpu":"100m","memory":"512Mi"}},"ingressController":{"enabled":true,"installCRDs":false}}]'
+    capabilities: Basic Install
+    categories: Networking
+    certified: 'false'
+    containerImage: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.2
+    createdAt: '2020-04-10T17:26:45Z'
+    description: Install and manage Kong clusters.
+    repository: https://github.com/kong/kong-operator
+    support: Harry Bagdi
+  name: kong.v0.2.2
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: A configuration file for a Kong cluster.
+      displayName: Kong
+      kind: Kong
+      name: kongs.charts.helm.k8s.io
+      version: v1alpha1
+  description: Install and manage Kong clusters.
+  displayName: Kong Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAI4AAACACAMAAADqKaFKAAAAnFBMVEUAAAAANFoAUnIANl0ANFkANFkAOWEANFkANFkAOl8ANFoANFoAOF0AQGMANFoANVoANFkANVoANFkANFkANVoANlwANFkANVoANVoANVoANFoANloAN1sANlsAQ2oANFoANFoANVoAOF0ANFkANVoANVoANFoANVoANlsAQGIANVkANVkANVkANVoANVkANVoANlsANVoANFoANFnuMUUSAAAAM3RSTlMA0AUt+lIYkbMT9u8hDOJ23KOM5loz84Bk68A5J0kJ17qHHMStbJVOQg/MPp57qXBUmslOI9JhAAAEs0lEQVR42szZ226qUBSF4eESFVQqFs/nc7Vat+14/3fbCSVGUVirCWvid+vNTID8mVPYok41hZdR/SHXVbyIcUiS4REvYeAw4mxRPFXjVXuGgnkL3ig1UahywDuNKQpU6TGpj8L0+YR7QCF8l08FZRSgOWeKegfipg2mE09Gy2E66WSoNjXCMeT8o4ZoMg5DaogmY0kN0WSs6tQQTcaJGqLJKFNDNhkuNUSTsaeGbDI+qSGajA7/bAd7xpVbfeqdIOedOm1IcpnNVZDkl5gp8CFqFb7SwwK6moR1YE2/drXb7eJCXjQhbcKSCu/Uu4h8MdNawQoV8F5YRaRdSNdbTPqc/c45YhZnDAu8Bh9s4p8CZmnBgm8+sURk0pAep+xkfcd7R3icRfaLMZAdZ8oUw2ZcU8lx1JxpSj4iruA4W6ZzrzWVGscbMsN7dk3re+SsxkyDrJq+dZGzicNMzvEatQejKmJyu9WwmVbTb4WY5G41PyByErirlKi3UE9qOjwif4O/rFNeYPmk4oc0sk3WdOPDgiXNONP7mn7BhmadhhqTm4fb+4AVNRoLvLimFg8pq5DGRgoRd+Ehydoipb8PzBTs6dBcC/aoGSJ9mvuALYfFBr/ONNaz9g6Xrhvb7IfG3qqwoRveLArVNyYIL8HTXryHaz4vmRvKwEns4RWasJSH5cMejhbNXZAndeaNM0zuFMlTS3689dODiFrTWLiy+B/wRXunSDm15GD8v3YzW0oYCKJoJwyLYqIgpFgECQoquJT0//+bD1CWVePkzk0n55WXLDOd26eHefDZdwqN5rkh4XZdUdpWGk/Z4tT1tA783KoyTfegtHnOqU0Hlw1AafM0IOoFLfQOWkGX315JZmnEc62imHoaEDIwdL5DmBw8DQgZ02VmfGbvopPDTOOZkevlXuMZ8b2OOwpBYKOAYJ5umO3FDg/5YP7mi0ugWgBg9oOC+c1cPYBqwTwUypJf2suja3xynRGP3LS94hTYp9bh3c+vWLXQH2++7x2oEqoFsXRak5Vv2bFqYeofv7141cLWP/5el4xqoesfc6/Nqpau2viW5lQLziyYL4NqgfWP507OrA921TJSMysRXrWcUm5yxzsTu2pZOrUyP+90u2rBT5fv6D4Y1ULUP7pBsKuWUs0UW/nFqFpe1M7OtAAOa1D/SJ7Eo6ZqWSdqxnnZhX3qJV5zhjPItVXLTu0koeDyTqsWR9xAJ0Aw1vGqpdVT4bxq0Vg2wsOrFqK34+FVS+tSb0epFi7p9ZMQi6sGxspDoarmjFtbtGpZSFzsPAuQqSMdNqtaSiESwFVOj4hI1dIVQuY912gLONWyFSLNTvA7tZ2vyUUU8pjJhU19ZzyO3DCKKB4CB1O4D8kgrkemIvltnS43XrUcRSiJlyaERKK3l8vg5RxS+cuUWGl0L5eICHlkv2+YME4iFAi5FLLcMMAvcXljhysvcerABxfSjogAXwxUL/GnDKhaChBO571/feYwKmbyMnQBLue1dsH/DIdDkAj4CpsqphcUkGCwysepG8u8cw9ugY/qK4sQDSexXCouxx0NWTxPJcAWlU9eQPcNDeIEKW/48vmo4LYSYlT5ORf5AWrXrLl1P4wQAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - roles
+          - clusterrolebindings
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - charts.helm.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: kong-operator
+      deployments:
+      - name: kong-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kong-operator
+          template:
+            metadata:
+              labels:
+                name: kong-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: kong-operator
+                image: kong-docker-kong-operator.bintray.io/kong-operator:v0.2.2
+                imagePullPolicy: Always
+                name: kong-operator
+              serviceAccountName: kong-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - kong
+  - ingress
+  - proxy
+  - microservices
+  links:
+  - name: Kong
+    url: https://konghq.com/kong
+  - name: Helm Chart Source
+    url: https://github.com/kong/charts/tree/master/charts/kong
+  - name: Configuration Options
+    url: https://github.com/kong/charts/tree/master/charts/kong#configuration
+  - name: Kong Operator
+    url: https://github.com/kong/kong-operator
+  maintainers:
+  - email: harry@konghq.com
+    name: Harry
+  maturity: alpha
+  provider:
+    name: Kong Inc
+  version: 0.2.2
+  replaces: 0.2.1

--- a/upstream-community-operators/kong/0.2.2/kongs.charts.helm.k8s.io.crd.yaml
+++ b/upstream-community-operators/kong/0.2.2/kongs.charts.helm.k8s.io.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongs.charts.helm.k8s.io
+spec:
+  group: charts.helm.k8s.io
+  names:
+    kind: Kong
+    listKind: KongList
+    plural: kongs
+    singular: kong
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/upstream-community-operators/kong/kong.package.yaml
+++ b/upstream-community-operators/kong/kong.package.yaml
@@ -1,4 +1,4 @@
 channels:
-- currentCSV: kong.v0.1.0
+- currentCSV: kong.v0.2.2
   name: alpha
 packageName: kong


### PR DESCRIPTION
### Updates to existing Operators

OLM has not been tested. Fresh installations have, and we test upgrades of the chart within the operator independently. Please let us know if you'd need us to conduct an OLM test to proceed.

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [ ] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo
