### PR TITLE
Extend timeout for check_subscription_passes

### DIFF
--- a/scripts/lib/cluster
+++ b/scripts/lib/cluster
@@ -22,7 +22,7 @@ function check_subscription_passes() {
   local sub="$1"
   local namespace="$2"
   local packageName="$3"
-  local retries=30 # 1 minute timeout
+  local retries=90 # 3 minute timeout
 
   echo "Checking subscription \"$sub\" reaches \"AtLatestKnown\" state"
   while ! kubectl get "subscription/${sub}" --namespace=${namespace} -o json | jq .status -e &> /dev/null; do


### PR DESCRIPTION
I find the one minute timeout is too short in my test environments with check_subscription_passes failing spuriously.  This PR simply bumps the timeout up. 