### PR TITLE
Added fix for triggering OHIO prod deploy only on push to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,4 @@ jobs:
   - stage: operatorhubio prod deploy
     name: Trigger PROD deploy of operatorhub.io
     script: scripts/ci/trigger-operatorhubio-ci.sh
+    if: type = push


### PR DESCRIPTION
Fixed trigger for OHIO prod deploy, no trigger for PR builds, only push to master.