### PR TITLE
add 2.1.11 back to stable

### DIFF
--- a/community-operators/cockroachdb/cockroachdb.package.yaml
+++ b/community-operators/cockroachdb/cockroachdb.package.yaml
@@ -1,4 +1,9 @@
 channels:
 - currentCSV: cockroachdb.v3.0.7
+  name: stable-3.x
+- currentCSV: cockroachdb.v2.1.11
+  name: stable-2.x
+- currentCSV: cockroachdb.v2.1.11
   name: stable
+defaultChannel: stable-3.x
 packageName: cockroachdb


### PR DESCRIPTION
Signed-off-by: dmesser <dmesser@redhat.com>

### Updates to existing Operators

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?