### PR TITLE
Fix the Strimzi Kafka CR example for OCP 4.5 UI

### DIFF
--- a/community-operators/strimzi-kafka-operator/0.18.0/strimzi-cluster-operator.v0.18.0.clusterserviceversion.yaml
+++ b/community-operators/strimzi-kafka-operator/0.18.0/strimzi-cluster-operator.v0.18.0.clusterserviceversion.yaml
@@ -16,8 +16,14 @@ metadata:
                 "replicas":3,
                 "listeners":{
                   "plain":{
+                    "authentiation":{
+                        "type":"scram-sha-512"
+                      }
                     },
                   "tls":{
+                    "authentiation":{
+                          "type":"tls"
+                        }
                     }
                 },
                 "config":{
@@ -38,8 +44,10 @@ metadata:
             },
             "entityOperator":{
                 "topicOperator":{
+                    "reconciliationIntervalSeconds":90
                   },
                 "userOperator":{
+                    "reconciliationIntervalSeconds":120
                   }
             }
           }


### PR DESCRIPTION
This PR changes the Kafka CR example in the Strimzi operator for OCP to work around a bug in the OCP4.5 UI which doesn't like empty objects in the examples.

### Updates to existing Operators

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo