### PR TITLE
Update registry base image

### DIFF
--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/upstream-registry-builder:v1.5.6 as builder
+FROM quay.io/operator-framework/upstream-registry-builder:v1.13.3 as builder
 ARG PERMISSIVE_LOAD=true
 COPY upstream-community-operators manifests
 RUN if [ $PERMISSIVE_LOAD = "true" ] ; then ./bin/initializer --permissive -o ./bundles.db ; else ./bin/initializer -o ./bundles.db ; fi 


### PR DESCRIPTION
The base image used for the upstream catalog is very old, and doesn't support some newer additions to the grpc api. This change should bring it up to speed and allow the operatorhubio catalog to work with the new resolver.