### PR TITLE
Submariner: fix CRD validation

### DIFF
--- a/community-operators/submariner/0.0.1/submariners.submariner.io.crd.yaml
+++ b/community-operators/submariner/0.0.1/submariners.submariner.io.crd.yaml
@@ -10,97 +10,88 @@ spec:
     plural: submariners
     singular: submariner
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Submariner is the Schema for the submariners API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SubmarinerSpec defines the desired state of Submariner
+          properties:
+            broker:
+              type: string
+            brokerK8sApiServer:
+              type: string
+            brokerK8sApiServerToken:
+              type: string
+            brokerK8sCA:
+              type: string
+            brokerK8sRemoteNamespace:
+              type: string
+            ceIPSecDebug:
+              type: boolean
+            ceIPSecIKEPort:
+              type: integer
+            ceIPSecNATTPort:
+              type: integer
+            ceIPSecPSK:
+              type: string
+            clusterCIDR:
+              type: string
+            clusterID:
+              type: string
+            colorCodes:
+              type: string
+            count:
+              format: int32
+              type: integer
+            debug:
+              type: boolean
+            namespace:
+              type: string
+            natEnabled:
+              type: boolean
+            repository:
+              type: string
+            serviceCIDR:
+              type: string
+            version:
+              type: string
+          required:
+          - broker
+          - brokerK8sApiServer
+          - brokerK8sApiServerToken
+          - brokerK8sCA
+          - brokerK8sRemoteNamespace
+          - ceIPSecDebug
+          - ceIPSecPSK
+          - clusterCIDR
+          - clusterID
+          - count
+          - debug
+          - namespace
+          - natEnabled
+          - serviceCIDR
+          type: object
+        status:
+          description: SubmarinerStatus defines the observed state of Submariner
+          type: object
+      type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Submariner is the Schema for the submariners API
-          properties:
-            apiVersion:
-              description: >-
-                APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
-              type: string
-            kind:
-              description: >-
-                Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SubmarinerSpec defines the desired state of Submariner
-              properties:
-                broker:
-                  type: string
-                brokerK8sApiServer:
-                  type: string
-                brokerK8sApiServerToken:
-                  type: string
-                brokerK8sCA:
-                  type: string
-                brokerK8sRemoteNamespace:
-                  type: string
-                ceIPSecDebug:
-                  type: boolean
-                ceIPSecIKEPort:
-                  type: integer
-                ceIPSecNATTPort:
-                  type: integer
-                ceIPSecPSK:
-                  type: string
-                clusterCIDR:
-                  type: string
-                clusterID:
-                  type: string
-                colorCodes:
-                  type: string
-                count:
-                  format: int32
-                  type: integer
-                debug:
-                  type: boolean
-                namespace:
-                  type: string
-                natEnabled:
-                  type: boolean
-                repository:
-                  type: string
-                serviceCIDR:
-                  type: string
-                token:
-                  type: string
-                version:
-                  type: string
-              required:
-                - broker
-                - brokerK8sApiServer
-                - brokerK8sApiServerToken
-                - brokerK8sCA
-                - brokerK8sRemoteNamespace
-                - ceIPSecDebug
-                - ceIPSecPSK
-                - clusterCIDR
-                - clusterID
-                - count
-                - debug
-                - namespace
-                - natEnabled
-                - serviceCIDR
-                - token
-              type: object
-            status:
-              description: SubmarinerStatus defines the observed state of Submariner
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
The current Submariner CRD defines validation criteria inside the
per-version stanza, which is no longer allowed when all the criteria
are identical for all published versions (which is the case here,
since there's only one version).

We'd fixed this for Kubernetes 1.15 compatibility, but hadn't updated
the resources here; this patch updates the CRD as appropriate.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

### Updates to existing Operators

* [ ] Is your new CSV pointing to the previous version with the `replaces` property?

N/A, this updates an existing CSV to make it pass validation.

* [ ] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?

N/A, this updates an existing CSV to make it pass validation.

* [X] Have you tested an update to your Operator when deployed via OLM?
* [X] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?

### Your submission should not

* [X] Modify more than one operator
* [X] Modify an Operator you don't own
* [X] Rename an operator - please remove and add with a different name instead
* [X] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [X] Modify any files outside the above mentioned folders
* [X] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [X] Description about the managed Application and where to find more information
2. [X] Features and capabilities of your Operator and how to use it
3. [X] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [X] Human readable name and 1-liner description about your Operator
* [X] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
* [X] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [X] Links to the maintainer, source code and documentation
* [X] Example templates for all Custom Resource Definitions intended to be used
* [X] A quadratic logo

Remember that you can preview your CSV [here](https://operatorhub.io/preview).

--

<sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file an issue against this repo and explain your need

<sup>2</sup> For more information see [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.svg)
