### PR TITLE
aws-efs-operator 0.0.4: Fix roles from 0.0.3

### DIFF
--- a/community-operators/aws-efs-operator/0.0.4/aws-efs-operator.v0.0.4.clusterserviceversion.yaml
+++ b/community-operators/aws-efs-operator/0.0.4/aws-efs-operator.v0.0.4.clusterserviceversion.yaml
@@ -1,0 +1,212 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: aws-efs-operator.v0.0.4
+  namespace: placeholder
+  annotations:
+    alm-examples: >-
+      [{"apiVersion":"aws-efs.managed.openshift.io/v1alpha1","kind":"SharedVolume","metadata":{"name":"sv1"},"spec":{"accessPointID":
+      "fsap-0123456789abcdef", "fileSystemID": "fs-0123cdef"}}]
+    categories: Storage
+    certified: 'false'
+    createdAt: '2020-07-10T11:43:33Z'
+    description: Manage read-write-many access to AWS EFS volumes in an OpenShift cluster.
+    containerImage: 'quay.io/app-sre/aws-efs-operator:df227ac'
+    support: 'https://github.com/openshift/aws-efs-operator/issues/new'
+    capabilities: Basic Install
+    repository: 'https://github.com/openshift/aws-efs-operator'
+spec:
+  displayName: AWS EFS Operator
+  description: >-
+    ## About the managed application
+
+    AWS provides Elastic File System, an NFS-based shared storage solution. A
+    couple of mechanisms exist to enable mounting such a file system in
+    containers. Curating these options and making them work in a cluster is
+    nontrivial.
+
+    ## About this Operator
+
+    The aws-efs-operator minimizes the barrier to entry for container use of EFS
+    by:
+
+    - Installing the [AWS EFS CSI
+    Driver](https://github.com/kubernetes-sigs/aws-efs-csi-driver) and
+    supporting infrastructure.
+
+    - Reducing the identification of a shared storage resource to a simple
+    Custom Resource Definition with only two fields.
+
+    - Creating the necessary PersistentVolume and PersistentVolumeClaim
+    resources that can simply be referenced from a Pod specification.
+
+
+    More information can be found in the operator's [source
+    repository](https://github.com/openshift/aws-efs-operator).
+
+    ## Prerequisites for enabling this Operator
+
+    An OpenShift cluster backed by AWS.
+  maturity: alpha
+  version: 0.0.4
+  skips: []
+  replaces: aws-efs-operator.v0.0.3
+  minKubeVersion: ''
+  keywords:
+    - AWS
+    - EFS
+    - NFS
+    - Shared storage
+  maintainers:
+    - name: Support
+      email: support@redhat.com
+  provider:
+    name: Red Hat
+  links:
+    - name: README
+      url: 'https://github.com/openshift/aws-efs-operator/blob/master/README.md'
+    - name: Design
+      url: 'https://github.com/openshift/aws-efs-operator/blob/master/DESIGN.md'
+  icon:
+    - base64data: >-
+        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAC4VJREFUeNrtnXtsVFUexz/3zqO0BesKdEstEfGB4WXQxcW4CEtkawK6yFoVXUOTjQqbDSTrH6ysQdcl6ppNWBP24W4iLhV8AImgpYhQXR9ABSryCEKhgCA1pW/ovO7j7B9npi2Fqe2dmXsK3G8ymTLMvb9zft855/x+v3N+v6vRA4QQAEFgLHA/MBW4ERgCZOGhK6JAA3AE2AqUAweAqKZpSS+66P/EFZ8NzAZmAXcCwwBddS8vEdjA98B2YA2wAQhfjIjzPokrHuSv/FmgBMhR3ZtLHCFgLfBn5OigKxEdf3VR/p3AcuA21S2/zFANPAXsgk4SdLhA+f/CU34mcBtSt5OgU+dal3/cBLwF3K66pZc5dgNzgBpN09C7LLh/xFO+G7gdqetsIUSHVfMr4CHVLbuCUAIUg1wDgsAvkaPAgzvIQZr4QR0Yh1x8PbiLacA4HZiJdLI8uIthwEwd+Dmeh6sCOjBVR3q9HtTgJk0IEcELrKlCVBNd3GAP7sOb+xXDI0AxPAIUwyNAMTwCFMMjQDEubQKEgFgMTFN1SxzDr7oBXSGam7GPHkVYFvqIEej5+ZDkRIFdW0v0tdew9u5FGzgQraAA3/jx+KdMwTdyJPj7VdeSot84YsaWLUSefx5r/34QAn3ECAIPPEDW3Lno119/3nftujpC8+ZhbNhw/k10Hb2oCP+UKQRmziQwdSpafr7qrvWIfkGAdegQ7SUlWPv2dWudhm/MGIKPPYZ/2jT0wYOxDh8mumwZxpYtcgpKhkAA3/jxBGfPJnDfffhuuQUCAdVdvQDKCRChEKEnnyS2alUPrdTQ8vLQcnMRLS2I9vY+9FBDLyiQo+Lee/EXF6MXFKjs8vnNU02AsWkT7SUliHPnMi/M78c3dixZTz1F8KGH0K65RmXXAdVWkG1jrFvnjvIBTBNrzx5CCxZwbtYsYmvXIsJhpSpQOgKsw4c5V1yMffy4ms7n5BB48EEGLF6Mb9QoJW1QOgLMrVuxT5xQJl+EQsRWriQ0dy7WwYNK2qCUAKu6umdLxiWYVVVEXnhByXSkjAD79GnMqipV4i+AsXEj1vbtrstVRoD5+edY33yjSvwFEG1tSqYhNQRYFsbGjWAYSsQnbdaRI67LVEKAVVOD+fHHKkT33K6dOxGtra7KVEKA+dFH2N9+q0J0j7AOHcI+dsxVma4TIMJhjE2b3Bbbu7Y1NWHt3euqTNcJOFNVRXjbNrfF9g62jbltm6umsesErC0v52RLS7/dCTJ37UI0N7smz1U9tLS08PaOHaxCphFqqd4wA7CPHXM1NJL+bSPTxG5sxK6txT5yBPvECez6enyWRWVbG7uqq/kayAd+E2+Ael+4E6K5GXPnTny3uZMmlzYCRH09xubNGBUVWF9/jX3ypIxy2jYgswI/CgYJR6OEgaVALvB44npXutubjgjM7dvJeuIJ0DM/QaRMgGhpIbZ6NdHXX5cWRBLnKgYci5MBcA54AbCAR5FpOvYPi3MF1t69iOZmtMGDMy4rJYrtmhraS0sJLVyItXt3z56tEOjdTi+cQWar/R6ZwdxfttHt2lrXwiSOCRD19YQWLMBYv75Xx0KygFsv8nk78CYyg3kLchSotpBEa2v/JyC6ciXGhx/2+vsaUCwEyc4o7EYuys8Dp5CjQRURAmhraHBlXXLUR9HQQOydd/rksFjIbMBZPXynGfg7cmFeBhyPN9BtIgzgk+pqoi4c+HLUN/vkSeza2j5f5wd+C/ykh+8I4CvkSCgB/gHU4R4ROtAIvPvVVzQdOuSKvD5DnDsHkUifr7OB64GXgJt/SAZQAywBHgT+AnwTv4cv/kq3I5e433rgi+PH+W7OHGIvvohdV5dmSV1kOtmUt6qrOTt9OqKpyZFQHTnnPwN82QflXAv8FBiNrBw1ChgYv5+NJM3JvK0hCW0FVgJ/A1p1nVV+P8WmCRMnEiwtJThnDlpenkNVJ5HthABRX8/Z6dNTihz6gf3AYuB/DhR3DZKIiUhSRgFDkSnoCXNWdHvv6HSXdxtoA/YB/wY2ItcANI2/ZmXxZCSCCRAIEJgxg+yXX07rCQpHprc2dCj+yZNTIsAExgCvIRfcMqRJ2ls0AZ/HX1nI0MZw5NQ2EiiMf3YVsgZDEDlSTCACtCDXln3IUXggTkQHhOBby+p0Dg0D4733EI2N5Cxfjm/8+LQQ4PhckFlVRfvs2dinT6fUAB3pJVcgyahCWkypQkcSMwCp/MSaYSN/4SFkkbeeZP1B03hGiAu+4xs9muyXXiJw//0pt9P5wSwhCC9ZQmTp0jSoSyroDPA28B9A3WkhiRzkqLyHi5OkFxWRu3o1/smTU5Lj3LLTNLLmz8c/aVJaOmwBg4HfAauQTtmP03JnZ5gM3EHy+JR96hSRV15Jee8gJdNaLyxkwLPPohcWpqXTIt7hsUizcy3wJ2QpFzcrB96MjE9dRc/GgVFRQeTVVzsivk6QlrOhsTffJLRwoWOzNBl88fdmpNm6AfgUGarIxIEWH/AzpBM4gd5FZ/VhwxhYXo5vwgRHMtMSgAw++igiHCa8aFFat/MSc28eci6eAnyHLD/4CbL84ElkaDuVULYP6SA+DvwaWZW2t4aAXVdHbN06sh0SkL7T0ZZFrKyM8OLFGfUcEyEJA2mKHkd6zC1IMmqRFVNbkWZtDGl6JrZAA8iNoMHAdcgI7Q3I8MjwuIy+KsQ/cSIDN21ylG+Q3uPpQmBs3kz46aexDhxI222TNh5JRsKxspGmZTvSzDwbf48hf9E60izNA64GBiFN1YR56nQUaUOGMKiyEt+4cX2+Nr17IJpGoLgYvaiI0IIFmJWVab19dwgunCoCwI+QnjJcPF4kurzS4XMQDjs+UZeRAKNvzBhy33iDAUuWoA9zvxpawpqykQru/krEjdIGXXecFpuxCK8+fDjZzz1H7po1+O++O2m+7+UAbdAgx/lmmQ2x6zr+u+4id/VqBixa1O9zdh13c/hwmVTu5FpXGnjttWQvXcrA998na/58V04buAn/tGloV1/t6Fr3k/QMA3PHDqL//CfGBx8gzp51VXy6oRUUMKi83PFBLvf3vQMB/JMnk7tiBbllZQSKi9FyLt1HFAQffhjfrbc6vl55orY4exZz2zaMigqMDRtk1mQKsRU3EbjnHnJWrEAvKnJ8D+UEdMC2sWtrMcrLib31FuaePRCNqm5VUug33EBuWRn+O1Or+tx/COgC0dCA+dlnxNavx6ysxD51ql+ksybgmzCBnGXL8E+ZkvK9+iUBHTBNrJoarC+/xDp4ELOyEuvgQfdKG3SDNnQoWaWlZM2bhz5yZHru2a8J6AbR2Ih14ADmF19gfvop1v792PX1smpWBqEXFhKYMYNgaSn+O+5IazGoS4qArhDhMOLUKTkydu6UR+KPHsX+/ntEW1tqZcz8fvT8fHxjx+KfOpXAjBn4Ro/OSBWuS5aACxCLyZJnp09j1dYiGhrAMBBNTdhnziCamqTPEYkg4uRogQDk5KDl5aEPGYJWWIiWk4Oen48+ejT6ddehZWf2uRaXDwE/BNsGywLb7nyCkaZ1BtIUxaquHAL6KVQfxb/i4RGgGB4BiuERoBgeAYrhEaAYOvIkhwc1iOjIx3B7UINGHXmwzIMa1OhAJf2nSsCVBBvYqiPTojJ3mNNDMtQBG3VkmpT7BTM9VAL7Eylaa5HnWD24g3bgXSCW8APWA2tUt+oKwhpkbRJ5eDgekb4RmSPnPVc+s9gNPAIc0TTtPE/4CDAv/gUPmUEVUscdJXo7toG67MtMApbjjYR0YzdS+bsgvhtHl1iQ1rkltwM5RP6LtzCnA+1IXT5CN+VDkoIj8dGQDfwCWaxkGlCAF7zrLWxkqtrHyHV1KxDWLrLv3ONOdJyIIDJ19z7k8+dvRCYSek/hPh8RZKmhGqTCNyJLUES1Hjb8/w+bHUpuhYx6lgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAyMC0wMS0xMFQxNjo0Njo0NCswMDowMKzwOm4AAAAldEVYdGRhdGU6bW9kaWZ5ADIwMjAtMDEtMTBUMTY6NDY6NDQrMDA6MDDdrYLSAAAARnRFWHRzb2Z0d2FyZQBJbWFnZU1hZ2ljayA2LjcuOC05IDIwMTktMDItMDEgUTE2IGh0dHA6Ly93d3cuaW1hZ2VtYWdpY2sub3JnQXviyAAAABh0RVh0VGh1bWI6OkRvY3VtZW50OjpQYWdlcwAxp/+7LwAAABh0RVh0VGh1bWI6OkltYWdlOjpoZWlnaHQANTEywNBQUQAAABd0RVh0VGh1bWI6OkltYWdlOjpXaWR0aAA1MTIcfAPcAAAAGXRFWHRUaHVtYjo6TWltZXR5cGUAaW1hZ2UvcG5nP7JWTgAAABd0RVh0VGh1bWI6Ok1UaW1lADE1Nzg2NzQ4MDTgzTkjAAAAE3RFWHRUaHVtYjo6U2l6ZQAxNS4xS0JCehw8bwAAAEJ0RVh0VGh1bWI6OlVSSQBmaWxlOi8vLi91cGxvYWRzLzU2LzhRdFpYUGgvMjEwOC9yZWRoYXRfaWNvbl8xMzA4NDQucG5n7pb6GgAAAABJRU5ErkJggg==
+      mediatype: image/png
+  customresourcedefinitions:
+    owned:
+      - name: sharedvolumes.aws-efs.managed.openshift.io
+        displayName: SharedVolume
+        kind: SharedVolume
+        version: v1alpha1
+        description: Shared Volume
+        specDescriptors:
+          - path: accessPointID
+            description: Access Point ID
+            displayName: Access Point ID
+            x-descriptors: []
+          - path: fileSystemID
+            description: File System ID
+            displayName: File System ID
+            x-descriptors: []
+        statusDescriptors:
+          - path: claimRef
+            description: Claim Ref
+            displayName: Claim Ref
+            x-descriptors: []
+          - path: message
+            description: Message
+            displayName: Message
+            x-descriptors: []
+          - path: phase
+            description: Phase
+            displayName: Phase
+            x-descriptors: []
+    required: []
+  install:
+    strategy: deployment
+    spec:
+      permissions: []
+      clusterPermissions:
+        - serviceAccountName: aws-efs-operator
+          rules:
+            - apiGroups:
+                - ''
+              resources:
+                - pods
+                - services
+                - services/finalizers
+                - endpoints
+                - persistentvolumes
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                - serviceaccounts
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - apps
+              resourceNames:
+                - aws-efs-operator
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - aws-efs.managed.openshift.io
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - csidrivers
+                - storageclasses
+              verbs:
+                - '*'
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - '*'
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - list
+                - watch
+      deployments:
+        - name: aws-efs-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: aws-efs-operator
+            template:
+              metadata:
+                labels:
+                  name: aws-efs-operator
+              spec:
+                serviceAccountName: aws-efs-operator
+                containers:
+                  - name: aws-efs-operator
+                    image: quay.io/app-sre/aws-efs-operator:df227ac
+                    command:
+                      - aws-efs-operator
+                    imagePullPolicy: Always
+                    env:
+                      - name: WATCH_NAMESPACE
+                        value: ''
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: aws-efs-operator
+  installModes:
+    - type: OwnNamespace
+      supported: false
+    - type: SingleNamespace
+      supported: false
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true

--- a/community-operators/aws-efs-operator/0.0.4/aws-efs.managed.openshift.io_sharedvolumes_crd.yaml
+++ b/community-operators/aws-efs-operator/0.0.4/aws-efs.managed.openshift.io_sharedvolumes_crd.yaml
@@ -1,0 +1,105 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: sharedvolumes.aws-efs.managed.openshift.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.fileSystemID
+    name: File System
+    type: string
+  - JSONPath: .spec.accessPointID
+    name: Access Point
+    type: string
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  - JSONPath: .status.claimRef.name
+    name: Claim
+    type: string
+  - JSONPath: .status.message
+    name: Message
+    type: string
+  group: aws-efs.managed.openshift.io
+  names:
+    kind: SharedVolume
+    listKind: SharedVolumeList
+    plural: sharedvolumes
+    shortNames:
+    - sv
+    singular: sharedvolume
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: SharedVolume is the Schema for the sharedvolumes API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SharedVolumeSpec defines the desired state of SharedVolume
+          properties:
+            accessPointID:
+              description: The ID of an EFS volume access point, e.g. `fsap-0123456789abcdef`.
+                The EFS volume will be mounted to the specified access point. Required.
+                Immutable.
+              pattern: ^fsap-[0-9a-f]+$
+              type: string
+            fileSystemID:
+              description: The ID of the EFS volume, e.g. `fs-0123cdef`. Required.
+                Immutable.
+              pattern: ^fs-[0-9a-f]+$
+              type: string
+          required:
+          - accessPointID
+          - fileSystemID
+          type: object
+        status:
+          description: SharedVolumeStatus defines the observed state of SharedVolume
+          properties:
+            claimRef:
+              description: ClaimRef refers to the PersistentVolumeClaim bound to a
+                PersistentVolume representing the file system access point, both of
+                which are created at the behest of this SharedVolume.
+              properties:
+                apiGroup:
+                  description: APIGroup is the group for the resource being referenced.
+                    If APIGroup is not specified, the specified Kind must be in the
+                    core API group. For any other third-party types, APIGroup is required.
+                  type: string
+                kind:
+                  description: Kind is the type of resource being referenced
+                  type: string
+                name:
+                  description: Name is the name of resource being referenced
+                  type: string
+              required:
+              - kind
+              - name
+              type: object
+            message:
+              description: Message is a human-readable string, usually describing
+                what went wrong when `Phase` is `SharedVolumeFailed`.
+              type: string
+            phase:
+              description: Phase indicates the state of the PersistentVolume and PersistentVolumeClaim
+                artifacts associated with this SharedVolume. See SharedVolumePhase
+                consts for possible values.
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/aws-efs-operator/aws-efs-operator.package.yaml
+++ b/community-operators/aws-efs-operator/aws-efs-operator.package.yaml
@@ -1,5 +1,5 @@
 packageName: aws-efs-operator
 channels:
 - name: stable
-  currentCSV: aws-efs-operator.v0.0.3
+  currentCSV: aws-efs-operator.v0.0.4
 defaultChannel: stable


### PR DESCRIPTION
Version 0.0.3 was broken due to a missing role. This version keeps the
same everything else, just adds that role.

Signed-off-by: Eric Fried <efried@redhat.com>

### Updates to existing Operators

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [ ] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
