### PR TITLE
Add Strimzi 0.19.0 to Upstream Community Operators

### DIFF
--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkabridges.kafka.strimzi.io.crd.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkabridges.kafka.strimzi.io.crd.yaml
@@ -1,0 +1,918 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkabridges.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaBridge
+    listKind: KafkaBridgeList
+    singular: kafkabridge
+    plural: kafkabridges
+    shortNames:
+    - kb
+    categories:
+    - strimzi
+  additionalPrinterColumns:
+  - name: Desired replicas
+    description: The desired number of Kafka Bridge replicas
+    JSONPath: .spec.replicas
+    type: integer
+  - name: Bootstrap Servers
+    description: The boostrap servers
+    JSONPath: .spec.bootstrapServers
+    type: string
+    priority: 1
+  subresources:
+    status: {}
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+      labelSelectorPath: .status.selector
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              minimum: 0
+              description: The number of pods in the `Deployment`.
+            image:
+              type: string
+              description: The docker image for the pods.
+            bootstrapServers:
+              type: string
+              description: A list of host:port pairs for establishing the initial
+                connection to the Kafka cluster.
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the certificate.
+                    required:
+                    - certificate
+                    - secretName
+                  description: Trusted certificates for TLS connection.
+              description: TLS configuration for connecting Kafka Bridge to the cluster.
+            authentication:
+              type: object
+              properties:
+                accessToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
+                  required:
+                  - key
+                  - secretName
+                  description: Link to Kubernetes Secret containing the access token
+                    which was obtained from the authorization server.
+                accessTokenIsJwt:
+                  type: boolean
+                  description: Configure whether access token should be treated as
+                    JWT. This should be set to `false` if the authorization server
+                    returns opaque tokens. Defaults to `true`.
+                certificateAndKey:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                      description: The name of the file certificate in the Secret.
+                    key:
+                      type: string
+                      description: The name of the private key in the Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Secret containing the certificate.
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                  description: Reference to the `Secret` which holds the certificate
+                    and private key pair.
+                clientId:
+                  type: string
+                  description: OAuth Client ID which the Kafka client can use to authenticate
+                    against the OAuth server and use the token endpoint URI.
+                clientSecret:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
+                  required:
+                  - key
+                  - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client
+                    secret which the Kafka client can use to authenticate against
+                    the OAuth server and use the token endpoint URI.
+                disableTlsHostnameVerification:
+                  type: boolean
+                  description: Enable or disable TLS hostname verification. Default
+                    value is `false`.
+                maxTokenExpirySeconds:
+                  type: integer
+                  description: Set or limit time-to-live of the access tokens to the
+                    specified number of seconds. This should be set if the authorization
+                    server returns opaque tokens.
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                      description: The name of the key in the Secret under which the
+                        password is stored.
+                    secretName:
+                      type: string
+                      description: The name of the Secret containing the password.
+                  required:
+                  - password
+                  - secretName
+                  description: Reference to the `Secret` which holds the password.
+                refreshToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
+                  required:
+                  - key
+                  - secretName
+                  description: Link to Kubernetes Secret containing the refresh token
+                    which can be used to obtain access token from the authorization
+                    server.
+                scope:
+                  type: string
+                  description: OAuth scope to use when authenticating against the
+                    authorization server. Some authorization servers require this
+                    to be set. The possible values depend on how authorization server
+                    is configured. By default `scope` is not specified when doing
+                    the token endpoint request.
+                tlsTrustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the certificate.
+                    required:
+                    - certificate
+                    - secretName
+                  description: Trusted certificates for TLS connection to the OAuth
+                    server.
+                tokenEndpointUri:
+                  type: string
+                  description: Authorization server token endpoint URI.
+                type:
+                  type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+                  - plain
+                  - oauth
+                  description: Authentication type. Currently the only supported types
+                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
+                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
+                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
+                    The `tls` type uses TLS Client Authentication. The `tls` type
+                    is supported only over TLS connections.
+                username:
+                  type: string
+                  description: Username used for the authentication.
+              required:
+              - type
+              description: Authentication configuration for connecting to the cluster.
+            http:
+              type: object
+              properties:
+                port:
+                  type: integer
+                  minimum: 1023
+                  description: The port which is the server listening on.
+                cors:
+                  type: object
+                  properties:
+                    allowedOrigins:
+                      type: array
+                      items:
+                        type: string
+                      description: List of allowed origins. Java regular expressions
+                        can be used.
+                    allowedMethods:
+                      type: array
+                      items:
+                        type: string
+                      description: List of allowed HTTP methods.
+                  required:
+                  - allowedOrigins
+                  - allowedMethods
+                  description: CORS configuration for the HTTP Bridge.
+              description: The HTTP related configuration.
+            consumer:
+              type: object
+              properties:
+                config:
+                  type: object
+                  description: 'The Kafka consumer configuration used for consumer
+                    instances created by the bridge. Properties with the following
+                    prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl.,
+                    security. (with the exception of: ssl.endpoint.identification.algorithm,
+                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+              description: Kafka consumer related configuration.
+            producer:
+              type: object
+              properties:
+                config:
+                  type: object
+                  description: 'The Kafka producer configuration used for producer
+                    instances created by the bridge. Properties with the following
+                    prefixes cannot be set: ssl., bootstrap.servers, sasl., security.
+                    (with the exception of: ssl.endpoint.identification.algorithm,
+                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+              description: Kafka producer related configuration.
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
+              description: CPU and memory resources to reserve.
+            jvmOptions:
+              type: object
+              properties:
+                "-XX":
+                  type: object
+                  description: A map of -XX options to the JVM.
+                "-Xms":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM.
+                "-Xmx":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM.
+                gcLoggingEnabled:
+                  type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
+                javaSystemProperties:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: The system property name.
+                      value:
+                        type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: '**Currently not supported** JVM Options for pods.'
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                  description: A Map from logger name to logger level.
+                name:
+                  type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
+                type:
+                  type: string
+                  enum:
+                  - inline
+                  - external
+                  description: Logging type, must be either 'inline' or 'external'.
+              required:
+              - type
+              description: Logging configuration for Kafka Bridge.
+            enableMetrics:
+              type: boolean
+              description: Enable the metrics for the Kafka Bridge. Default is false.
+            livenessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
+            readinessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
+            template:
+              type: object
+              properties:
+                deployment:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for Kafka Bridge `Deployment`.
+                pod:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                    imagePullSecrets:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod. When
+                        the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster
+                        Operator and the `imagePullSecrets` option are specified,
+                        only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS`
+                        variable is ignored.
+                    securityContext:
+                      type: object
+                      properties:
+                        fsGroup:
+                          type: integer
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        supplementalGroups:
+                          type: array
+                          items:
+                            type: integer
+                        sysctls:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
+                    terminationGracePeriodSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal,
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value to longer than the expected cleanup
+                        time for your process. Value must be a non-negative integer.
+                        A zero value indicates delete immediately. You might need
+                        to increase the grace period for very large Kafka clusters,
+                        so that the Kafka brokers have enough time to transfer their
+                        work to another broker before they are terminated. Defaults
+                        to 30 seconds.
+                    affinity:
+                      type: object
+                      properties:
+                        nodeAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  preference:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: object
+                              properties:
+                                nodeSelectorTerms:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                        podAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                        podAntiAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                      description: The pod's affinity rules.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            type: integer
+                          value:
+                            type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Bridge `Pods`.
+                apiService:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for Kafka Bridge API `Service`.
+                bridgeContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The environment variable key.
+                          value:
+                            type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                    securityContext:
+                      type: object
+                      properties:
+                        allowPrivilegeEscalation:
+                          type: boolean
+                        capabilities:
+                          type: object
+                          properties:
+                            add:
+                              type: array
+                              items:
+                                type: string
+                            drop:
+                              type: array
+                              items:
+                                type: string
+                        privileged:
+                          type: boolean
+                        procMount:
+                          type: string
+                        readOnlyRootFilesystem:
+                          type: boolean
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Security context for the container.
+                  description: Template for the Kafka Bridge container.
+                podDisruptionBudget:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
+                    maxUnavailable:
+                      type: integer
+                      minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Bridge `PodDisruptionBudget`.
+              description: Template for Kafka Bridge resources. The template allows
+                users to specify how is the `Deployment` and `Pods` generated.
+            tracing:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing.
+              required:
+              - type
+              description: The configuration of tracing in Kafka Bridge.
+          required:
+          - bootstrapServers
+          description: The specification of the Kafka Bridge.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+            url:
+              type: string
+              description: The URL at which external client applications can access
+                the Kafka Bridge.
+            podSelector:
+              type: object
+              properties:
+                matchExpressions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: string
+                matchLabels:
+                  type: object
+              description: Label selector for pods providing this resource.
+            replicas:
+              type: integer
+              description: The current number of pods being used to provide this resource.
+          description: The status of the Kafka Bridge.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkaconnectors.kafka.strimzi.io.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkaconnectors.kafka.strimzi.io.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnectors.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaConnector
+    listKind: KafkaConnectorList
+    singular: kafkaconnector
+    plural: kafkaconnectors
+    shortNames:
+    - kctr
+    categories:
+    - strimzi
+  subresources:
+    status: {}
+    scale:
+      specReplicasPath: .spec.tasksMax
+      statusReplicasPath: .status.tasksMax
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            class:
+              type: string
+              description: The Class for the Kafka Connector.
+            tasksMax:
+              type: integer
+              minimum: 1
+              description: The maximum number of tasks for the Kafka Connector.
+            config:
+              type: object
+              description: 'The Kafka Connector configuration. The following properties
+                cannot be set: connector.class, tasks.max.'
+            pause:
+              type: boolean
+              description: Whether the connector should be paused. Defaults to false.
+          description: The specification of the Kafka Connector.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+            connectorStatus:
+              type: object
+              description: The connector status, as reported by the Kafka Connect
+                REST API.
+            tasksMax:
+              type: integer
+              description: The maximum number of tasks for the Kafka Connector.
+          description: The status of the Kafka Connector.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkaconnects.kafka.strimzi.io.crd.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkaconnects.kafka.strimzi.io.crd.yaml
@@ -1,0 +1,1228 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnects.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: KafkaConnect
+    listKind: KafkaConnectList
+    singular: kafkaconnect
+    plural: kafkaconnects
+    shortNames:
+    - kc
+    categories:
+    - strimzi
+  additionalPrinterColumns:
+  - name: Desired replicas
+    description: The desired number of Kafka Connect replicas
+    JSONPath: .spec.replicas
+    type: integer
+  subresources:
+    status: {}
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+      labelSelectorPath: .status.selector
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              description: The number of pods in the Kafka Connect group.
+            version:
+              type: string
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
+                Consult the user documentation to understand the process required
+                to upgrade or downgrade the version.
+            image:
+              type: string
+              description: The docker image for the pods.
+            bootstrapServers:
+              type: string
+              description: Bootstrap servers to connect to. This should be given as
+                a comma separated list of _<hostname>_:‍_<port>_ pairs.
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the certificate.
+                    required:
+                    - certificate
+                    - secretName
+                  description: Trusted certificates for TLS connection.
+              description: TLS configuration.
+            authentication:
+              type: object
+              properties:
+                accessToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
+                  required:
+                  - key
+                  - secretName
+                  description: Link to Kubernetes Secret containing the access token
+                    which was obtained from the authorization server.
+                accessTokenIsJwt:
+                  type: boolean
+                  description: Configure whether access token should be treated as
+                    JWT. This should be set to `false` if the authorization server
+                    returns opaque tokens. Defaults to `true`.
+                certificateAndKey:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                      description: The name of the file certificate in the Secret.
+                    key:
+                      type: string
+                      description: The name of the private key in the Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Secret containing the certificate.
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                  description: Reference to the `Secret` which holds the certificate
+                    and private key pair.
+                clientId:
+                  type: string
+                  description: OAuth Client ID which the Kafka client can use to authenticate
+                    against the OAuth server and use the token endpoint URI.
+                clientSecret:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
+                  required:
+                  - key
+                  - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client
+                    secret which the Kafka client can use to authenticate against
+                    the OAuth server and use the token endpoint URI.
+                disableTlsHostnameVerification:
+                  type: boolean
+                  description: Enable or disable TLS hostname verification. Default
+                    value is `false`.
+                maxTokenExpirySeconds:
+                  type: integer
+                  description: Set or limit time-to-live of the access tokens to the
+                    specified number of seconds. This should be set if the authorization
+                    server returns opaque tokens.
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                      description: The name of the key in the Secret under which the
+                        password is stored.
+                    secretName:
+                      type: string
+                      description: The name of the Secret containing the password.
+                  required:
+                  - password
+                  - secretName
+                  description: Reference to the `Secret` which holds the password.
+                refreshToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
+                  required:
+                  - key
+                  - secretName
+                  description: Link to Kubernetes Secret containing the refresh token
+                    which can be used to obtain access token from the authorization
+                    server.
+                scope:
+                  type: string
+                  description: OAuth scope to use when authenticating against the
+                    authorization server. Some authorization servers require this
+                    to be set. The possible values depend on how authorization server
+                    is configured. By default `scope` is not specified when doing
+                    the token endpoint request.
+                tlsTrustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the certificate.
+                    required:
+                    - certificate
+                    - secretName
+                  description: Trusted certificates for TLS connection to the OAuth
+                    server.
+                tokenEndpointUri:
+                  type: string
+                  description: Authorization server token endpoint URI.
+                type:
+                  type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+                  - plain
+                  - oauth
+                  description: Authentication type. Currently the only supported types
+                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
+                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
+                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
+                    The `tls` type uses TLS Client Authentication. The `tls` type
+                    is supported only over TLS connections.
+                username:
+                  type: string
+                  description: Username used for the authentication.
+              required:
+              - type
+              description: Authentication configuration for Kafka Connect.
+            config:
+              type: object
+              description: 'The Kafka Connect configuration. Properties with the following
+                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
+                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
+                ssl.protocol, ssl.enabled.protocols).'
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
+              description: The maximum limits for CPU and memory resources and the
+                requested initial resources.
+            livenessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
+            readinessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
+            jvmOptions:
+              type: object
+              properties:
+                "-XX":
+                  type: object
+                  description: A map of -XX options to the JVM.
+                "-Xms":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM.
+                "-Xmx":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM.
+                gcLoggingEnabled:
+                  type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
+                javaSystemProperties:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: The system property name.
+                      value:
+                        type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods.
+            affinity:
+              type: object
+              properties:
+                nodeAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          preference:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: object
+                      properties:
+                        nodeSelectorTerms:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                podAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+                podAntiAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+              description: The pod's affinity rules.
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+              description: The pod's tolerations.
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                  description: A Map from logger name to logger level.
+                name:
+                  type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
+                type:
+                  type: string
+                  enum:
+                  - inline
+                  - external
+                  description: Logging type, must be either 'inline' or 'external'.
+              required:
+              - type
+              description: Logging configuration for Kafka Connect.
+            metrics:
+              type: object
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                for details of the structure of this configuration.
+            tracing:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing.
+              required:
+              - type
+              description: The configuration of tracing in Kafka Connect.
+            template:
+              type: object
+              properties:
+                deployment:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for Kafka Connect `Deployment`.
+                pod:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                    imagePullSecrets:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod. When
+                        the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster
+                        Operator and the `imagePullSecrets` option are specified,
+                        only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS`
+                        variable is ignored.
+                    securityContext:
+                      type: object
+                      properties:
+                        fsGroup:
+                          type: integer
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        supplementalGroups:
+                          type: array
+                          items:
+                            type: integer
+                        sysctls:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
+                    terminationGracePeriodSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal,
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value to longer than the expected cleanup
+                        time for your process. Value must be a non-negative integer.
+                        A zero value indicates delete immediately. You might need
+                        to increase the grace period for very large Kafka clusters,
+                        so that the Kafka brokers have enough time to transfer their
+                        work to another broker before they are terminated. Defaults
+                        to 30 seconds.
+                    affinity:
+                      type: object
+                      properties:
+                        nodeAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  preference:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: object
+                              properties:
+                                nodeSelectorTerms:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                        podAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                        podAntiAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                      description: The pod's affinity rules.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            type: integer
+                          value:
+                            type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Connect `Pods`.
+                apiService:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for Kafka Connect API `Service`.
+                connectContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The environment variable key.
+                          value:
+                            type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                    securityContext:
+                      type: object
+                      properties:
+                        allowPrivilegeEscalation:
+                          type: boolean
+                        capabilities:
+                          type: object
+                          properties:
+                            add:
+                              type: array
+                              items:
+                                type: string
+                            drop:
+                              type: array
+                              items:
+                                type: string
+                        privileged:
+                          type: boolean
+                        procMount:
+                          type: string
+                        readOnlyRootFilesystem:
+                          type: boolean
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Security context for the container.
+                  description: Template for the Kafka Connect container.
+                podDisruptionBudget:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
+                    maxUnavailable:
+                      type: integer
+                      minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Connect `PodDisruptionBudget`.
+              description: Template for Kafka Connect and Kafka Connect S2I resources.
+                The template allows users to specify how the `Deployment`, `Pods`
+                and `Service` are generated.
+            externalConfiguration:
+              type: object
+              properties:
+                env:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: Name of the environment variable which will be
+                          passed to the Kafka Connect pods. The name of the environment
+                          variable cannot start with `KAFKA_` or `STRIMZI_`.
+                      valueFrom:
+                        type: object
+                        properties:
+                          configMapKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            description: Refernce to a key in a ConfigMap.
+                          secretKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            description: Reference to a key in a Secret.
+                        description: Value of the environment variable which will
+                          be passed to the Kafka Connect pods. It can be passed either
+                          as a reference to Secret or ConfigMap field. The field has
+                          to specify exactly one Secret or ConfigMap.
+                    required:
+                    - name
+                    - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as environment variables.
+                volumes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      configMap:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to a key in a ConfigMap. Exactly one
+                          Secret or ConfigMap has to be specified.
+                      name:
+                        type: string
+                        description: Name of the volume which will be added to the
+                          Kafka Connect pods.
+                      secret:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        description: Reference to a key in a Secret. Exactly one Secret
+                          or ConfigMap has to be specified.
+                    required:
+                    - name
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
+                pods and use them to configure connectors.
+          required:
+          - bootstrapServers
+          description: The specification of the Kafka Connect cluster.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+            url:
+              type: string
+              description: The URL of the REST API endpoint for managing and monitoring
+                Kafka Connect connectors.
+            connectorPlugins:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The type of the connector plugin. The available types
+                      are `sink` and `source`.
+                  version:
+                    type: string
+                    description: The version of the connector plugin.
+                  class:
+                    type: string
+                    description: The class of the connector plugin.
+              description: The list of connector plugins available in this Kafka Connect
+                deployment.
+            podSelector:
+              type: object
+              properties:
+                matchExpressions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: string
+                matchLabels:
+                  type: object
+              description: Label selector for pods providing this resource.
+            replicas:
+              type: integer
+              description: The current number of pods being used to provide this resource.
+          description: The status of the Kafka Connect cluster.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkaconnects2is.kafka.strimzi.io.crd.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkaconnects2is.kafka.strimzi.io.crd.yaml
@@ -1,0 +1,1245 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnects2is.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: KafkaConnectS2I
+    listKind: KafkaConnectS2IList
+    singular: kafkaconnects2i
+    plural: kafkaconnects2is
+    shortNames:
+    - kcs2i
+    categories:
+    - strimzi
+  additionalPrinterColumns:
+  - name: Desired replicas
+    description: The desired number of Kafka Connect replicas
+    JSONPath: .spec.replicas
+    type: integer
+  subresources:
+    status: {}
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+      labelSelectorPath: .status.selector
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              description: The number of pods in the Kafka Connect group.
+            image:
+              type: string
+              description: The docker image for the pods.
+            buildResources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
+              description: CPU and memory resources to reserve.
+            livenessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
+            readinessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
+            jvmOptions:
+              type: object
+              properties:
+                "-XX":
+                  type: object
+                  description: A map of -XX options to the JVM.
+                "-Xms":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM.
+                "-Xmx":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM.
+                gcLoggingEnabled:
+                  type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
+                javaSystemProperties:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: The system property name.
+                      value:
+                        type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods.
+            affinity:
+              type: object
+              properties:
+                nodeAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          preference:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: object
+                      properties:
+                        nodeSelectorTerms:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                podAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+                podAntiAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+              description: The pod's affinity rules.
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                  description: A Map from logger name to logger level.
+                name:
+                  type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
+                type:
+                  type: string
+                  enum:
+                  - inline
+                  - external
+                  description: Logging type, must be either 'inline' or 'external'.
+              required:
+              - type
+              description: Logging configuration for Kafka Connect.
+            metrics:
+              type: object
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                for details of the structure of this configuration.
+            template:
+              type: object
+              properties:
+                deployment:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for Kafka Connect `Deployment`.
+                pod:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                    imagePullSecrets:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod. When
+                        the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster
+                        Operator and the `imagePullSecrets` option are specified,
+                        only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS`
+                        variable is ignored.
+                    securityContext:
+                      type: object
+                      properties:
+                        fsGroup:
+                          type: integer
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        supplementalGroups:
+                          type: array
+                          items:
+                            type: integer
+                        sysctls:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
+                    terminationGracePeriodSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal,
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value to longer than the expected cleanup
+                        time for your process. Value must be a non-negative integer.
+                        A zero value indicates delete immediately. You might need
+                        to increase the grace period for very large Kafka clusters,
+                        so that the Kafka brokers have enough time to transfer their
+                        work to another broker before they are terminated. Defaults
+                        to 30 seconds.
+                    affinity:
+                      type: object
+                      properties:
+                        nodeAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  preference:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: object
+                              properties:
+                                nodeSelectorTerms:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                        podAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                        podAntiAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                      description: The pod's affinity rules.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            type: integer
+                          value:
+                            type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Connect `Pods`.
+                apiService:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for Kafka Connect API `Service`.
+                connectContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The environment variable key.
+                          value:
+                            type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                    securityContext:
+                      type: object
+                      properties:
+                        allowPrivilegeEscalation:
+                          type: boolean
+                        capabilities:
+                          type: object
+                          properties:
+                            add:
+                              type: array
+                              items:
+                                type: string
+                            drop:
+                              type: array
+                              items:
+                                type: string
+                        privileged:
+                          type: boolean
+                        procMount:
+                          type: string
+                        readOnlyRootFilesystem:
+                          type: boolean
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Security context for the container.
+                  description: Template for the Kafka Connect container.
+                podDisruptionBudget:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
+                    maxUnavailable:
+                      type: integer
+                      minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Connect `PodDisruptionBudget`.
+              description: Template for Kafka Connect and Kafka Connect S2I resources.
+                The template allows users to specify how the `Deployment`, `Pods`
+                and `Service` are generated.
+            authentication:
+              type: object
+              properties:
+                accessToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
+                  required:
+                  - key
+                  - secretName
+                  description: Link to Kubernetes Secret containing the access token
+                    which was obtained from the authorization server.
+                accessTokenIsJwt:
+                  type: boolean
+                  description: Configure whether access token should be treated as
+                    JWT. This should be set to `false` if the authorization server
+                    returns opaque tokens. Defaults to `true`.
+                certificateAndKey:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                      description: The name of the file certificate in the Secret.
+                    key:
+                      type: string
+                      description: The name of the private key in the Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Secret containing the certificate.
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                  description: Reference to the `Secret` which holds the certificate
+                    and private key pair.
+                clientId:
+                  type: string
+                  description: OAuth Client ID which the Kafka client can use to authenticate
+                    against the OAuth server and use the token endpoint URI.
+                clientSecret:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
+                  required:
+                  - key
+                  - secretName
+                  description: Link to Kubernetes Secret containing the OAuth client
+                    secret which the Kafka client can use to authenticate against
+                    the OAuth server and use the token endpoint URI.
+                disableTlsHostnameVerification:
+                  type: boolean
+                  description: Enable or disable TLS hostname verification. Default
+                    value is `false`.
+                maxTokenExpirySeconds:
+                  type: integer
+                  description: Set or limit time-to-live of the access tokens to the
+                    specified number of seconds. This should be set if the authorization
+                    server returns opaque tokens.
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                      description: The name of the key in the Secret under which the
+                        password is stored.
+                    secretName:
+                      type: string
+                      description: The name of the Secret containing the password.
+                  required:
+                  - password
+                  - secretName
+                  description: Reference to the `Secret` which holds the password.
+                refreshToken:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The key under which the secret value is stored
+                        in the Kubernetes Secret.
+                    secretName:
+                      type: string
+                      description: The name of the Kubernetes Secret containing the
+                        secret value.
+                  required:
+                  - key
+                  - secretName
+                  description: Link to Kubernetes Secret containing the refresh token
+                    which can be used to obtain access token from the authorization
+                    server.
+                scope:
+                  type: string
+                  description: OAuth scope to use when authenticating against the
+                    authorization server. Some authorization servers require this
+                    to be set. The possible values depend on how authorization server
+                    is configured. By default `scope` is not specified when doing
+                    the token endpoint request.
+                tlsTrustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the certificate.
+                    required:
+                    - certificate
+                    - secretName
+                  description: Trusted certificates for TLS connection to the OAuth
+                    server.
+                tokenEndpointUri:
+                  type: string
+                  description: Authorization server token endpoint URI.
+                type:
+                  type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+                  - plain
+                  - oauth
+                  description: Authentication type. Currently the only supported types
+                    are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512` type
+                    uses SASL SCRAM-SHA-512 Authentication. `plain` type uses SASL
+                    PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication.
+                    The `tls` type uses TLS Client Authentication. The `tls` type
+                    is supported only over TLS connections.
+                username:
+                  type: string
+                  description: Username used for the authentication.
+              required:
+              - type
+              description: Authentication configuration for Kafka Connect.
+            bootstrapServers:
+              type: string
+              description: Bootstrap servers to connect to. This should be given as
+                a comma separated list of _<hostname>_:‍_<port>_ pairs.
+            config:
+              type: object
+              description: 'The Kafka Connect configuration. Properties with the following
+                prefixes cannot be set: ssl., sasl., security., listeners, plugin.path,
+                rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes
+                (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites,
+                ssl.protocol, ssl.enabled.protocols).'
+            externalConfiguration:
+              type: object
+              properties:
+                env:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: Name of the environment variable which will be
+                          passed to the Kafka Connect pods. The name of the environment
+                          variable cannot start with `KAFKA_` or `STRIMZI_`.
+                      valueFrom:
+                        type: object
+                        properties:
+                          configMapKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            description: Refernce to a key in a ConfigMap.
+                          secretKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            description: Reference to a key in a Secret.
+                        description: Value of the environment variable which will
+                          be passed to the Kafka Connect pods. It can be passed either
+                          as a reference to Secret or ConfigMap field. The field has
+                          to specify exactly one Secret or ConfigMap.
+                    required:
+                    - name
+                    - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as environment variables.
+                volumes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      configMap:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to a key in a ConfigMap. Exactly one
+                          Secret or ConfigMap has to be specified.
+                      name:
+                        type: string
+                        description: Name of the volume which will be added to the
+                          Kafka Connect pods.
+                      secret:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        description: Reference to a key in a Secret. Exactly one Secret
+                          or ConfigMap has to be specified.
+                    required:
+                    - name
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
+                pods and use them to configure connectors.
+            insecureSourceRepository:
+              type: boolean
+              description: When true this configures the source repository with the
+                'Local' reference policy and an import policy that accepts insecure
+                source tags.
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
+              description: The maximum limits for CPU and memory resources and the
+                requested initial resources.
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the certificate.
+                    required:
+                    - certificate
+                    - secretName
+                  description: Trusted certificates for TLS connection.
+              description: TLS configuration.
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+              description: The pod's tolerations.
+            tracing:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing.
+              required:
+              - type
+              description: The configuration of tracing in Kafka Connect.
+            version:
+              type: string
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
+                Consult the user documentation to understand the process required
+                to upgrade or downgrade the version.
+          required:
+          - bootstrapServers
+          description: The specification of the Kafka Connect Source-to-Image (S2I)
+            cluster.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+            url:
+              type: string
+              description: The URL of the REST API endpoint for managing and monitoring
+                Kafka Connect connectors.
+            connectorPlugins:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The type of the connector plugin. The available types
+                      are `sink` and `source`.
+                  version:
+                    type: string
+                    description: The version of the connector plugin.
+                  class:
+                    type: string
+                    description: The class of the connector plugin.
+              description: The list of connector plugins available in this Kafka Connect
+                deployment.
+            buildConfigName:
+              type: string
+              description: The name of the build configuration.
+            podSelector:
+              type: object
+              properties:
+                matchExpressions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: string
+                matchLabels:
+                  type: object
+              description: Label selector for pods providing this resource.
+            replicas:
+              type: integer
+              description: The current number of pods being used to provide this resource.
+          description: The status of the Kafka Connect Source-to-Image (S2I) cluster.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkamirrormaker2s.kafka.strimzi.io.crd.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkamirrormaker2s.kafka.strimzi.io.crd.yaml
@@ -1,0 +1,1340 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkamirrormaker2s.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaMirrorMaker2
+    listKind: KafkaMirrorMaker2List
+    singular: kafkamirrormaker2
+    plural: kafkamirrormaker2s
+    shortNames:
+    - kmm2
+    categories:
+    - strimzi
+  additionalPrinterColumns:
+  - name: Desired replicas
+    description: The desired number of Kafka MirrorMaker 2.0 replicas
+    JSONPath: .spec.replicas
+    type: integer
+  subresources:
+    status: {}
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+      labelSelectorPath: .status.selector
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              description: The number of pods in the Kafka Connect group.
+            version:
+              type: string
+              description: The Kafka Connect version. Defaults to {DefaultKafkaVersion}.
+                Consult the user documentation to understand the process required
+                to upgrade or downgrade the version.
+            image:
+              type: string
+              description: The docker image for the pods.
+            connectCluster:
+              type: string
+              description: The cluster alias used for Kafka Connect. The alias must
+                match a cluster in the list at `spec.clusters`.
+            clusters:
+              type: array
+              items:
+                type: object
+                properties:
+                  alias:
+                    type: string
+                    pattern: ^[a-zA-Z0-9\._\-]{1,100}$
+                    description: Alias used to reference the Kafka cluster.
+                  bootstrapServers:
+                    type: string
+                    description: A comma-separated list of `host:port` pairs for establishing
+                      the connection to the Kafka cluster.
+                  config:
+                    type: object
+                    description: 'The MirrorMaker 2.0 cluster config. Properties with
+                      the following prefixes cannot be set: ssl., sasl., security.,
+                      listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes,
+                      producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
+                      ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                  tls:
+                    type: object
+                    properties:
+                      trustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the
+                                Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Secret containing the certificate.
+                          required:
+                          - certificate
+                          - secretName
+                        description: Trusted certificates for TLS connection.
+                    description: TLS configuration for connecting MirrorMaker 2.0
+                      connectors to a cluster.
+                  authentication:
+                    type: object
+                    properties:
+                      accessToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored
+                              in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing
+                              the secret value.
+                        required:
+                        - key
+                        - secretName
+                        description: Link to Kubernetes Secret containing the access
+                          token which was obtained from the authorization server.
+                      accessTokenIsJwt:
+                        type: boolean
+                        description: Configure whether access token should be treated
+                          as JWT. This should be set to `false` if the authorization
+                          server returns opaque tokens. Defaults to `true`.
+                      certificateAndKey:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
+                          key:
+                            type: string
+                            description: The name of the private key in the Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the certificate.
+                        required:
+                        - certificate
+                        - key
+                        - secretName
+                        description: Reference to the `Secret` which holds the certificate
+                          and private key pair.
+                      clientId:
+                        type: string
+                        description: OAuth Client ID which the Kafka client can use
+                          to authenticate against the OAuth server and use the token
+                          endpoint URI.
+                      clientSecret:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored
+                              in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing
+                              the secret value.
+                        required:
+                        - key
+                        - secretName
+                        description: Link to Kubernetes Secret containing the OAuth
+                          client secret which the Kafka client can use to authenticate
+                          against the OAuth server and use the token endpoint URI.
+                      disableTlsHostnameVerification:
+                        type: boolean
+                        description: Enable or disable TLS hostname verification.
+                          Default value is `false`.
+                      maxTokenExpirySeconds:
+                        type: integer
+                        description: Set or limit time-to-live of the access tokens
+                          to the specified number of seconds. This should be set if
+                          the authorization server returns opaque tokens.
+                      passwordSecret:
+                        type: object
+                        properties:
+                          password:
+                            type: string
+                            description: The name of the key in the Secret under which
+                              the password is stored.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the password.
+                        required:
+                        - password
+                        - secretName
+                        description: Reference to the `Secret` which holds the password.
+                      refreshToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored
+                              in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing
+                              the secret value.
+                        required:
+                        - key
+                        - secretName
+                        description: Link to Kubernetes Secret containing the refresh
+                          token which can be used to obtain access token from the
+                          authorization server.
+                      scope:
+                        type: string
+                        description: OAuth scope to use when authenticating against
+                          the authorization server. Some authorization servers require
+                          this to be set. The possible values depend on how authorization
+                          server is configured. By default `scope` is not specified
+                          when doing the token endpoint request.
+                      tlsTrustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the
+                                Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Secret containing the certificate.
+                          required:
+                          - certificate
+                          - secretName
+                        description: Trusted certificates for TLS connection to the
+                          OAuth server.
+                      tokenEndpointUri:
+                        type: string
+                        description: Authorization server token endpoint URI.
+                      type:
+                        type: string
+                        enum:
+                        - tls
+                        - scram-sha-512
+                        - plain
+                        - oauth
+                        description: Authentication type. Currently the only supported
+                          types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
+                          type uses SASL SCRAM-SHA-512 Authentication. `plain` type
+                          uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
+                          Authentication. The `tls` type uses TLS Client Authentication.
+                          The `tls` type is supported only over TLS connections.
+                      username:
+                        type: string
+                        description: Username used for the authentication.
+                    required:
+                    - type
+                    description: Authentication configuration for connecting to the
+                      cluster.
+                required:
+                - alias
+                - bootstrapServers
+              description: Kafka clusters for mirroring.
+            mirrors:
+              type: array
+              items:
+                type: object
+                properties:
+                  sourceCluster:
+                    type: string
+                    description: The alias of the source cluster used by the Kafka
+                      MirrorMaker 2.0 connectors. The alias must match a cluster in
+                      the list at `spec.clusters`.
+                  targetCluster:
+                    type: string
+                    description: The alias of the target cluster used by the Kafka
+                      MirrorMaker 2.0 connectors. The alias must match a cluster in
+                      the list at `spec.clusters`.
+                  sourceConnector:
+                    type: object
+                    properties:
+                      tasksMax:
+                        type: integer
+                        minimum: 1
+                        description: The maximum number of tasks for the Kafka Connector.
+                      config:
+                        type: object
+                        description: 'The Kafka Connector configuration. The following
+                          properties cannot be set: connector.class, tasks.max.'
+                      pause:
+                        type: boolean
+                        description: Whether the connector should be paused. Defaults
+                          to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 source
+                      connector.
+                  checkpointConnector:
+                    type: object
+                    properties:
+                      tasksMax:
+                        type: integer
+                        minimum: 1
+                        description: The maximum number of tasks for the Kafka Connector.
+                      config:
+                        type: object
+                        description: 'The Kafka Connector configuration. The following
+                          properties cannot be set: connector.class, tasks.max.'
+                      pause:
+                        type: boolean
+                        description: Whether the connector should be paused. Defaults
+                          to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 checkpoint
+                      connector.
+                  heartbeatConnector:
+                    type: object
+                    properties:
+                      tasksMax:
+                        type: integer
+                        minimum: 1
+                        description: The maximum number of tasks for the Kafka Connector.
+                      config:
+                        type: object
+                        description: 'The Kafka Connector configuration. The following
+                          properties cannot be set: connector.class, tasks.max.'
+                      pause:
+                        type: boolean
+                        description: Whether the connector should be paused. Defaults
+                          to false.
+                    description: The specification of the Kafka MirrorMaker 2.0 heartbeat
+                      connector.
+                  topicsPattern:
+                    type: string
+                    description: A regular expression matching the topics to be mirrored,
+                      for example, "topic1\|topic2\|topic3". Comma-separated lists
+                      are also supported.
+                  topicsBlacklistPattern:
+                    type: string
+                    description: A regular expression matching the topics to exclude
+                      from mirroring. Comma-separated lists are also supported.
+                  groupsPattern:
+                    type: string
+                    description: A regular expression matching the consumer groups
+                      to be mirrored. Comma-separated lists are also supported.
+                  groupsBlacklistPattern:
+                    type: string
+                    description: A regular expression matching the consumer groups
+                      to exclude from mirroring. Comma-separated lists are also supported.
+                required:
+                - sourceCluster
+                - targetCluster
+              description: Configuration of the MirrorMaker 2.0 connectors.
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
+              description: The maximum limits for CPU and memory resources and the
+                requested initial resources.
+            livenessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
+            readinessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
+            jvmOptions:
+              type: object
+              properties:
+                "-XX":
+                  type: object
+                  description: A map of -XX options to the JVM.
+                "-Xms":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM.
+                "-Xmx":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM.
+                gcLoggingEnabled:
+                  type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
+                javaSystemProperties:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: The system property name.
+                      value:
+                        type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods.
+            affinity:
+              type: object
+              properties:
+                nodeAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          preference:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: object
+                      properties:
+                        nodeSelectorTerms:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                podAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+                podAntiAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+              description: The pod's affinity rules.
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+              description: The pod's tolerations.
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                  description: A Map from logger name to logger level.
+                name:
+                  type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
+                type:
+                  type: string
+                  enum:
+                  - inline
+                  - external
+                  description: Logging type, must be either 'inline' or 'external'.
+              required:
+              - type
+              description: Logging configuration for Kafka Connect.
+            metrics:
+              type: object
+              description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                for details of the structure of this configuration.
+            tracing:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing.
+              required:
+              - type
+              description: The configuration of tracing in Kafka Connect.
+            template:
+              type: object
+              properties:
+                deployment:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for Kafka Connect `Deployment`.
+                pod:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                    imagePullSecrets:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod. When
+                        the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster
+                        Operator and the `imagePullSecrets` option are specified,
+                        only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS`
+                        variable is ignored.
+                    securityContext:
+                      type: object
+                      properties:
+                        fsGroup:
+                          type: integer
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        supplementalGroups:
+                          type: array
+                          items:
+                            type: integer
+                        sysctls:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
+                    terminationGracePeriodSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal,
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value to longer than the expected cleanup
+                        time for your process. Value must be a non-negative integer.
+                        A zero value indicates delete immediately. You might need
+                        to increase the grace period for very large Kafka clusters,
+                        so that the Kafka brokers have enough time to transfer their
+                        work to another broker before they are terminated. Defaults
+                        to 30 seconds.
+                    affinity:
+                      type: object
+                      properties:
+                        nodeAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  preference:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: object
+                              properties:
+                                nodeSelectorTerms:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                        podAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                        podAntiAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                      description: The pod's affinity rules.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            type: integer
+                          value:
+                            type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka Connect `Pods`.
+                apiService:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for Kafka Connect API `Service`.
+                connectContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The environment variable key.
+                          value:
+                            type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                    securityContext:
+                      type: object
+                      properties:
+                        allowPrivilegeEscalation:
+                          type: boolean
+                        capabilities:
+                          type: object
+                          properties:
+                            add:
+                              type: array
+                              items:
+                                type: string
+                            drop:
+                              type: array
+                              items:
+                                type: string
+                        privileged:
+                          type: boolean
+                        procMount:
+                          type: string
+                        readOnlyRootFilesystem:
+                          type: boolean
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Security context for the container.
+                  description: Template for the Kafka Connect container.
+                podDisruptionBudget:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
+                    maxUnavailable:
+                      type: integer
+                      minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka Connect `PodDisruptionBudget`.
+              description: Template for Kafka Connect and Kafka Connect S2I resources.
+                The template allows users to specify how the `Deployment`, `Pods`
+                and `Service` are generated.
+            externalConfiguration:
+              type: object
+              properties:
+                env:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: Name of the environment variable which will be
+                          passed to the Kafka Connect pods. The name of the environment
+                          variable cannot start with `KAFKA_` or `STRIMZI_`.
+                      valueFrom:
+                        type: object
+                        properties:
+                          configMapKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            description: Refernce to a key in a ConfigMap.
+                          secretKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            description: Reference to a key in a Secret.
+                        description: Value of the environment variable which will
+                          be passed to the Kafka Connect pods. It can be passed either
+                          as a reference to Secret or ConfigMap field. The field has
+                          to specify exactly one Secret or ConfigMap.
+                    required:
+                    - name
+                    - valueFrom
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as environment variables.
+                volumes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      configMap:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to a key in a ConfigMap. Exactly one
+                          Secret or ConfigMap has to be specified.
+                      name:
+                        type: string
+                        description: Name of the volume which will be added to the
+                          Kafka Connect pods.
+                      secret:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        description: Reference to a key in a Secret. Exactly one Secret
+                          or ConfigMap has to be specified.
+                    required:
+                    - name
+                  description: Allows to pass data from Secret or ConfigMap to the
+                    Kafka Connect pods as volumes.
+              description: Pass data from Secrets or ConfigMaps to the Kafka Connect
+                pods and use them to configure connectors.
+          required:
+          - connectCluster
+          description: The specification of the Kafka MirrorMaker 2.0 cluster.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+            url:
+              type: string
+              description: The URL of the REST API endpoint for managing and monitoring
+                Kafka Connect connectors.
+            connectorPlugins:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The type of the connector plugin. The available types
+                      are `sink` and `source`.
+                  version:
+                    type: string
+                    description: The version of the connector plugin.
+                  class:
+                    type: string
+                    description: The class of the connector plugin.
+              description: The list of connector plugins available in this Kafka Connect
+                deployment.
+            connectors:
+              type: array
+              items:
+                type: object
+              description: List of MirrorMaker 2.0 connector statuses, as reported
+                by the Kafka Connect REST API.
+            podSelector:
+              type: object
+              properties:
+                matchExpressions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: string
+                matchLabels:
+                  type: object
+              description: Label selector for pods providing this resource.
+            replicas:
+              type: integer
+              description: The current number of pods being used to provide this resource.
+          description: The status of the Kafka MirrorMaker 2.0 cluster.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkamirrormakers.kafka.strimzi.io.crd.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkamirrormakers.kafka.strimzi.io.crd.yaml
@@ -1,0 +1,1318 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkamirrormakers.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: KafkaMirrorMaker
+    listKind: KafkaMirrorMakerList
+    singular: kafkamirrormaker
+    plural: kafkamirrormakers
+    shortNames:
+    - kmm
+    categories:
+    - strimzi
+  additionalPrinterColumns:
+  - name: Desired replicas
+    description: The desired number of Kafka MirrorMaker replicas
+    JSONPath: .spec.replicas
+    type: integer
+  - name: Consumer Bootstrap Servers
+    description: The boostrap servers for the consumer
+    JSONPath: .spec.consumer.bootstrapServers
+    type: string
+    priority: 1
+  - name: Producer Bootstrap Servers
+    description: The boostrap servers for the producer
+    JSONPath: .spec.producer.bootstrapServers
+    type: string
+    priority: 1
+  subresources:
+    status: {}
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+      labelSelectorPath: .status.selector
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              minimum: 1
+              description: The number of pods in the `Deployment`.
+            image:
+              type: string
+              description: The docker image for the pods.
+            whitelist:
+              type: string
+              description: List of topics which are included for mirroring. This option
+                allows any regular expression using Java-style regular expressions.
+                Mirroring two topics named A and B is achieved by using the whitelist
+                `'A\|B'`. Or, as a special case, you can mirror all topics using the
+                whitelist '*'. You can also specify multiple regular expressions separated
+                by commas.
+            consumer:
+              type: object
+              properties:
+                numStreams:
+                  type: integer
+                  minimum: 1
+                  description: Specifies the number of consumer stream threads to
+                    create.
+                offsetCommitInterval:
+                  type: integer
+                  description: Specifies the offset auto-commit interval in ms. Default
+                    value is 60000.
+                groupId:
+                  type: string
+                  description: A unique string that identifies the consumer group
+                    this consumer belongs to.
+                bootstrapServers:
+                  type: string
+                  description: A list of host:port pairs for establishing the initial
+                    connection to the Kafka cluster.
+                authentication:
+                  type: object
+                  properties:
+                    accessToken:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
+                      required:
+                      - key
+                      - secretName
+                      description: Link to Kubernetes Secret containing the access
+                        token which was obtained from the authorization server.
+                    accessTokenIsJwt:
+                      type: boolean
+                      description: Configure whether access token should be treated
+                        as JWT. This should be set to `false` if the authorization
+                        server returns opaque tokens. Defaults to `true`.
+                    certificateAndKey:
+                      type: object
+                      properties:
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
+                        key:
+                          type: string
+                          description: The name of the private key in the Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Secret containing the certificate.
+                      required:
+                      - certificate
+                      - key
+                      - secretName
+                      description: Reference to the `Secret` which holds the certificate
+                        and private key pair.
+                    clientId:
+                      type: string
+                      description: OAuth Client ID which the Kafka client can use
+                        to authenticate against the OAuth server and use the token
+                        endpoint URI.
+                    clientSecret:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
+                      required:
+                      - key
+                      - secretName
+                      description: Link to Kubernetes Secret containing the OAuth
+                        client secret which the Kafka client can use to authenticate
+                        against the OAuth server and use the token endpoint URI.
+                    disableTlsHostnameVerification:
+                      type: boolean
+                      description: Enable or disable TLS hostname verification. Default
+                        value is `false`.
+                    maxTokenExpirySeconds:
+                      type: integer
+                      description: Set or limit time-to-live of the access tokens
+                        to the specified number of seconds. This should be set if
+                        the authorization server returns opaque tokens.
+                    passwordSecret:
+                      type: object
+                      properties:
+                        password:
+                          type: string
+                          description: The name of the key in the Secret under which
+                            the password is stored.
+                        secretName:
+                          type: string
+                          description: The name of the Secret containing the password.
+                      required:
+                      - password
+                      - secretName
+                      description: Reference to the `Secret` which holds the password.
+                    refreshToken:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
+                      required:
+                      - key
+                      - secretName
+                      description: Link to Kubernetes Secret containing the refresh
+                        token which can be used to obtain access token from the authorization
+                        server.
+                    scope:
+                      type: string
+                      description: OAuth scope to use when authenticating against
+                        the authorization server. Some authorization servers require
+                        this to be set. The possible values depend on how authorization
+                        server is configured. By default `scope` is not specified
+                        when doing the token endpoint request.
+                    tlsTrustedCertificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the certificate.
+                        required:
+                        - certificate
+                        - secretName
+                      description: Trusted certificates for TLS connection to the
+                        OAuth server.
+                    tokenEndpointUri:
+                      type: string
+                      description: Authorization server token endpoint URI.
+                    type:
+                      type: string
+                      enum:
+                      - tls
+                      - scram-sha-512
+                      - plain
+                      - oauth
+                      description: Authentication type. Currently the only supported
+                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
+                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
+                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
+                        Authentication. The `tls` type uses TLS Client Authentication.
+                        The `tls` type is supported only over TLS connections.
+                    username:
+                      type: string
+                      description: Username used for the authentication.
+                  required:
+                  - type
+                  description: Authentication configuration for connecting to the
+                    cluster.
+                config:
+                  type: object
+                  description: 'The MirrorMaker consumer config. Properties with the
+                    following prefixes cannot be set: ssl., bootstrap.servers, group.id,
+                    sasl., security., interceptor.classes (with the exception of:
+                    ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol,
+                    ssl.enabled.protocols).'
+                tls:
+                  type: object
+                  properties:
+                    trustedCertificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the certificate.
+                        required:
+                        - certificate
+                        - secretName
+                      description: Trusted certificates for TLS connection.
+                  description: TLS configuration for connecting MirrorMaker to the
+                    cluster.
+              required:
+              - groupId
+              - bootstrapServers
+              description: Configuration of source cluster.
+            producer:
+              type: object
+              properties:
+                bootstrapServers:
+                  type: string
+                  description: A list of host:port pairs for establishing the initial
+                    connection to the Kafka cluster.
+                abortOnSendFailure:
+                  type: boolean
+                  description: Flag to set the MirrorMaker to exit on a failed send.
+                    Default value is `true`.
+                authentication:
+                  type: object
+                  properties:
+                    accessToken:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
+                      required:
+                      - key
+                      - secretName
+                      description: Link to Kubernetes Secret containing the access
+                        token which was obtained from the authorization server.
+                    accessTokenIsJwt:
+                      type: boolean
+                      description: Configure whether access token should be treated
+                        as JWT. This should be set to `false` if the authorization
+                        server returns opaque tokens. Defaults to `true`.
+                    certificateAndKey:
+                      type: object
+                      properties:
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
+                        key:
+                          type: string
+                          description: The name of the private key in the Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Secret containing the certificate.
+                      required:
+                      - certificate
+                      - key
+                      - secretName
+                      description: Reference to the `Secret` which holds the certificate
+                        and private key pair.
+                    clientId:
+                      type: string
+                      description: OAuth Client ID which the Kafka client can use
+                        to authenticate against the OAuth server and use the token
+                        endpoint URI.
+                    clientSecret:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
+                      required:
+                      - key
+                      - secretName
+                      description: Link to Kubernetes Secret containing the OAuth
+                        client secret which the Kafka client can use to authenticate
+                        against the OAuth server and use the token endpoint URI.
+                    disableTlsHostnameVerification:
+                      type: boolean
+                      description: Enable or disable TLS hostname verification. Default
+                        value is `false`.
+                    maxTokenExpirySeconds:
+                      type: integer
+                      description: Set or limit time-to-live of the access tokens
+                        to the specified number of seconds. This should be set if
+                        the authorization server returns opaque tokens.
+                    passwordSecret:
+                      type: object
+                      properties:
+                        password:
+                          type: string
+                          description: The name of the key in the Secret under which
+                            the password is stored.
+                        secretName:
+                          type: string
+                          description: The name of the Secret containing the password.
+                      required:
+                      - password
+                      - secretName
+                      description: Reference to the `Secret` which holds the password.
+                    refreshToken:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: The key under which the secret value is stored
+                            in the Kubernetes Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Kubernetes Secret containing
+                            the secret value.
+                      required:
+                      - key
+                      - secretName
+                      description: Link to Kubernetes Secret containing the refresh
+                        token which can be used to obtain access token from the authorization
+                        server.
+                    scope:
+                      type: string
+                      description: OAuth scope to use when authenticating against
+                        the authorization server. Some authorization servers require
+                        this to be set. The possible values depend on how authorization
+                        server is configured. By default `scope` is not specified
+                        when doing the token endpoint request.
+                    tlsTrustedCertificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the certificate.
+                        required:
+                        - certificate
+                        - secretName
+                      description: Trusted certificates for TLS connection to the
+                        OAuth server.
+                    tokenEndpointUri:
+                      type: string
+                      description: Authorization server token endpoint URI.
+                    type:
+                      type: string
+                      enum:
+                      - tls
+                      - scram-sha-512
+                      - plain
+                      - oauth
+                      description: Authentication type. Currently the only supported
+                        types are `tls`, `scram-sha-512`, and `plain`. `scram-sha-512`
+                        type uses SASL SCRAM-SHA-512 Authentication. `plain` type
+                        uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER
+                        Authentication. The `tls` type uses TLS Client Authentication.
+                        The `tls` type is supported only over TLS connections.
+                    username:
+                      type: string
+                      description: Username used for the authentication.
+                  required:
+                  - type
+                  description: Authentication configuration for connecting to the
+                    cluster.
+                config:
+                  type: object
+                  description: 'The MirrorMaker producer config. Properties with the
+                    following prefixes cannot be set: ssl., bootstrap.servers, sasl.,
+                    security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm,
+                    ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).'
+                tls:
+                  type: object
+                  properties:
+                    trustedCertificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the certificate.
+                        required:
+                        - certificate
+                        - secretName
+                      description: Trusted certificates for TLS connection.
+                  description: TLS configuration for connecting MirrorMaker to the
+                    cluster.
+              required:
+              - bootstrapServers
+              description: Configuration of target cluster.
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                requests:
+                  type: object
+              description: CPU and memory resources to reserve.
+            affinity:
+              type: object
+              properties:
+                nodeAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          preference:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: object
+                      properties:
+                        nodeSelectorTerms:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                podAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+                podAntiAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+              description: The pod's affinity rules.
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+              description: The pod's tolerations.
+            jvmOptions:
+              type: object
+              properties:
+                "-XX":
+                  type: object
+                  description: A map of -XX options to the JVM.
+                "-Xms":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xms option to to the JVM.
+                "-Xmx":
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                  description: -Xmx option to to the JVM.
+                gcLoggingEnabled:
+                  type: boolean
+                  description: Specifies whether the Garbage Collection logging is
+                    enabled. The default is false.
+                javaSystemProperties:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: The system property name.
+                      value:
+                        type: string
+                        description: The system property value.
+                  description: A map of additional system properties which will be
+                    passed using the `-D` option to the JVM.
+              description: JVM Options for pods.
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                  description: A Map from logger name to logger level.
+                name:
+                  type: string
+                  description: The name of the `ConfigMap` from which to get the logging
+                    configuration.
+                type:
+                  type: string
+                  enum:
+                  - inline
+                  - external
+                  description: Logging type, must be either 'inline' or 'external'.
+              required:
+              - type
+              description: Logging configuration for MirrorMaker.
+            metrics:
+              type: object
+              description: The Prometheus JMX Exporter configuration. See {JMXExporter}
+                for details of the structure of this configuration.
+            tracing:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - jaeger
+                  description: Type of the tracing used. Currently the only supported
+                    type is `jaeger` for Jaeger tracing.
+              required:
+              - type
+              description: The configuration of tracing in Kafka MirrorMaker.
+            template:
+              type: object
+              properties:
+                deployment:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for Kafka MirrorMaker `Deployment`.
+                pod:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                    imagePullSecrets:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      description: List of references to secrets in the same namespace
+                        to use for pulling any of the images used by this Pod. When
+                        the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster
+                        Operator and the `imagePullSecrets` option are specified,
+                        only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS`
+                        variable is ignored.
+                    securityContext:
+                      type: object
+                      properties:
+                        fsGroup:
+                          type: integer
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        supplementalGroups:
+                          type: array
+                          items:
+                            type: integer
+                        sysctls:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Configures pod-level security attributes and common
+                        container settings.
+                    terminationGracePeriodSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The grace period is the duration in seconds after
+                        the processes running in the pod are sent a termination signal,
+                        and the time when the processes are forcibly halted with a
+                        kill signal. Set this value to longer than the expected cleanup
+                        time for your process. Value must be a non-negative integer.
+                        A zero value indicates delete immediately. You might need
+                        to increase the grace period for very large Kafka clusters,
+                        so that the Kafka brokers have enough time to transfer their
+                        work to another broker before they are terminated. Defaults
+                        to 30 seconds.
+                    affinity:
+                      type: object
+                      properties:
+                        nodeAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  preference:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: object
+                              properties:
+                                nodeSelectorTerms:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchFields:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                        podAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                        podAntiAffinity:
+                          type: object
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  podAffinityTerm:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                                  weight:
+                                    type: integer
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                      description: The pod's affinity rules.
+                    priorityClassName:
+                      type: string
+                      description: The name of the priority class used to assign priority
+                        to the pods. For more information about priority classes,
+                        see {K8sPriorityClass}.
+                    schedulerName:
+                      type: string
+                      description: The name of the scheduler used to dispatch this
+                        `Pod`. If not specified, the default scheduler will be used.
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            type: integer
+                          value:
+                            type: string
+                      description: The pod's tolerations.
+                  description: Template for Kafka MirrorMaker `Pods`.
+                mirrorMakerContainer:
+                  type: object
+                  properties:
+                    env:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The environment variable key.
+                          value:
+                            type: string
+                            description: The environment variable value.
+                      description: Environment variables which should be applied to
+                        the container.
+                    securityContext:
+                      type: object
+                      properties:
+                        allowPrivilegeEscalation:
+                          type: boolean
+                        capabilities:
+                          type: object
+                          properties:
+                            add:
+                              type: array
+                              items:
+                                type: string
+                            drop:
+                              type: array
+                              items:
+                                type: string
+                        privileged:
+                          type: boolean
+                        procMount:
+                          type: string
+                        readOnlyRootFilesystem:
+                          type: boolean
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        windowsOptions:
+                          type: object
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                      description: Security context for the container.
+                  description: Template for Kafka MirrorMaker container.
+                podDisruptionBudget:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                        resource.
+                    maxUnavailable:
+                      type: integer
+                      minimum: 0
+                      description: Maximum number of unavailable pods to allow automatic
+                        Pod eviction. A Pod eviction is allowed when the `maxUnavailable`
+                        number of pods or fewer are unavailable after the eviction.
+                        Setting this value to 0 prevents all voluntary evictions,
+                        so the pods must be evicted manually. Defaults to 1.
+                  description: Template for Kafka MirrorMaker `PodDisruptionBudget`.
+              description: Template to specify how Kafka MirrorMaker resources, `Deployments`
+                and `Pods`, are generated.
+            livenessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod liveness checking.
+            readinessProbe:
+              type: object
+              properties:
+                failureThreshold:
+                  type: integer
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded. Defaults to 3. Minimum value is
+                    1.
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                  description: The initial delay before first the health is first
+                    checked.
+                periodSeconds:
+                  type: integer
+                  description: How often (in seconds) to perform the probe. Default
+                    to 10 seconds. Minimum value is 1.
+                successThreshold:
+                  type: integer
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed. Defaults to 1. Must be 1 for liveness.
+                    Minimum value is 1.
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: The timeout for each attempted health check.
+              description: Pod readiness checking.
+            version:
+              type: string
+              description: The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}.
+                Consult the documentation to understand the process required to upgrade
+                or downgrade the version.
+          required:
+          - replicas
+          - whitelist
+          - consumer
+          - producer
+          description: The specification of Kafka MirrorMaker.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+            podSelector:
+              type: object
+              properties:
+                matchExpressions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: string
+                matchLabels:
+                  type: object
+              description: Label selector for pods providing this resource.
+            replicas:
+              type: integer
+              description: The current number of pods being used to provide this resource.
+          description: The status of Kafka MirrorMaker.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkarebalances.kafka.strimzi.io.crd.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkarebalances.kafka.strimzi.io.crd.yaml
@@ -1,0 +1,117 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkarebalances.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaRebalance
+    listKind: KafkaRebalanceList
+    singular: kafkarebalance
+    plural: kafkarebalances
+    shortNames:
+    - kr
+    categories:
+    - strimzi
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            goals:
+              type: array
+              items:
+                type: string
+              description: A list of goals, ordered by decreasing priority, to use
+                for generating and executing the rebalance proposal. The supported
+                goals are available at https://github.com/linkedin/cruise-control#goals.
+                If an empty goals list is provided, the goals declared in the default.goals
+                Cruise Control configuration parameter are used.
+            skipHardGoalCheck:
+              type: boolean
+              description: Whether to allow the hard goals specified in the Kafka
+                CR to be skipped in optimization proposal generation. This can be
+                useful when some of those hard goals are preventing a balance solution
+                being found. Default is false.
+            excludedTopics:
+              type: string
+              description: A regular expression where any matching topics will be
+                excluded from the calculation of optimization proposals. This expression
+                will be parsed by the java.util.regex.Pattern class; for more information
+                on the supported formar consult the documentation for that class.
+            concurrentPartitionMovementsPerBroker:
+              type: integer
+              minimum: 0
+              description: The upper bound of ongoing partition replica movements
+                going into/out of each broker. Default is 5.
+            concurrentIntraBrokerPartitionMovements:
+              type: integer
+              minimum: 0
+              description: The upper bound of ongoing partition replica movements
+                between disks within each broker. Default is 2.
+            concurrentLeaderMovements:
+              type: integer
+              minimum: 0
+              description: The upper bound of ongoing partition leadership movements.
+                Default is 1000.
+            replicationThrottle:
+              type: integer
+              minimum: 0
+              description: The upper bound, in bytes per second, on the bandwidth
+                used to move replicas. There is no limit by default.
+          description: The specification of the Kafka rebalance.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+            sessionId:
+              type: string
+              description: The session identifier for requests to Cruise Control pertaining
+                to this KafkaRebalance resource. This is used by the Kafka Rebalance
+                operator to track the status of ongoing rebalancing operations.
+            optimizationResult:
+              type: object
+              description: A JSON object describing the optimization result.
+          description: The status of the Kafka rebalance.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkas.kafka.strimzi.io.crd.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkas.kafka.strimzi.io.crd.yaml
@@ -1,0 +1,6852 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkas.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: Kafka
+    listKind: KafkaList
+    singular: kafka
+    plural: kafkas
+    shortNames:
+    - k
+    categories:
+    - strimzi
+  additionalPrinterColumns:
+  - name: Desired Kafka replicas
+    description: The desired number of Kafka replicas in the cluster
+    JSONPath: .spec.kafka.replicas
+    type: integer
+  - name: Desired ZK replicas
+    description: The desired number of ZooKeeper replicas in the cluster
+    JSONPath: .spec.zookeeper.replicas
+    type: integer
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            kafka:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                  minimum: 1
+                  description: The number of pods in the cluster.
+                image:
+                  type: string
+                  description: The docker image for the pods. The default value depends
+                    on the configured `Kafka.spec.kafka.version`.
+                storage:
+                  type: object
+                  properties:
+                    class:
+                      type: string
+                      description: The storage class to use for dynamic volume allocation.
+                    deleteClaim:
+                      type: boolean
+                      description: Specifies if the persistent volume claim has to
+                        be deleted when the cluster is un-deployed.
+                    id:
+                      type: integer
+                      minimum: 0
+                      description: Storage identification number. It is mandatory
+                        only for storage volumes defined in a storage of type 'jbod'.
+                    overrides:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                            description: The storage class to use for dynamic volume
+                              allocation for this broker.
+                          broker:
+                            type: integer
+                            description: Id of the kafka broker (broker identifier).
+                      description: Overrides for individual brokers. The `overrides`
+                        field allows to specify a different configuration for different
+                        brokers.
+                    selector:
+                      type: object
+                      description: Specifies a specific persistent volume to use.
+                        It contains key:value pairs representing labels for selecting
+                        such a volume.
+                    size:
+                      type: string
+                      description: When type=persistent-claim, defines the size of
+                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
+                    sizeLimit:
+                      type: string
+                      pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      description: When type=ephemeral, defines the total amount of
+                        local storage required for this EmptyDir volume (for example
+                        1Gi).
+                    type:
+                      type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                      - jbod
+                      description: Storage type, must be either 'ephemeral', 'persistent-claim',
+                        or 'jbod'.
+                    volumes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                            description: The storage class to use for dynamic volume
+                              allocation.
+                          deleteClaim:
+                            type: boolean
+                            description: Specifies if the persistent volume claim
+                              has to be deleted when the cluster is un-deployed.
+                          id:
+                            type: integer
+                            minimum: 0
+                            description: Storage identification number. It is mandatory
+                              only for storage volumes defined in a storage of type
+                              'jbod'.
+                          overrides:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                class:
+                                  type: string
+                                  description: The storage class to use for dynamic
+                                    volume allocation for this broker.
+                                broker:
+                                  type: integer
+                                  description: Id of the kafka broker (broker identifier).
+                            description: Overrides for individual brokers. The `overrides`
+                              field allows to specify a different configuration for
+                              different brokers.
+                          selector:
+                            type: object
+                            description: Specifies a specific persistent volume to
+                              use. It contains key:value pairs representing labels
+                              for selecting such a volume.
+                          size:
+                            type: string
+                            description: When type=persistent-claim, defines the size
+                              of the persistent volume claim (i.e 1Gi). Mandatory
+                              when type=persistent-claim.
+                          sizeLimit:
+                            type: string
+                            pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                            description: When type=ephemeral, defines the total amount
+                              of local storage required for this EmptyDir volume (for
+                              example 1Gi).
+                          type:
+                            type: string
+                            enum:
+                            - ephemeral
+                            - persistent-claim
+                            description: Storage type, must be either 'ephemeral'
+                              or 'persistent-claim'.
+                        required:
+                        - type
+                      description: List of volumes as Storage objects representing
+                        the JBOD disks array.
+                  required:
+                  - type
+                  description: Storage configuration (disk). Cannot be updated.
+                listeners:
+                  type: object
+                  properties:
+                    plain:
+                      type: object
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            accessTokenIsJwt:
+                              type: boolean
+                              description: Configure whether the access token is treated
+                                as JWT. This must be set to `false` if the authorization
+                                server returns opaque tokens. Defaults to `true`.
+                            checkAccessTokenType:
+                              type: boolean
+                              description: Configure whether the access token type
+                                check is performed or not. This should be set to `false`
+                                if the authorization server does not include 'typ'
+                                claim in JWT token. Defaults to `true`.
+                            checkIssuer:
+                              type: boolean
+                              description: Enable or disable issuer checking. By default
+                                issuer is checked using the value configured by `validIssuerUri`.
+                                Default value is `true`.
+                            clientId:
+                              type: string
+                              description: OAuth Client ID which the Kafka broker
+                                can use to authenticate against the authorization
+                                server and use the introspect endpoint URI.
+                            clientSecret:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                  description: The key under which the secret value
+                                    is stored in the Kubernetes Secret.
+                                secretName:
+                                  type: string
+                                  description: The name of the Kubernetes Secret containing
+                                    the secret value.
+                              required:
+                              - key
+                              - secretName
+                              description: Link to Kubernetes Secret containing the
+                                OAuth client secret which the Kafka broker can use
+                                to authenticate against the authorization server and
+                                use the introspect endpoint URI.
+                            disableTlsHostnameVerification:
+                              type: boolean
+                              description: Enable or disable TLS hostname verification.
+                                Default value is `false`.
+                            enableECDSA:
+                              type: boolean
+                              description: Enable or disable ECDSA support by installing
+                                BouncyCastle crypto provider. Default value is `false`.
+                            fallbackUserNameClaim:
+                              type: string
+                              description: The fallback username claim to be used
+                                for the user id if the claim specified by `userNameClaim`
+                                is not present. This is useful when `client_credentials`
+                                authentication only results in the client id being
+                                provided in another claim. It only takes effect if
+                                `userNameClaim` is set.
+                            fallbackUserNamePrefix:
+                              type: string
+                              description: The prefix to use with the value of `fallbackUserNameClaim`
+                                to construct the user id. This only takes effect if
+                                `fallbackUserNameClaim` is true, and the value is
+                                present for the claim. Mapping usernames and client
+                                ids into the same user id space is useful in preventing
+                                name collisions.
+                            introspectionEndpointUri:
+                              type: string
+                              description: URI of the token introspection endpoint
+                                which can be used to validate opaque non-JWT tokens.
+                            jwksEndpointUri:
+                              type: string
+                              description: URI of the JWKS certificate endpoint, which
+                                can be used for local JWT validation.
+                            jwksExpirySeconds:
+                              type: integer
+                              minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                considered valid. The expiry interval has to be at
+                                least 60 seconds longer then the refresh interval
+                                specified in `jwksRefreshSeconds`. Defaults to 360
+                                seconds.
+                            jwksRefreshSeconds:
+                              type: integer
+                              minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                refreshed. The refresh interval has to be at least
+                                60 seconds shorter then the expiry interval specified
+                                in `jwksExpirySeconds`. Defaults to 300 seconds.
+                            tlsTrustedCertificates:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  certificate:
+                                    type: string
+                                    description: The name of the file certificate
+                                      in the Secret.
+                                  secretName:
+                                    type: string
+                                    description: The name of the Secret containing
+                                      the certificate.
+                                required:
+                                - certificate
+                                - secretName
+                              description: Trusted certificates for TLS connection
+                                to the OAuth server.
+                            type:
+                              type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                              - oauth
+                              description: Authentication type. `oauth` type uses
+                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
+                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
+                                uses TLS Client Authentication. `tls` type is supported
+                                only on TLS listeners.
+                            userInfoEndpointUri:
+                              type: string
+                              description: 'URI of the User Info Endpoint to use as
+                                a fallback to obtaining the user id when the Introspection
+                                Endpoint does not return information that can be used
+                                for the user id. '
+                            userNameClaim:
+                              type: string
+                              description: Name of the claim from the JWT authentication
+                                token, Introspection Endpoint response or User Info
+                                Endpoint response which will be used to extract the
+                                user id. Defaults to `sub`.
+                            validIssuerUri:
+                              type: string
+                              description: URI of the token issuer used for authentication.
+                            validTokenType:
+                              type: string
+                              description: Valid value for the `token_type` attribute
+                                returned by the Introspection Endpoint. No default
+                                value, and not checked by default.
+                          required:
+                          - type
+                          description: 'Authentication configuration for this listener.
+                            Since this listener does not use TLS transport you cannot
+                            configure an authentication with `type: tls`.'
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                          description: List of peers which should be able to connect
+                            to this listener. Peers in this list are combined using
+                            a logical OR operation. If this field is empty or missing,
+                            all connections will be allowed for this listener. If
+                            this field is present and contains at least one item,
+                            the listener only allows the traffic which matches at
+                            least one item in this list.
+                      description: Configures plain listener on port 9092.
+                    tls:
+                      type: object
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            accessTokenIsJwt:
+                              type: boolean
+                              description: Configure whether the access token is treated
+                                as JWT. This must be set to `false` if the authorization
+                                server returns opaque tokens. Defaults to `true`.
+                            checkAccessTokenType:
+                              type: boolean
+                              description: Configure whether the access token type
+                                check is performed or not. This should be set to `false`
+                                if the authorization server does not include 'typ'
+                                claim in JWT token. Defaults to `true`.
+                            checkIssuer:
+                              type: boolean
+                              description: Enable or disable issuer checking. By default
+                                issuer is checked using the value configured by `validIssuerUri`.
+                                Default value is `true`.
+                            clientId:
+                              type: string
+                              description: OAuth Client ID which the Kafka broker
+                                can use to authenticate against the authorization
+                                server and use the introspect endpoint URI.
+                            clientSecret:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                  description: The key under which the secret value
+                                    is stored in the Kubernetes Secret.
+                                secretName:
+                                  type: string
+                                  description: The name of the Kubernetes Secret containing
+                                    the secret value.
+                              required:
+                              - key
+                              - secretName
+                              description: Link to Kubernetes Secret containing the
+                                OAuth client secret which the Kafka broker can use
+                                to authenticate against the authorization server and
+                                use the introspect endpoint URI.
+                            disableTlsHostnameVerification:
+                              type: boolean
+                              description: Enable or disable TLS hostname verification.
+                                Default value is `false`.
+                            enableECDSA:
+                              type: boolean
+                              description: Enable or disable ECDSA support by installing
+                                BouncyCastle crypto provider. Default value is `false`.
+                            fallbackUserNameClaim:
+                              type: string
+                              description: The fallback username claim to be used
+                                for the user id if the claim specified by `userNameClaim`
+                                is not present. This is useful when `client_credentials`
+                                authentication only results in the client id being
+                                provided in another claim. It only takes effect if
+                                `userNameClaim` is set.
+                            fallbackUserNamePrefix:
+                              type: string
+                              description: The prefix to use with the value of `fallbackUserNameClaim`
+                                to construct the user id. This only takes effect if
+                                `fallbackUserNameClaim` is true, and the value is
+                                present for the claim. Mapping usernames and client
+                                ids into the same user id space is useful in preventing
+                                name collisions.
+                            introspectionEndpointUri:
+                              type: string
+                              description: URI of the token introspection endpoint
+                                which can be used to validate opaque non-JWT tokens.
+                            jwksEndpointUri:
+                              type: string
+                              description: URI of the JWKS certificate endpoint, which
+                                can be used for local JWT validation.
+                            jwksExpirySeconds:
+                              type: integer
+                              minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                considered valid. The expiry interval has to be at
+                                least 60 seconds longer then the refresh interval
+                                specified in `jwksRefreshSeconds`. Defaults to 360
+                                seconds.
+                            jwksRefreshSeconds:
+                              type: integer
+                              minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                refreshed. The refresh interval has to be at least
+                                60 seconds shorter then the expiry interval specified
+                                in `jwksExpirySeconds`. Defaults to 300 seconds.
+                            tlsTrustedCertificates:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  certificate:
+                                    type: string
+                                    description: The name of the file certificate
+                                      in the Secret.
+                                  secretName:
+                                    type: string
+                                    description: The name of the Secret containing
+                                      the certificate.
+                                required:
+                                - certificate
+                                - secretName
+                              description: Trusted certificates for TLS connection
+                                to the OAuth server.
+                            type:
+                              type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                              - oauth
+                              description: Authentication type. `oauth` type uses
+                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
+                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
+                                uses TLS Client Authentication. `tls` type is supported
+                                only on TLS listeners.
+                            userInfoEndpointUri:
+                              type: string
+                              description: 'URI of the User Info Endpoint to use as
+                                a fallback to obtaining the user id when the Introspection
+                                Endpoint does not return information that can be used
+                                for the user id. '
+                            userNameClaim:
+                              type: string
+                              description: Name of the claim from the JWT authentication
+                                token, Introspection Endpoint response or User Info
+                                Endpoint response which will be used to extract the
+                                user id. Defaults to `sub`.
+                            validIssuerUri:
+                              type: string
+                              description: URI of the token issuer used for authentication.
+                            validTokenType:
+                              type: string
+                              description: Valid value for the `token_type` attribute
+                                returned by the Introspection Endpoint. No default
+                                value, and not checked by default.
+                          required:
+                          - type
+                          description: Authentication configuration for this listener.
+                        configuration:
+                          type: object
+                          properties:
+                            brokerCertChainAndKey:
+                              type: object
+                              properties:
+                                certificate:
+                                  type: string
+                                  description: The name of the file certificate in
+                                    the Secret.
+                                key:
+                                  type: string
+                                  description: The name of the private key in the
+                                    Secret.
+                                secretName:
+                                  type: string
+                                  description: The name of the Secret containing the
+                                    certificate.
+                              required:
+                              - certificate
+                              - key
+                              - secretName
+                              description: Reference to the `Secret` which holds the
+                                certificate and private key pair. The certificate
+                                can optionally contain the whole chain.
+                          description: Configuration of TLS listener.
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                          description: List of peers which should be able to connect
+                            to this listener. Peers in this list are combined using
+                            a logical OR operation. If this field is empty or missing,
+                            all connections will be allowed for this listener. If
+                            this field is present and contains at least one item,
+                            the listener only allows the traffic which matches at
+                            least one item in this list.
+                      description: Configures TLS listener on port 9093.
+                    external:
+                      type: object
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            accessTokenIsJwt:
+                              type: boolean
+                              description: Configure whether the access token is treated
+                                as JWT. This must be set to `false` if the authorization
+                                server returns opaque tokens. Defaults to `true`.
+                            checkAccessTokenType:
+                              type: boolean
+                              description: Configure whether the access token type
+                                check is performed or not. This should be set to `false`
+                                if the authorization server does not include 'typ'
+                                claim in JWT token. Defaults to `true`.
+                            checkIssuer:
+                              type: boolean
+                              description: Enable or disable issuer checking. By default
+                                issuer is checked using the value configured by `validIssuerUri`.
+                                Default value is `true`.
+                            clientId:
+                              type: string
+                              description: OAuth Client ID which the Kafka broker
+                                can use to authenticate against the authorization
+                                server and use the introspect endpoint URI.
+                            clientSecret:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                  description: The key under which the secret value
+                                    is stored in the Kubernetes Secret.
+                                secretName:
+                                  type: string
+                                  description: The name of the Kubernetes Secret containing
+                                    the secret value.
+                              required:
+                              - key
+                              - secretName
+                              description: Link to Kubernetes Secret containing the
+                                OAuth client secret which the Kafka broker can use
+                                to authenticate against the authorization server and
+                                use the introspect endpoint URI.
+                            disableTlsHostnameVerification:
+                              type: boolean
+                              description: Enable or disable TLS hostname verification.
+                                Default value is `false`.
+                            enableECDSA:
+                              type: boolean
+                              description: Enable or disable ECDSA support by installing
+                                BouncyCastle crypto provider. Default value is `false`.
+                            fallbackUserNameClaim:
+                              type: string
+                              description: The fallback username claim to be used
+                                for the user id if the claim specified by `userNameClaim`
+                                is not present. This is useful when `client_credentials`
+                                authentication only results in the client id being
+                                provided in another claim. It only takes effect if
+                                `userNameClaim` is set.
+                            fallbackUserNamePrefix:
+                              type: string
+                              description: The prefix to use with the value of `fallbackUserNameClaim`
+                                to construct the user id. This only takes effect if
+                                `fallbackUserNameClaim` is true, and the value is
+                                present for the claim. Mapping usernames and client
+                                ids into the same user id space is useful in preventing
+                                name collisions.
+                            introspectionEndpointUri:
+                              type: string
+                              description: URI of the token introspection endpoint
+                                which can be used to validate opaque non-JWT tokens.
+                            jwksEndpointUri:
+                              type: string
+                              description: URI of the JWKS certificate endpoint, which
+                                can be used for local JWT validation.
+                            jwksExpirySeconds:
+                              type: integer
+                              minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                considered valid. The expiry interval has to be at
+                                least 60 seconds longer then the refresh interval
+                                specified in `jwksRefreshSeconds`. Defaults to 360
+                                seconds.
+                            jwksRefreshSeconds:
+                              type: integer
+                              minimum: 1
+                              description: Configures how often are the JWKS certificates
+                                refreshed. The refresh interval has to be at least
+                                60 seconds shorter then the expiry interval specified
+                                in `jwksExpirySeconds`. Defaults to 300 seconds.
+                            tlsTrustedCertificates:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  certificate:
+                                    type: string
+                                    description: The name of the file certificate
+                                      in the Secret.
+                                  secretName:
+                                    type: string
+                                    description: The name of the Secret containing
+                                      the certificate.
+                                required:
+                                - certificate
+                                - secretName
+                              description: Trusted certificates for TLS connection
+                                to the OAuth server.
+                            type:
+                              type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                              - oauth
+                              description: Authentication type. `oauth` type uses
+                                SASL OAUTHBEARER Authentication. `scram-sha-512` type
+                                uses SASL SCRAM-SHA-512 Authentication. `tls` type
+                                uses TLS Client Authentication. `tls` type is supported
+                                only on TLS listeners.
+                            userInfoEndpointUri:
+                              type: string
+                              description: 'URI of the User Info Endpoint to use as
+                                a fallback to obtaining the user id when the Introspection
+                                Endpoint does not return information that can be used
+                                for the user id. '
+                            userNameClaim:
+                              type: string
+                              description: Name of the claim from the JWT authentication
+                                token, Introspection Endpoint response or User Info
+                                Endpoint response which will be used to extract the
+                                user id. Defaults to `sub`.
+                            validIssuerUri:
+                              type: string
+                              description: URI of the token issuer used for authentication.
+                            validTokenType:
+                              type: string
+                              description: Valid value for the `token_type` attribute
+                                returned by the Introspection Endpoint. No default
+                                value, and not checked by default.
+                          required:
+                          - type
+                          description: Authentication configuration for Kafka brokers.
+                        class:
+                          type: string
+                          description: Configures the `Ingress` class that defines
+                            which `Ingress` controller will be used. If not set, the
+                            `Ingress` class is set to `nginx`.
+                        configuration:
+                          type: object
+                          properties:
+                            bootstrap:
+                              type: object
+                              properties:
+                                address:
+                                  type: string
+                                  description: Additional address name for the bootstrap
+                                    service. The address will be added to the list
+                                    of subject alternative names of the TLS certificates.
+                                dnsAnnotations:
+                                  type: object
+                                  description: Annotations that will be added to the
+                                    `Ingress` resource. You can use this field to
+                                    configure DNS providers such as External DNS.
+                                host:
+                                  type: string
+                                  description: Host for the bootstrap route. This
+                                    field will be used in the Ingress resource.
+                              required:
+                              - host
+                              description: External bootstrap ingress configuration.
+                            brokers:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  broker:
+                                    type: integer
+                                    description: Id of the kafka broker (broker identifier).
+                                  advertisedHost:
+                                    type: string
+                                    description: The host name which will be used
+                                      in the brokers' `advertised.brokers`.
+                                  advertisedPort:
+                                    type: integer
+                                    description: The port number which will be used
+                                      in the brokers' `advertised.brokers`.
+                                  host:
+                                    type: string
+                                    description: Host for the broker ingress. This
+                                      field will be used in the Ingress resource.
+                                  dnsAnnotations:
+                                    type: object
+                                    description: Annotations that will be added to
+                                      the `Ingress` resources for individual brokers.
+                                      You can use this field to configure DNS providers
+                                      such as External DNS.
+                                required:
+                                - host
+                              description: External broker ingress configuration.
+                            brokerCertChainAndKey:
+                              type: object
+                              properties:
+                                certificate:
+                                  type: string
+                                  description: The name of the file certificate in
+                                    the Secret.
+                                key:
+                                  type: string
+                                  description: The name of the private key in the
+                                    Secret.
+                                secretName:
+                                  type: string
+                                  description: The name of the Secret containing the
+                                    certificate.
+                              required:
+                              - certificate
+                              - key
+                              - secretName
+                              description: Reference to the `Secret` which holds the
+                                certificate and private key pair. The certificate
+                                can optionally contain the whole chain.
+                          description: External listener configuration.
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                          description: List of peers which should be able to connect
+                            to this listener. Peers in this list are combined using
+                            a logical OR operation. If this field is empty or missing,
+                            all connections will be allowed for this listener. If
+                            this field is present and contains at least one item,
+                            the listener only allows the traffic which matches at
+                            least one item in this list.
+                        overrides:
+                          type: object
+                          properties:
+                            bootstrap:
+                              type: object
+                              properties:
+                                address:
+                                  type: string
+                                  description: Additional address name for the bootstrap
+                                    service. The address will be added to the list
+                                    of subject alternative names of the TLS certificates.
+                                dnsAnnotations:
+                                  type: object
+                                  description: Annotations that will be added to the
+                                    `Service` resource. You can use this field to
+                                    configure DNS providers such as External DNS.
+                                nodePort:
+                                  type: integer
+                                  description: Node port for the bootstrap service.
+                              description: External bootstrap service configuration.
+                            brokers:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  broker:
+                                    type: integer
+                                    description: Id of the kafka broker (broker identifier).
+                                  advertisedHost:
+                                    type: string
+                                    description: The host name which will be used
+                                      in the brokers' `advertised.brokers`.
+                                  advertisedPort:
+                                    type: integer
+                                    description: The port number which will be used
+                                      in the brokers' `advertised.brokers`.
+                                  nodePort:
+                                    type: integer
+                                    description: Node port for the broker service.
+                                  dnsAnnotations:
+                                    type: object
+                                    description: Annotations that will be added to
+                                      the `Service` resources for individual brokers.
+                                      You can use this field to configure DNS providers
+                                      such as External DNS.
+                              description: External broker services configuration.
+                          description: Overrides for external bootstrap and broker
+                            services and externally advertised addresses.
+                        tls:
+                          type: boolean
+                          description: Enables TLS encryption on the listener. By
+                            default set to `true` for enabled TLS encryption.
+                        type:
+                          type: string
+                          enum:
+                          - route
+                          - loadbalancer
+                          - nodeport
+                          - ingress
+                          description: "Type of the external listener. Currently the\
+                            \ supported types are `route`, `loadbalancer`, and `nodeport`.\
+                            \ \n\n* `route` type uses OpenShift Routes to expose Kafka.*\
+                            \ `loadbalancer` type uses LoadBalancer type services\
+                            \ to expose Kafka.* `nodeport` type uses NodePort type\
+                            \ services to expose Kafka.."
+                      required:
+                      - type
+                      description: Configures external listener on port 9094.
+                  description: Configures listeners of Kafka brokers.
+                authorization:
+                  type: object
+                  properties:
+                    allowOnError:
+                      type: boolean
+                      description: Defines whether a Kafka client should be allowed
+                        or denied by default when the authorizer fails to query the
+                        Open Policy Agent, for example, when it is temporarily unavailable).
+                        Defaults to `false` - all actions will be denied.
+                    clientId:
+                      type: string
+                      description: OAuth Client ID which the Kafka client can use
+                        to authenticate against the OAuth server and use the token
+                        endpoint URI.
+                    delegateToKafkaAcls:
+                      type: boolean
+                      description: Whether authorization decision should be delegated
+                        to the 'Simple' authorizer if DENIED by Keycloak Authorization
+                        Services policies.Default value is `false`.
+                    disableTlsHostnameVerification:
+                      type: boolean
+                      description: Enable or disable TLS hostname verification. Default
+                        value is `false`.
+                    expireAfterMs:
+                      type: integer
+                      description: The expiration of the records kept in the local
+                        cache to avoid querying the Open Policy Agent for every request.
+                        Defines how often the cached authorization decisions are reloaded
+                        from the Open Policy Agent server. In milliseconds. Defaults
+                        to `3600000`.
+                    initialCacheCapacity:
+                      type: integer
+                      description: Initial capacity of the local cache used by the
+                        authorizer to avoid querying the Open Policy Agent for every
+                        request Defaults to `5000`.
+                    maximumCacheSize:
+                      type: integer
+                      description: Maximum capacity of the local cache used by the
+                        authorizer to avoid querying the Open Policy Agent for every
+                        request. Defaults to `50000`.
+                    superUsers:
+                      type: array
+                      items:
+                        type: string
+                      description: List of super users. Should contain list of user
+                        principals which should get unlimited access rights.
+                    tlsTrustedCertificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the certificate.
+                        required:
+                        - certificate
+                        - secretName
+                      description: Trusted certificates for TLS connection to the
+                        OAuth server.
+                    tokenEndpointUri:
+                      type: string
+                      description: Authorization server token endpoint URI.
+                    type:
+                      type: string
+                      enum:
+                      - simple
+                      - opa
+                      - keycloak
+                      description: Authorization type. Currently, the supported types
+                        are `simple`, `keycloak`, and `opa`. `simple` authorization
+                        type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer`
+                        class for authorization. `keycloak` authorization type uses
+                        Keycloak Authorization Services for authorization. `opa` authorization
+                        type uses Open Policy Agent based authorization.
+                    url:
+                      type: string
+                      example: http://opa:8181/v1/data/kafka/authz/allow
+                      description: The URL used to connect to the Open Policy Agent
+                        server. The URL has to include the policy which will be queried
+                        by the authorizer. This option is required.
+                  required:
+                  - type
+                  description: Authorization configuration for Kafka brokers.
+                config:
+                  type: object
+                  description: 'Kafka broker config properties with the following
+                    prefixes cannot be set: listeners, advertised., broker., listener.,
+                    host.name, port, inter.broker.listener.name, sasl., ssl., security.,
+                    password., principal.builder.class, log.dir, zookeeper.connect,
+                    zookeeper.set.acl, authorizer., super.user, cruise.control.metrics.topic,
+                    cruise.control.metrics.reporter.bootstrap.servers (with the exception
+                    of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol,
+                    ssl.enabled.protocols,cruise.control.metrics.topic.num.partitions,
+                    cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries,
+                    cruise.control.metrics.topic.auto.create.timeout.ms).'
+                rack:
+                  type: object
+                  properties:
+                    topologyKey:
+                      type: string
+                      example: topology.kubernetes.io/zone
+                      description: A key that matches labels assigned to the Kubernetes
+                        cluster nodes. The value of the label is used to set the broker's
+                        `broker.rack` config.
+                  required:
+                  - topologyKey
+                  description: Configuration of the `broker.rack` broker config.
+                brokerRackInitImage:
+                  type: string
+                  description: The image of the init container used for initializing
+                    the `broker.rack`.
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                  description: The pod's affinity rules.
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                  description: The pod's tolerations.
+                livenessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking.
+                readinessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking.
+                jvmOptions:
+                  type: object
+                  properties:
+                    "-XX":
+                      type: object
+                      description: A map of -XX options to the JVM.
+                    "-Xms":
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                      description: -Xms option to to the JVM.
+                    "-Xmx":
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                      description: -Xmx option to to the JVM.
+                    gcLoggingEnabled:
+                      type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
+                    javaSystemProperties:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The system property name.
+                          value:
+                            type: string
+                            description: The system property value.
+                      description: A map of additional system properties which will
+                        be passed using the `-D` option to the JVM.
+                  description: JVM Options for pods.
+                jmxOptions:
+                  type: object
+                  properties:
+                    authentication:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                          - password
+                          description: Authentication type. Currently the only supported
+                            types are `password`.`password` type creates a username
+                            and protected port with no TLS.
+                      required:
+                      - type
+                      description: Authentication configuration for connecting to
+                        the Kafka JMX port.
+                  description: JMX Options for Kafka brokers.
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                    requests:
+                      type: object
+                  description: CPU and memory resources to reserve.
+                metrics:
+                  type: object
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                    for details of the structure of this configuration.
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                      description: A Map from logger name to logger level.
+                    name:
+                      type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
+                    type:
+                      type: string
+                      enum:
+                      - inline
+                      - external
+                      description: Logging type, must be either 'inline' or 'external'.
+                  required:
+                  - type
+                  description: Logging configuration for Kafka.
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                      description: The docker image for the container.
+                    livenessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
+                    readinessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                        requests:
+                          type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration.
+                template:
+                  type: object
+                  properties:
+                    statefulset:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        podManagementPolicy:
+                          type: string
+                          enum:
+                          - OrderedReady
+                          - Parallel
+                          description: PodManagementPolicy which will be used for
+                            this StatefulSet. Valid values are `Parallel` and `OrderedReady`.
+                            Defaults to `Parallel`.
+                      description: Template for Kafka `StatefulSet`.
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        imagePullSecrets:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
+                            When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable
+                            in Cluster Operator and the `imagePullSecrets` option
+                            are specified, only the `imagePullSecrets` variable is
+                            used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is
+                            ignored.
+                        securityContext:
+                          type: object
+                          properties:
+                            fsGroup:
+                              type: integer
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal, and the time when the processes are forcibly halted
+                            with a kill signal. Set this value to longer than the
+                            expected cleanup time for your process. Value must be
+                            a non-negative integer. A zero value indicates delete
+                            immediately. You might need to increase the grace period
+                            for very large Kafka clusters, so that the Kafka brokers
+                            have enough time to transfer their work to another broker
+                            before they are terminated. Defaults to 30 seconds.
+                        affinity:
+                          type: object
+                          properties:
+                            nodeAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      preference:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: object
+                                  properties:
+                                    nodeSelectorTerms:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                            podAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                            podAntiAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                          description: The pod's affinity rules.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                type: integer
+                              value:
+                                type: string
+                          description: The pod's tolerations.
+                      description: Template for Kafka `Pods`.
+                    bootstrapService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka bootstrap `Service`.
+                    brokersService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka broker `Service`.
+                    externalBootstrapService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        externalTrafficPolicy:
+                          type: string
+                          enum:
+                          - Local
+                          - Cluster
+                          description: Specifies whether the service routes external
+                            traffic to node-local or cluster-wide endpoints. `Cluster`
+                            may cause a second hop to another node and obscures the
+                            client source IP. `Local` avoids a second hop for LoadBalancer
+                            and Nodeport type services and preserves the client source
+                            IP (when supported by the infrastructure). If unspecified,
+                            Kubernetes will use `Cluster` as the default.
+                        loadBalancerSourceRanges:
+                          type: array
+                          items:
+                            type: string
+                          description: A list of CIDR ranges (for example `10.0.0.0/8`
+                            or `130.211.204.1/32`) from which clients can connect
+                            to load balancer type listeners. If supported by the platform,
+                            traffic through the loadbalancer is restricted to the
+                            specified CIDR ranges. This field is applicable only for
+                            loadbalancer type services and is ignored if the cloud
+                            provider does not support the feature. For more information,
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+                      description: Template for Kafka external bootstrap `Service`.
+                    perPodService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        externalTrafficPolicy:
+                          type: string
+                          enum:
+                          - Local
+                          - Cluster
+                          description: Specifies whether the service routes external
+                            traffic to node-local or cluster-wide endpoints. `Cluster`
+                            may cause a second hop to another node and obscures the
+                            client source IP. `Local` avoids a second hop for LoadBalancer
+                            and Nodeport type services and preserves the client source
+                            IP (when supported by the infrastructure). If unspecified,
+                            Kubernetes will use `Cluster` as the default.
+                        loadBalancerSourceRanges:
+                          type: array
+                          items:
+                            type: string
+                          description: A list of CIDR ranges (for example `10.0.0.0/8`
+                            or `130.211.204.1/32`) from which clients can connect
+                            to load balancer type listeners. If supported by the platform,
+                            traffic through the loadbalancer is restricted to the
+                            specified CIDR ranges. This field is applicable only for
+                            loadbalancer type services and is ignored if the cloud
+                            provider does not support the feature. For more information,
+                            see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/.
+                      description: Template for Kafka per-pod `Services` used for
+                        access from outside of Kubernetes.
+                    externalBootstrapRoute:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka external bootstrap `Route`.
+                    perPodRoute:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka per-pod `Routes` used for access
+                        from outside of OpenShift.
+                    externalBootstrapIngress:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka external bootstrap `Ingress`.
+                    perPodIngress:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka per-pod `Ingress` used for access
+                        from outside of Kubernetes.
+                    persistentVolumeClaim:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for all Kafka `PersistentVolumeClaims`.
+                    podDisruptionBudget:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                            resource.
+                        maxUnavailable:
+                          type: integer
+                          minimum: 0
+                          description: Maximum number of unavailable pods to allow
+                            automatic Pod eviction. A Pod eviction is allowed when
+                            the `maxUnavailable` number of pods or fewer are unavailable
+                            after the eviction. Setting this value to 0 prevents all
+                            voluntary evictions, so the pods must be evicted manually.
+                            Defaults to 1.
+                      description: Template for Kafka `PodDisruptionBudget`.
+                    kafkaContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Kafka broker container.
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Kafka broker TLS sidecar container.
+                    initContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Kafka init container.
+                  description: Template for Kafka cluster resources. The template
+                    allows users to specify how are the `StatefulSet`, `Pods` and
+                    `Services` generated.
+                version:
+                  type: string
+                  description: The kafka broker version. Defaults to {DefaultKafkaVersion}.
+                    Consult the user documentation to understand the process required
+                    to upgrade or downgrade the version.
+              required:
+              - replicas
+              - storage
+              - listeners
+              description: Configuration of the Kafka cluster.
+            zookeeper:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                  minimum: 1
+                  description: The number of pods in the cluster.
+                image:
+                  type: string
+                  description: The docker image for the pods.
+                storage:
+                  type: object
+                  properties:
+                    class:
+                      type: string
+                      description: The storage class to use for dynamic volume allocation.
+                    deleteClaim:
+                      type: boolean
+                      description: Specifies if the persistent volume claim has to
+                        be deleted when the cluster is un-deployed.
+                    id:
+                      type: integer
+                      minimum: 0
+                      description: Storage identification number. It is mandatory
+                        only for storage volumes defined in a storage of type 'jbod'.
+                    overrides:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                            description: The storage class to use for dynamic volume
+                              allocation for this broker.
+                          broker:
+                            type: integer
+                            description: Id of the kafka broker (broker identifier).
+                      description: Overrides for individual brokers. The `overrides`
+                        field allows to specify a different configuration for different
+                        brokers.
+                    selector:
+                      type: object
+                      description: Specifies a specific persistent volume to use.
+                        It contains key:value pairs representing labels for selecting
+                        such a volume.
+                    size:
+                      type: string
+                      description: When type=persistent-claim, defines the size of
+                        the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.
+                    sizeLimit:
+                      type: string
+                      pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                      description: When type=ephemeral, defines the total amount of
+                        local storage required for this EmptyDir volume (for example
+                        1Gi).
+                    type:
+                      type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                      description: Storage type, must be either 'ephemeral' or 'persistent-claim'.
+                  required:
+                  - type
+                  description: Storage configuration (disk). Cannot be updated.
+                config:
+                  type: object
+                  description: 'The ZooKeeper broker config. Properties with the following
+                    prefixes cannot be set: server., dataDir, dataLogDir, clientPort,
+                    authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty,
+                    standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort,
+                    ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol,
+                    ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols,
+                    ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification,
+                    ssl.quorum.hostnameVerification).'
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                  description: The pod's affinity rules.
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                  description: The pod's tolerations.
+                livenessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking.
+                readinessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking.
+                jvmOptions:
+                  type: object
+                  properties:
+                    "-XX":
+                      type: object
+                      description: A map of -XX options to the JVM.
+                    "-Xms":
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                      description: -Xms option to to the JVM.
+                    "-Xmx":
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                      description: -Xmx option to to the JVM.
+                    gcLoggingEnabled:
+                      type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
+                    javaSystemProperties:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The system property name.
+                          value:
+                            type: string
+                            description: The system property value.
+                      description: A map of additional system properties which will
+                        be passed using the `-D` option to the JVM.
+                  description: JVM Options for pods.
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                    requests:
+                      type: object
+                  description: CPU and memory resources to reserve.
+                metrics:
+                  type: object
+                  description: The Prometheus JMX Exporter configuration. See https://github.com/prometheus/jmx_exporter
+                    for details of the structure of this configuration.
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                      description: A Map from logger name to logger level.
+                    name:
+                      type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
+                    type:
+                      type: string
+                      enum:
+                      - inline
+                      - external
+                      description: Logging type, must be either 'inline' or 'external'.
+                  required:
+                  - type
+                  description: Logging configuration for ZooKeeper.
+                template:
+                  type: object
+                  properties:
+                    statefulset:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        podManagementPolicy:
+                          type: string
+                          enum:
+                          - OrderedReady
+                          - Parallel
+                          description: PodManagementPolicy which will be used for
+                            this StatefulSet. Valid values are `Parallel` and `OrderedReady`.
+                            Defaults to `Parallel`.
+                      description: Template for ZooKeeper `StatefulSet`.
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        imagePullSecrets:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
+                            When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable
+                            in Cluster Operator and the `imagePullSecrets` option
+                            are specified, only the `imagePullSecrets` variable is
+                            used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is
+                            ignored.
+                        securityContext:
+                          type: object
+                          properties:
+                            fsGroup:
+                              type: integer
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal, and the time when the processes are forcibly halted
+                            with a kill signal. Set this value to longer than the
+                            expected cleanup time for your process. Value must be
+                            a non-negative integer. A zero value indicates delete
+                            immediately. You might need to increase the grace period
+                            for very large Kafka clusters, so that the Kafka brokers
+                            have enough time to transfer their work to another broker
+                            before they are terminated. Defaults to 30 seconds.
+                        affinity:
+                          type: object
+                          properties:
+                            nodeAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      preference:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: object
+                                  properties:
+                                    nodeSelectorTerms:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                            podAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                            podAntiAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                          description: The pod's affinity rules.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                type: integer
+                              value:
+                                type: string
+                          description: The pod's tolerations.
+                      description: Template for ZooKeeper `Pods`.
+                    clientService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for ZooKeeper client `Service`.
+                    nodesService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for ZooKeeper nodes `Service`.
+                    persistentVolumeClaim:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for all ZooKeeper `PersistentVolumeClaims`.
+                    podDisruptionBudget:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                            resource.
+                        maxUnavailable:
+                          type: integer
+                          minimum: 0
+                          description: Maximum number of unavailable pods to allow
+                            automatic Pod eviction. A Pod eviction is allowed when
+                            the `maxUnavailable` number of pods or fewer are unavailable
+                            after the eviction. Setting this value to 0 prevents all
+                            voluntary evictions, so the pods must be evicted manually.
+                            Defaults to 1.
+                      description: Template for ZooKeeper `PodDisruptionBudget`.
+                    zookeeperContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the ZooKeeper container.
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Zookeeper server TLS sidecar container.
+                        The TLS sidecar is not used anymore and this option will be
+                        ignored.
+                  description: Template for ZooKeeper cluster resources. The template
+                    allows users to specify how are the `StatefulSet`, `Pods` and
+                    `Services` generated.
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                      description: The docker image for the container.
+                    livenessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
+                    readinessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                        requests:
+                          type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration. The TLS sidecar is not used
+                    anymore and this option will be ignored.
+              required:
+              - replicas
+              - storage
+              description: Configuration of the ZooKeeper cluster.
+            topicOperator:
+              type: object
+              properties:
+                watchedNamespace:
+                  type: string
+                  description: The namespace the Topic Operator should watch.
+                image:
+                  type: string
+                  description: The image to use for the Topic Operator.
+                reconciliationIntervalSeconds:
+                  type: integer
+                  minimum: 0
+                  description: Interval between periodic reconciliations.
+                zookeeperSessionTimeoutSeconds:
+                  type: integer
+                  minimum: 0
+                  description: Timeout for the ZooKeeper session.
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                  description: Pod affinity rules.
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                    requests:
+                      type: object
+                  description: CPU and memory resources to reserve.
+                topicMetadataMaxAttempts:
+                  type: integer
+                  minimum: 0
+                  description: The number of attempts at getting topic metadata.
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                      description: The docker image for the container.
+                    livenessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
+                    readinessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                        requests:
+                          type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration.
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                      description: A Map from logger name to logger level.
+                    name:
+                      type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
+                    type:
+                      type: string
+                      enum:
+                      - inline
+                      - external
+                      description: Logging type, must be either 'inline' or 'external'.
+                  required:
+                  - type
+                  description: Logging configuration.
+                jvmOptions:
+                  type: object
+                  properties:
+                    "-XX":
+                      type: object
+                      description: A map of -XX options to the JVM.
+                    "-Xms":
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                      description: -Xms option to to the JVM.
+                    "-Xmx":
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                      description: -Xmx option to to the JVM.
+                    gcLoggingEnabled:
+                      type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
+                    javaSystemProperties:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The system property name.
+                          value:
+                            type: string
+                            description: The system property value.
+                      description: A map of additional system properties which will
+                        be passed using the `-D` option to the JVM.
+                  description: JVM Options for pods.
+                livenessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking.
+                readinessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking.
+              description: Configuration of the Topic Operator.
+            entityOperator:
+              type: object
+              properties:
+                topicOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                      description: The namespace the Topic Operator should watch.
+                    image:
+                      type: string
+                      description: The image to use for the Topic Operator.
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                      description: Interval between periodic reconciliations.
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: Timeout for the ZooKeeper session.
+                    livenessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
+                    readinessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                        requests:
+                          type: object
+                      description: CPU and memory resources to reserve.
+                    topicMetadataMaxAttempts:
+                      type: integer
+                      minimum: 0
+                      description: The number of attempts at getting topic metadata.
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                          description: A Map from logger name to logger level.
+                        name:
+                          type: string
+                          description: The name of the `ConfigMap` from which to get
+                            the logging configuration.
+                        type:
+                          type: string
+                          enum:
+                          - inline
+                          - external
+                          description: Logging type, must be either 'inline' or 'external'.
+                      required:
+                      - type
+                      description: Logging configuration.
+                    jvmOptions:
+                      type: object
+                      properties:
+                        "-XX":
+                          type: object
+                          description: A map of -XX options to the JVM.
+                        "-Xms":
+                          type: string
+                          pattern: '[0-9]+[mMgG]?'
+                          description: -Xms option to to the JVM.
+                        "-Xmx":
+                          type: string
+                          pattern: '[0-9]+[mMgG]?'
+                          description: -Xmx option to to the JVM.
+                        gcLoggingEnabled:
+                          type: boolean
+                          description: Specifies whether the Garbage Collection logging
+                            is enabled. The default is false.
+                        javaSystemProperties:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The system property name.
+                              value:
+                                type: string
+                                description: The system property value.
+                          description: A map of additional system properties which
+                            will be passed using the `-D` option to the JVM.
+                      description: JVM Options for pods.
+                  description: Configuration of the Topic Operator.
+                userOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                      description: The namespace the User Operator should watch.
+                    image:
+                      type: string
+                      description: The image to use for the User Operator.
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                      description: Interval between periodic reconciliations.
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: Timeout for the ZooKeeper session.
+                    livenessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
+                    readinessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                        requests:
+                          type: object
+                      description: CPU and memory resources to reserve.
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                          description: A Map from logger name to logger level.
+                        name:
+                          type: string
+                          description: The name of the `ConfigMap` from which to get
+                            the logging configuration.
+                        type:
+                          type: string
+                          enum:
+                          - inline
+                          - external
+                          description: Logging type, must be either 'inline' or 'external'.
+                      required:
+                      - type
+                      description: Logging configuration.
+                    jvmOptions:
+                      type: object
+                      properties:
+                        "-XX":
+                          type: object
+                          description: A map of -XX options to the JVM.
+                        "-Xms":
+                          type: string
+                          pattern: '[0-9]+[mMgG]?'
+                          description: -Xms option to to the JVM.
+                        "-Xmx":
+                          type: string
+                          pattern: '[0-9]+[mMgG]?'
+                          description: -Xmx option to to the JVM.
+                        gcLoggingEnabled:
+                          type: boolean
+                          description: Specifies whether the Garbage Collection logging
+                            is enabled. The default is false.
+                        javaSystemProperties:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The system property name.
+                              value:
+                                type: string
+                                description: The system property value.
+                          description: A map of additional system properties which
+                            will be passed using the `-D` option to the JVM.
+                      description: JVM Options for pods.
+                  description: Configuration of the User Operator.
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                  description: The pod's affinity rules.
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                  description: The pod's tolerations.
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                      description: The docker image for the container.
+                    livenessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
+                    readinessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                        requests:
+                          type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration.
+                template:
+                  type: object
+                  properties:
+                    deployment:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Entity Operator `Deployment`.
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        imagePullSecrets:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
+                            When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable
+                            in Cluster Operator and the `imagePullSecrets` option
+                            are specified, only the `imagePullSecrets` variable is
+                            used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is
+                            ignored.
+                        securityContext:
+                          type: object
+                          properties:
+                            fsGroup:
+                              type: integer
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal, and the time when the processes are forcibly halted
+                            with a kill signal. Set this value to longer than the
+                            expected cleanup time for your process. Value must be
+                            a non-negative integer. A zero value indicates delete
+                            immediately. You might need to increase the grace period
+                            for very large Kafka clusters, so that the Kafka brokers
+                            have enough time to transfer their work to another broker
+                            before they are terminated. Defaults to 30 seconds.
+                        affinity:
+                          type: object
+                          properties:
+                            nodeAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      preference:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: object
+                                  properties:
+                                    nodeSelectorTerms:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                            podAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                            podAntiAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                          description: The pod's affinity rules.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                type: integer
+                              value:
+                                type: string
+                          description: The pod's tolerations.
+                      description: Template for Entity Operator `Pods`.
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Entity Operator TLS sidecar container.
+                    topicOperatorContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Entity Topic Operator container.
+                    userOperatorContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Entity User Operator container.
+                  description: Template for Entity Operator resources. The template
+                    allows users to specify how is the `Deployment` and `Pods` generated.
+              description: Configuration of the Entity Operator.
+            clusterCa:
+              type: object
+              properties:
+                generateCertificateAuthority:
+                  type: boolean
+                  description: If true then Certificate Authority certificates will
+                    be generated automatically. Otherwise the user will need to provide
+                    a Secret with the CA certificate. Default is true.
+                validityDays:
+                  type: integer
+                  minimum: 1
+                  description: The number of days generated certificates should be
+                    valid for. The default is 365.
+                renewalDays:
+                  type: integer
+                  minimum: 1
+                  description: The number of days in the certificate renewal period.
+                    This is the number of days before the a certificate expires during
+                    which renewal actions may be performed. When `generateCertificateAuthority`
+                    is true, this will cause the generation of a new certificate.
+                    When `generateCertificateAuthority` is true, this will cause extra
+                    logging at WARN level about the pending certificate expiry. Default
+                    is 30.
+                certificateExpirationPolicy:
+                  type: string
+                  enum:
+                  - renew-certificate
+                  - replace-key
+                  description: How should CA certificate expiration be handled when
+                    `generateCertificateAuthority=true`. The default is for a new
+                    CA certificate to be generated reusing the existing private key.
+              description: Configuration of the cluster certificate authority.
+            clientsCa:
+              type: object
+              properties:
+                generateCertificateAuthority:
+                  type: boolean
+                  description: If true then Certificate Authority certificates will
+                    be generated automatically. Otherwise the user will need to provide
+                    a Secret with the CA certificate. Default is true.
+                validityDays:
+                  type: integer
+                  minimum: 1
+                  description: The number of days generated certificates should be
+                    valid for. The default is 365.
+                renewalDays:
+                  type: integer
+                  minimum: 1
+                  description: The number of days in the certificate renewal period.
+                    This is the number of days before the a certificate expires during
+                    which renewal actions may be performed. When `generateCertificateAuthority`
+                    is true, this will cause the generation of a new certificate.
+                    When `generateCertificateAuthority` is true, this will cause extra
+                    logging at WARN level about the pending certificate expiry. Default
+                    is 30.
+                certificateExpirationPolicy:
+                  type: string
+                  enum:
+                  - renew-certificate
+                  - replace-key
+                  description: How should CA certificate expiration be handled when
+                    `generateCertificateAuthority=true`. The default is for a new
+                    CA certificate to be generated reusing the existing private key.
+              description: Configuration of the clients certificate authority.
+            cruiseControl:
+              type: object
+              properties:
+                image:
+                  type: string
+                  description: The docker image for the pods.
+                config:
+                  type: object
+                  description: 'The Cruise Control configuration. For a full list
+                    of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations.
+                    Note that properties with the following prefixes cannot be set:
+                    bootstrap.servers, client.id, zookeeper., network., security.,
+                    failed.brokers.zk.path,webserver.http., webserver.api.urlprefix,
+                    webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers,
+                    metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file,
+                    self.healing., anomaly.detection., ssl.'
+                livenessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness checking for the Cruise Control container.
+                readinessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness checking for the Cruise Control container.
+                jvmOptions:
+                  type: object
+                  properties:
+                    "-XX":
+                      type: object
+                      description: A map of -XX options to the JVM.
+                    "-Xms":
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                      description: -Xms option to to the JVM.
+                    "-Xmx":
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                      description: -Xmx option to to the JVM.
+                    gcLoggingEnabled:
+                      type: boolean
+                      description: Specifies whether the Garbage Collection logging
+                        is enabled. The default is false.
+                    javaSystemProperties:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The system property name.
+                          value:
+                            type: string
+                            description: The system property value.
+                      description: A map of additional system properties which will
+                        be passed using the `-D` option to the JVM.
+                  description: JVM Options for the Cruise Control container.
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                    requests:
+                      type: object
+                  description: CPU and memory resources to reserve for the Cruise
+                    Control container.
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                      description: A Map from logger name to logger level.
+                    name:
+                      type: string
+                      description: The name of the `ConfigMap` from which to get the
+                        logging configuration.
+                    type:
+                      type: string
+                      enum:
+                      - inline
+                      - external
+                      description: Logging type, must be either 'inline' or 'external'.
+                  required:
+                  - type
+                  description: Logging configuration (log4j1) for Cruise Control.
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                      description: The docker image for the container.
+                    livenessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod liveness checking.
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
+                      description: The log level for the TLS sidecar. Default value
+                        is `notice`.
+                    readinessProbe:
+                      type: object
+                      properties:
+                        failureThreshold:
+                          type: integer
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is
+                            first checked.
+                        periodSeconds:
+                          type: integer
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The timeout for each attempted health check.
+                      description: Pod readiness checking.
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                        requests:
+                          type: object
+                      description: CPU and memory resources to reserve.
+                  description: TLS sidecar configuration.
+                template:
+                  type: object
+                  properties:
+                    deployment:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Cruise Control `Deployment`.
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        imagePullSecrets:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
+                            When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable
+                            in Cluster Operator and the `imagePullSecrets` option
+                            are specified, only the `imagePullSecrets` variable is
+                            used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is
+                            ignored.
+                        securityContext:
+                          type: object
+                          properties:
+                            fsGroup:
+                              type: integer
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal, and the time when the processes are forcibly halted
+                            with a kill signal. Set this value to longer than the
+                            expected cleanup time for your process. Value must be
+                            a non-negative integer. A zero value indicates delete
+                            immediately. You might need to increase the grace period
+                            for very large Kafka clusters, so that the Kafka brokers
+                            have enough time to transfer their work to another broker
+                            before they are terminated. Defaults to 30 seconds.
+                        affinity:
+                          type: object
+                          properties:
+                            nodeAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      preference:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: object
+                                  properties:
+                                    nodeSelectorTerms:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                            podAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                            podAntiAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                          description: The pod's affinity rules.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                type: integer
+                              value:
+                                type: string
+                          description: The pod's tolerations.
+                      description: Template for Cruise Control `Pods`.
+                    apiService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Cruise Control API `Service`.
+                    podDisruptionBudget:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata to apply to the `PodDistruptionBugetTemplate`
+                            resource.
+                        maxUnavailable:
+                          type: integer
+                          minimum: 0
+                          description: Maximum number of unavailable pods to allow
+                            automatic Pod eviction. A Pod eviction is allowed when
+                            the `maxUnavailable` number of pods or fewer are unavailable
+                            after the eviction. Setting this value to 0 prevents all
+                            voluntary evictions, so the pods must be evicted manually.
+                            Defaults to 1.
+                      description: Template for Cruise Control `PodDisruptionBudget`.
+                    cruiseControlContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Cruise Control container.
+                    tlsSidecarContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Cruise Control TLS sidecar container.
+                  description: Template to specify how Cruise Control resources, `Deployments`
+                    and `Pods`, are generated.
+                brokerCapacity:
+                  type: object
+                  properties:
+                    disk:
+                      type: string
+                      pattern: ^[0-9]+([.][0-9]*)?([KMGTPE]i?|e[0-9]+)?$
+                      description: Broker capacity for disk in bytes, for example,
+                        100Gi.
+                    cpuUtilization:
+                      type: integer
+                      minimum: 0
+                      maximum: 100
+                      description: Broker capacity for CPU resource utilization as
+                        a percentage (0 - 100).
+                    inboundNetwork:
+                      type: string
+                      pattern: '[0-9]+([KMG]i?)?B/s'
+                      description: Broker capacity for inbound network throughput
+                        in bytes per second, for example, 10000KB/s.
+                    outboundNetwork:
+                      type: string
+                      pattern: '[0-9]+([KMG]i?)?B/s'
+                      description: Broker capacity for outbound network throughput
+                        in bytes per second, for example 10000KB/s.
+                  description: The Cruise Control `brokerCapacity` configuration.
+              description: Configuration for Cruise Control deployment. Deploys a
+                Cruise Control instance when specified.
+            jmxTrans:
+              type: object
+              properties:
+                image:
+                  type: string
+                  description: The image to use for the JmxTrans.
+                outputDefinitions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      outputType:
+                        type: string
+                        description: Template for setting the format of the data that
+                          will be pushed.For more information see https://github.com/jmxtrans/jmxtrans/wiki/OutputWriters[JmxTrans
+                          OutputWriters].
+                      host:
+                        type: string
+                        description: The DNS/hostname of the remote host that the
+                          data is pushed to.
+                      port:
+                        type: integer
+                        description: The port of the remote host that the data is
+                          pushed to.
+                      flushDelayInSeconds:
+                        type: integer
+                        description: How many seconds the JmxTrans waits before pushing
+                          a new set of data out.
+                      typeNames:
+                        type: array
+                        items:
+                          type: string
+                        description: Template for filtering data to be included in
+                          response to a wildcard query. For more information see https://github.com/jmxtrans/jmxtrans/wiki/Queries[JmxTrans
+                          queries].
+                      name:
+                        type: string
+                        description: Template for setting the name of the output definition.
+                          This is used to identify where to send the results of queries
+                          should be sent.
+                    required:
+                    - outputType
+                    - name
+                  description: Defines the output hosts that will be referenced later
+                    on. For more information on these properties see, xref:type-JmxTransOutputDefinitionTemplate-reference[`JmxTransOutputDefinitionTemplate`
+                    schema reference].
+                logLevel:
+                  type: string
+                  description: Sets the logging level of the JmxTrans deployment.For
+                    more information see, https://github.com/jmxtrans/jmxtrans-agent/wiki/Troubleshooting[JmxTrans
+                    Logging Level].
+                kafkaQueries:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      targetMBean:
+                        type: string
+                        description: If using wildcards instead of a specific MBean
+                          then the data is gathered from multiple MBeans. Otherwise
+                          if specifying an MBean then data is gathered from that specified
+                          MBean.
+                      attributes:
+                        type: array
+                        items:
+                          type: string
+                        description: Determine which attributes of the targeted MBean
+                          should be included.
+                      outputs:
+                        type: array
+                        items:
+                          type: string
+                        description: List of the names of output definitions specified
+                          in the spec.kafka.jmxTrans.outputDefinitions that have defined
+                          where JMX metrics are pushed to, and in which data format.
+                    required:
+                    - targetMBean
+                    - attributes
+                    - outputs
+                  description: Queries to send to the Kafka brokers to define what
+                    data should be read from each broker. For more information on
+                    these properties see, xref:type-JmxTransQueryTemplate-reference[`JmxTransQueryTemplate`
+                    schema reference].
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                    requests:
+                      type: object
+                  description: CPU and memory resources to reserve.
+                template:
+                  type: object
+                  properties:
+                    deployment:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for JmxTrans `Deployment`.
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        imagePullSecrets:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
+                            When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable
+                            in Cluster Operator and the `imagePullSecrets` option
+                            are specified, only the `imagePullSecrets` variable is
+                            used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is
+                            ignored.
+                        securityContext:
+                          type: object
+                          properties:
+                            fsGroup:
+                              type: integer
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal, and the time when the processes are forcibly halted
+                            with a kill signal. Set this value to longer than the
+                            expected cleanup time for your process. Value must be
+                            a non-negative integer. A zero value indicates delete
+                            immediately. You might need to increase the grace period
+                            for very large Kafka clusters, so that the Kafka brokers
+                            have enough time to transfer their work to another broker
+                            before they are terminated. Defaults to 30 seconds.
+                        affinity:
+                          type: object
+                          properties:
+                            nodeAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      preference:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: object
+                                  properties:
+                                    nodeSelectorTerms:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                            podAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                            podAntiAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                          description: The pod's affinity rules.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                type: integer
+                              value:
+                                type: string
+                          description: The pod's tolerations.
+                      description: Template for JmxTrans `Pods`.
+                    container:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for JmxTrans container.
+                  description: Template for JmxTrans resources.
+              required:
+              - outputDefinitions
+              - kafkaQueries
+              description: Configuration for JmxTrans. When the property is present
+                a JmxTrans deployment is created for gathering JMX metrics from each
+                Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans
+                GitHub].
+            kafkaExporter:
+              type: object
+              properties:
+                image:
+                  type: string
+                  description: The docker image for the pods.
+                groupRegex:
+                  type: string
+                  description: Regular expression to specify which consumer groups
+                    to collect. Default value is `.*`.
+                topicRegex:
+                  type: string
+                  description: Regular expression to specify which topics to collect.
+                    Default value is `.*`.
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                    requests:
+                      type: object
+                  description: CPU and memory resources to reserve.
+                logging:
+                  type: string
+                  description: 'Only log messages with the given severity or above.
+                    Valid levels: [`debug`, `info`, `warn`, `error`, `fatal`]. Default
+                    log level is `info`.'
+                enableSaramaLogging:
+                  type: boolean
+                  description: Enable Sarama logging, a Go client library used by
+                    the Kafka Exporter.
+                template:
+                  type: object
+                  properties:
+                    deployment:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka Exporter `Deployment`.
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                        imagePullSecrets:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                          description: List of references to secrets in the same namespace
+                            to use for pulling any of the images used by this Pod.
+                            When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable
+                            in Cluster Operator and the `imagePullSecrets` option
+                            are specified, only the `imagePullSecrets` variable is
+                            used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is
+                            ignored.
+                        securityContext:
+                          type: object
+                          properties:
+                            fsGroup:
+                              type: integer
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Configures pod-level security attributes and
+                            common container settings.
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+                          description: The grace period is the duration in seconds
+                            after the processes running in the pod are sent a termination
+                            signal, and the time when the processes are forcibly halted
+                            with a kill signal. Set this value to longer than the
+                            expected cleanup time for your process. Value must be
+                            a non-negative integer. A zero value indicates delete
+                            immediately. You might need to increase the grace period
+                            for very large Kafka clusters, so that the Kafka brokers
+                            have enough time to transfer their work to another broker
+                            before they are terminated. Defaults to 30 seconds.
+                        affinity:
+                          type: object
+                          properties:
+                            nodeAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      preference:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: object
+                                  properties:
+                                    nodeSelectorTerms:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                            podAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                            podAntiAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                          description: The pod's affinity rules.
+                        priorityClassName:
+                          type: string
+                          description: The name of the priority class used to assign
+                            priority to the pods. For more information about priority
+                            classes, see {K8sPriorityClass}.
+                        schedulerName:
+                          type: string
+                          description: The name of the scheduler used to dispatch
+                            this `Pod`. If not specified, the default scheduler will
+                            be used.
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                type: integer
+                              value:
+                                type: string
+                          description: The pod's tolerations.
+                      description: Template for Kafka Exporter `Pods`.
+                    service:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              description: Labels added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                            annotations:
+                              type: object
+                              description: Annotations added to the resource template.
+                                Can be applied to different resources such as `StatefulSets`,
+                                `Deployments`, `Pods`, and `Services`.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka Exporter `Service`.
+                    container:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                          description: Environment variables which should be applied
+                            to the container.
+                        securityContext:
+                          type: object
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                          description: Security context for the container.
+                      description: Template for the Kafka Exporter container.
+                  description: Customization of deployment templates and pods.
+                livenessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod liveness check.
+                readinessProbe:
+                  type: object
+                  properties:
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                      description: The initial delay before first the health is first
+                        checked.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                      description: The timeout for each attempted health check.
+                  description: Pod readiness check.
+              description: Configuration of the Kafka Exporter. Kafka Exporter can
+                provide additional metrics, for example lag of consumer group at topic/partition.
+            maintenanceTimeWindows:
+              type: array
+              items:
+                type: string
+              description: A list of time windows for maintenance tasks (that is,
+                certificates renewal). Each time window is defined by a cron expression.
+          required:
+          - kafka
+          - zookeeper
+          description: The specification of the Kafka and ZooKeeper clusters, and
+            Topic Operator.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+            listeners:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: 'The type of the listener. Can be one of the following
+                      three types: `plain`, `tls`, and `external`.'
+                  addresses:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        host:
+                          type: string
+                          description: The DNS name or IP address of the Kafka bootstrap
+                            service.
+                        port:
+                          type: integer
+                          description: The port of the Kafka bootstrap service.
+                    description: A list of the addresses for this listener.
+                  bootstrapServers:
+                    type: string
+                    description: A comma-separated list of `host:port` pairs for connecting
+                      to the Kafka cluster using this listener.
+                  certificates:
+                    type: array
+                    items:
+                      type: string
+                    description: A list of TLS certificates which can be used to verify
+                      the identity of the server when connecting to the given listener.
+                      Set only for `tls` and `external` listeners.
+              description: Addresses of the internal and external listeners.
+          description: The status of the Kafka and ZooKeeper clusters, and Topic Operator.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkatopics.kafka.strimzi.io.crd.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkatopics.kafka.strimzi.io.crd.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkatopics.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: KafkaTopic
+    listKind: KafkaTopicList
+    singular: kafkatopic
+    plural: kafkatopics
+    shortNames:
+    - kt
+    categories:
+    - strimzi
+  additionalPrinterColumns:
+  - name: Partitions
+    description: The desired number of partitions in the topic
+    JSONPath: .spec.partitions
+    type: integer
+  - name: Replication factor
+    description: The desired number of replicas of each partition
+    JSONPath: .spec.replicas
+    type: integer
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            partitions:
+              type: integer
+              minimum: 1
+              description: The number of partitions the topic should have. This cannot
+                be decreased after topic creation. It can be increased after topic
+                creation, but it is important to understand the consequences that
+                has, especially for topics with semantic partitioning.
+            replicas:
+              type: integer
+              minimum: 1
+              maximum: 32767
+              description: The number of replicas the topic should have.
+            config:
+              type: object
+              description: The topic configuration.
+            topicName:
+              type: string
+              description: The name of the topic. When absent this will default to
+                the metadata.name of the topic. It is recommended to not set this
+                unless the topic name is not a valid Kubernetes resource name.
+          required:
+          - partitions
+          - replicas
+          description: The specification of the topic.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+          description: The status of the topic.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkausers.kafka.strimzi.io.crd.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/kafkausers.kafka.strimzi.io.crd.yaml
@@ -1,0 +1,231 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkausers.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: KafkaUser
+    listKind: KafkaUserList
+    singular: kafkauser
+    plural: kafkausers
+    shortNames:
+    - ku
+    categories:
+    - strimzi
+  additionalPrinterColumns:
+  - name: Authentication
+    description: How the user is authenticated
+    JSONPath: .spec.authentication.type
+    type: string
+  - name: Authorization
+    description: How the user is authorised
+    JSONPath: .spec.authorization.type
+    type: string
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            authentication:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+                  description: Authentication type.
+              required:
+              - type
+              description: Authentication mechanism enabled for this Kafka user.
+            authorization:
+              type: object
+              properties:
+                acls:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      host:
+                        type: string
+                        description: The host from which the action described in the
+                          ACL rule is allowed or denied.
+                      operation:
+                        type: string
+                        enum:
+                        - Read
+                        - Write
+                        - Create
+                        - Delete
+                        - Alter
+                        - Describe
+                        - ClusterAction
+                        - AlterConfigs
+                        - DescribeConfigs
+                        - IdempotentWrite
+                        - All
+                        description: 'Operation which will be allowed or denied. Supported
+                          operations are: Read, Write, Create, Delete, Alter, Describe,
+                          ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite
+                          and All.'
+                      resource:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: Name of resource for which given ACL rule
+                              applies. Can be combined with `patternType` field to
+                              use prefix pattern.
+                          patternType:
+                            type: string
+                            enum:
+                            - literal
+                            - prefix
+                            description: Describes the pattern used in the resource
+                              field. The supported types are `literal` and `prefix`.
+                              With `literal` pattern type, the resource field will
+                              be used as a definition of a full name. With `prefix`
+                              pattern type, the resource name will be used only as
+                              a prefix. Default value is `literal`.
+                          type:
+                            type: string
+                            enum:
+                            - topic
+                            - group
+                            - cluster
+                            - transactionalId
+                            description: Resource type. The available resource types
+                              are `topic`, `group`, `cluster`, and `transactionalId`.
+                        required:
+                        - type
+                        description: Indicates the resource for which given ACL rule
+                          applies.
+                      type:
+                        type: string
+                        enum:
+                        - allow
+                        - deny
+                        description: The type of the rule. Currently the only supported
+                          type is `allow`. ACL rules with type `allow` are used to
+                          allow user to execute the specified operations. Default
+                          value is `allow`.
+                    required:
+                    - operation
+                    - resource
+                  description: List of ACL rules which should be applied to this user.
+                type:
+                  type: string
+                  enum:
+                  - simple
+                  description: Authorization type. Currently the only supported type
+                    is `simple`. `simple` authorization type uses Kafka's `kafka.security.auth.SimpleAclAuthorizer`
+                    class for authorization.
+              required:
+              - acls
+              - type
+              description: Authorization rules for this Kafka user.
+            quotas:
+              type: object
+              properties:
+                consumerByteRate:
+                  type: integer
+                  minimum: 0
+                  description: A quota on the maximum bytes per-second that each client
+                    group can fetch from a broker before the clients in the group
+                    are throttled. Defined on a per-broker basis.
+                producerByteRate:
+                  type: integer
+                  minimum: 0
+                  description: A quota on the maximum bytes per-second that each client
+                    group can publish to a broker before the clients in the group
+                    are throttled. Defined on a per-broker basis.
+                requestPercentage:
+                  type: integer
+                  minimum: 0
+                  description: A quota on the maximum CPU utilization of each client
+                    group as a percentage of network and I/O threads.
+              description: Quotas on requests to control the broker resources used
+                by clients. Network bandwidth and request rate quotas can be enforced.Kafka
+                documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
+            template:
+              type: object
+              properties:
+                secret:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                          description: Labels added to the resource template. Can
+                            be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                        annotations:
+                          type: object
+                          description: Annotations added to the resource template.
+                            Can be applied to different resources such as `StatefulSets`,
+                            `Deployments`, `Pods`, and `Services`.
+                      description: Metadata applied to the resource.
+                  description: Template for KafkaUser resources. The template allows
+                    users to specify how the `Secret` with password or TLS certificates
+                    is generated.
+              description: Template to specify how Kafka User `Secrets` are generated.
+          description: The specification of the user.
+        status:
+          type: object
+          properties:
+            conditions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The unique identifier of a condition, used to distinguish
+                      between other conditions in the resource.
+                  status:
+                    type: string
+                    description: The status of the condition, either True, False or
+                      Unknown.
+                  lastTransitionTime:
+                    type: string
+                    description: Last time the condition of a type changed from one
+                      status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',
+                      in the UTC time zone.
+                  reason:
+                    type: string
+                    description: The reason for the condition's last transition (a
+                      single word in CamelCase).
+                  message:
+                    type: string
+                    description: Human-readable message indicating details about the
+                      condition's last transition.
+              description: List of status conditions.
+            observedGeneration:
+              type: integer
+              description: The generation of the CRD that was last reconciled by the
+                operator.
+            username:
+              type: string
+              description: Username.
+            secret:
+              type: string
+              description: The name of `Secret` where the credentials are stored.
+          description: The status of the Kafka User.

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/strimzi-cluster-operator.v0.19.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/strimzi-cluster-operator.v0.19.0.clusterserviceversion.yaml
@@ -1,0 +1,1268 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta1",
+          "kind":"Kafka",
+          "metadata":{
+            "name":"my-cluster"
+          },
+          "spec":{
+            "kafka":{
+                "version":"2.5.0",
+                "replicas":3,
+                "listeners":{
+                  "plain":{
+                    },
+                  "tls":{
+                    }
+                },
+                "config":{
+                  "offsets.topic.replication.factor":3,
+                  "transaction.state.log.replication.factor":3,
+                  "transaction.state.log.min.isr":2,
+                  "log.message.format.version":"2.5"
+                },
+                "storage":{
+                  "type":"ephemeral"
+                }
+            },
+            "zookeeper":{
+                "replicas":3,
+                "storage":{
+                  "type":"ephemeral"
+                }
+            },
+            "entityOperator":{
+                "topicOperator":{
+                  },
+                "userOperator":{
+                  }
+            }
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta1",
+          "kind":"KafkaConnect",
+          "metadata":{
+            "name":"my-connect-cluster"
+          },
+          "spec":{
+            "version":"2.5.0",
+            "replicas":1,
+            "bootstrapServers":"my-cluster-kafka-bootstrap:9093",
+            "tls":{
+                "trustedCertificates":[
+                  {
+                      "secretName":"my-cluster-cluster-ca-cert",
+                      "certificate":"ca.crt"
+                  }
+                ]
+            }
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta1",
+          "kind":"KafkaConnectS2I",
+          "metadata":{
+            "name":"my-connect-cluster"
+          },
+          "spec":{
+            "version":"2.5.0",
+            "replicas":1,
+            "bootstrapServers":"my-cluster-kafka-bootstrap:9093",
+            "tls":{
+                "trustedCertificates":[
+                  {
+                      "secretName":"my-cluster-cluster-ca-cert",
+                      "certificate":"ca.crt"
+                  }
+                ]
+            }
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta1",
+          "kind":"KafkaMirrorMaker",
+          "metadata":{
+            "name":"my-mirror-maker"
+          },
+          "spec":{
+            "version":"2.5.0",
+            "replicas":1,
+            "consumer":{
+                "bootstrapServers":"my-source-cluster-kafka-bootstrap:9092",
+                "groupId":"my-source-group-id"
+            },
+            "producer":{
+                "bootstrapServers":"my-target-cluster-kafka-bootstrap:9092"
+            },
+            "whitelist":".*"
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1alpha1",
+          "kind":"KafkaBridge",
+          "metadata":{
+            "name":"my-bridge"
+          },
+          "spec":{
+            "replicas":1,
+            "bootstrapServers":"my-cluster-kafka-bootstrap:9092",
+            "http":{
+                "port":8080
+            }
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta1",
+          "kind":"KafkaTopic",
+          "metadata":{
+            "name":"my-topic",
+            "labels":{
+                "strimzi.io/cluster":"my-cluster"
+            }
+          },
+          "spec":{
+            "partitions":10,
+            "replicas":3,
+            "config":{
+                "retention.ms":604800000,
+                "segment.bytes":1073741824
+            }
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta1",
+          "kind":"KafkaUser",
+          "metadata":{
+            "name":"my-user",
+            "labels":{
+                "strimzi.io/cluster":"my-cluster"
+            }
+          },
+          "spec":{
+            "authentication":{
+                "type":"tls"
+            },
+            "authorization":{
+                "type":"simple",
+                "acls":[
+                  {
+                      "resource":{
+                        "type":"topic",
+                        "name":"my-topic",
+                        "patternType":"literal"
+                      },
+                      "operation":"Read",
+                      "host":"*"
+                  },
+                  {
+                      "resource":{
+                        "type":"topic",
+                        "name":"my-topic",
+                        "patternType":"literal"
+                      },
+                      "operation":"Describe",
+                      "host":"*"
+                  },
+                  {
+                      "resource":{
+                        "type":"group",
+                        "name":"my-group",
+                        "patternType":"literal"
+                      },
+                      "operation":"Read",
+                      "host":"*"
+                  },
+                  {
+                      "resource":{
+                        "type":"topic",
+                        "name":"my-topic",
+                        "patternType":"literal"
+                      },
+                      "operation":"Write",
+                      "host":"*"
+                  },
+                  {
+                      "resource":{
+                        "type":"topic",
+                        "name":"my-topic",
+                        "patternType":"literal"
+                      },
+                      "operation":"Create",
+                      "host":"*"
+                  },
+                  {
+                      "resource":{
+                        "type":"topic",
+                        "name":"my-topic",
+                        "patternType":"literal"
+                      },
+                      "operation":"Describe",
+                      "host":"*"
+                  }
+                ]
+            }
+          }
+        },
+        {
+          "apiVersion": "kafka.strimzi.io/v1alpha1",
+          "kind": "KafkaConnector",
+          "metadata": {
+            "name": "my-source-connector",
+            "labels": {
+              "strimzi.io/cluster": "my-connect-cluster"
+            }
+          },
+          "spec": {
+            "class": "org.apache.kafka.connect.file.FileStreamSourceConnector",
+            "tasksMax": 2,
+            "config": {
+              "file": "/opt/kafka/LICENSE",
+              "topic": "my-topic"
+            }
+          }
+        },
+        {
+          "apiVersion": "kafka.strimzi.io/v1alpha1",
+          "kind": "KafkaMirrorMaker2",
+          "metadata": {
+            "name": "my-mm2-cluster"
+          },
+          "spec": {
+            "version":"2.5.0",
+            "replicas": 1,
+            "connectCluster": "my-cluster-target",
+            "clusters": [
+              {
+                "alias": "my-cluster-source",
+                "bootstrapServers": "my-cluster-source-kafka-bootstrap:9092"
+              },
+              {
+                "alias": "my-cluster-target",
+                "bootstrapServers": "my-cluster-target-kafka-bootstrap:9092",
+                "config": {
+                  "config.storage.replication.factor": 1,
+                  "offset.storage.replication.factor": 1,
+                  "status.storage.replication.factor": 1
+                }
+              }
+            ],
+            "mirrors": [
+              {
+                "sourceCluster": "my-cluster-source",
+                "targetCluster": "my-cluster-target",
+                "sourceConnector": {
+                  "config": {
+                    "replication.factor": 1,
+                    "offset-syncs.topic.replication.factor": 1,
+                    "sync.topic.acls.enabled": "false"
+                  }
+                },
+                "heartbeatConnector": {
+                  "config": {
+                    "heartbeats.topic.replication.factor": 1
+                  }
+                },
+                "checkpointConnector": {
+                  "config": {
+                    "checkpoints.topic.replication.factor": 1
+                  }
+                },
+                "topicsPattern": ".*",
+                "groupsPattern": ".*"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "kafka.strimzi.io/v1alpha1",
+          "kind": "KafkaRebalance",
+          "metadata": {
+            "name": "my-rebalance",
+            "labels": {
+              "strimzi.io/cluster": "my-cluster"
+            }
+          },
+          "spec": {
+            "goals": [
+              "NetworkInboundCapacityGoal",
+              "DiskCapacityGoal",
+              "RackAwareGoal",
+              "NetworkOutboundCapacityGoal",
+              "CpuCapacityGoal",
+              "ReplicaCapacityGoal"
+            ]
+          }
+        }
+      ]
+    capabilities: Deep Insights
+    categories: Streaming & Messaging
+    certified: 'false'
+    containerImage: docker.io/strimzi/operator:0.19.0
+    createdAt: 2020-07-27 22:49:00
+    description: Strimzi provides a way to run an Apache Kafka cluster on Kubernetes
+      or OpenShift in various deployment configurations.
+    repository: https://github.com/strimzi/strimzi-kafka-operator
+    support: Strimzi
+    operators.openshift.io/infrastructure-features: |-
+      ["Disconnected", "Proxy"]
+  name: strimzi-cluster-operator.v0.19.0
+  namespace: placeholder
+spec:
+  MinKubeVersion: 1.11.0
+  customresourcedefinitions:
+    owned:
+    - description: Represents a Kafka cluster
+      displayName: Kafka
+      kind: Kafka
+      name: kafkas.kafka.strimzi.io
+      resources:
+      - kind: Route
+        name: ''
+        version: route.openshift.io/v1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: Secret
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Kafka version
+        displayName: Version
+        path: kafka.version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The desired number of Kafka brokers.
+        displayName: Kafka Brokers
+        path: kafka.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The type of storage used by Kafka brokers
+        displayName: Kafka storage
+        path: kafka.storage.type
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
+          - urn:alm:descriptor:com.tectonic.ui:select:persistent-claim
+          - urn:alm:descriptor:com.tectonic.ui:select:jbod
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Kafka Resource Requirements
+        path: kafka.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The desired number of Zookeeper nodes.
+        displayName: Zookeeper Nodes
+        path: zookeeper.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The type of storage used by Zookeeper nodes
+        displayName: Zookeeper storage
+        path: zookeeper.storage.type
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
+          - urn:alm:descriptor:com.tectonic.ui:select:persistent-claim
+          - urn:alm:descriptor:com.tectonic.ui:select:jbod
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Zookeeper Resource Requirements
+        path: zookeeper.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka cluster conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta1
+    - description: Represents a Kafka Connect cluster
+      displayName: Kafka Connect
+      kind: KafkaConnect
+      name: kafkaconnects.kafka.strimzi.io
+      resources:
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kafka Connect nodes.
+        displayName: Connect nodes
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Kafka Connect version
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The address of the bootstrap server
+        displayName: Bootstrap server
+        path: bootstrapServers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka Connect conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta1
+    - description: Represents a Kafka Connect cluster with Source 2 Image support
+      displayName: Kafka Connect Source to Image
+      kind: KafkaConnectS2I
+      name: kafkaconnects2is.kafka.strimzi.io
+      resources:
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: DeploymentConfig
+        name: ''
+        version: apps.openshift.io/v1
+      - kind: ReplicationController
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: BuildConfig
+        name: ''
+        version: build.openshift.io/v1
+      - kind: ImageStream
+        name: ''
+        version: image.openshift.io/v1
+      specDescriptors:
+      - description: The desired number of Kafka Connect nodes.
+        displayName: Connect nodes
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Kafka Connect version
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The address of the bootstrap server
+        displayName: Bootstrap server
+        path: bootstrapServers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka Connect conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta1
+    - description: Represents a Kafka MirrorMaker cluster
+      displayName: Kafka Mirror Maker
+      kind: KafkaMirrorMaker
+      name: kafkamirrormakers.kafka.strimzi.io
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kafka MirrorMaker nodes.
+        displayName: MirrorMaker nodes
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Kafka Mirror Maker version
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The bootstrap address of the Source cluster
+        displayName: Source cluster
+        path: consumer.bootstrapServers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The bootstrap address of the Target cluster
+        displayName: Target cluster
+        path: producer.bootstrapServers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Expression specifying the topics which should be mirrored
+        displayName: Mirrored topics
+        path: whitelist
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka MirrorMaker conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta1
+    - description: Represents a Kafka Bridge cluster
+      displayName: Kafka Bridge
+      kind: KafkaBridge
+      name: kafkabridges.kafka.strimzi.io
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: Service
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kafka Bridge nodes.
+        displayName: Bridge nodes
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The bootstrap address of the Kafka cluster
+        displayName: Kafka cluster
+        path: bootstrapServers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The port where the HTTP Bridge is listening
+        displayName: HTTP port
+        path: http.port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka Bridge conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: Represents a topic inside a Kafka cluster
+      displayName: Kafka Topic
+      kind: KafkaTopic
+      name: kafkatopics.kafka.strimzi.io
+      specDescriptors:
+      - description: The number of partitions
+        displayName: Partitions
+        path: partitions
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The number of replicas
+        displayName: Replication factor
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: Kafka topic conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta1
+    - description: Represents a user inside a Kafka cluster
+      displayName: Kafka User
+      kind: KafkaUser
+      name: kafkausers.kafka.strimzi.io
+      resources:
+      - kind: Secret
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Authentication type
+        displayName: Authentication type
+        path: authentication.type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:tls
+        - urn:alm:descriptor:com.tectonic.ui:select:scram-sha-512
+      - description: Authorization type
+        displayName: Authorization type
+        path: authorization.type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:simple
+      statusDescriptors:
+      - description: Kafka user conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta1
+    - description: Represents a Connector inside a Kafka Connect cluster
+      displayName: Kafka Connector
+      kind: KafkaConnector
+      name: kafkaconnectors.kafka.strimzi.io
+      specDescriptors:
+      - description: Class of the Kafka Connect connector
+        displayName: Class
+        path: class
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Maximum number of tasks used by the connector
+        displayName: Max number of tasks
+        path: tasksMax
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: Connector conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: Represents a Kafka MirrorMaker 2 cluster
+      displayName: Kafka MirrorMaker 2
+      kind: KafkaMirrorMaker2
+      name: kafkamirrormaker2s.kafka.strimzi.io
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kafka MirrorMaker 2 nodes.
+        displayName: MirrorMaker2 nodes
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Kafka MirrorMaker 2 version
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Kafka cluster where the underlying Kafka Cannect connects
+        displayName: Connect cluster
+        path: connectCluster
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka MirrorMaker conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: Triggeres rebalance of replicas in a Kafka cluster
+      displayName: Kafka Rebalance
+      kind: KafkaRebalance
+      name: kafkarebalances.kafka.strimzi.io
+      resources: []
+      specDescriptors:
+      - description: Skip hard Cruise Cotnrol goals
+        displayName: Skip hard goals
+        path: 'skipHardGoalCheck'
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      statusDescriptors:
+      - description: Kafka Rebalance conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+  description: >
+    Strimzi provides a way to run an [Apache Kafka®](https://kafka.apache.org) cluster on 
+    [Kubernetes](https://kubernetes.io/) or [OpenShift](https://www.openshift.com/) in various deployment configurations.
+    See our [website](https://strimzi.io) for more details about the project.
+
+    ### New in 0.19
+
+    * Support for scale subresource in `KafkaConnect`, `KafkaConnectS2I`, `KafkaBridge`, `KafkaMirrorMaker`, `KafkaMirrorMaker2`, and `KafkaConnector` resources
+
+    * Use Java 11 as the Java runtime
+
+    * Add support for Open Policy Agent for Kafka authorization
+
+    * Use Strimzi Kafka Bridge 0.18.0
+
+    * Make it possible to configure labels and annotations for secrets created by the User Operator
+
+    * Remove deprecated `Kafka.spec.topicOperator` classes and deployment logic
+
+    * Refactored the format of the `KafkaRebalance` resource's status. The state of the rebalance is now displayed in the associated `Condition`'s `type` field rather than the `status` field. This was done so that the information would display correctly in various Kubernetes tools.
+
+    * Added performance tuning options to the `KafkaRebalance` CR and the ability to define a regular expression that will exclude matching topics from a rebalance optimization proposal.
+
+    * Support dynamically changeable logging in the Entity Operator and Kafka Bridge 
+
+    ### Supported Features
+
+    * **Manages the Kafka Cluster** - Deploys and manages all of the components of this complex application, including dependencies like Apache ZooKeeper® that are traditionally hard to administer.
+
+    * **Includes Kafka Connect** - Allows for configuration of common data sources and sinks to move data into and out of the Kafka cluster.
+
+    * **Topic Management** - Creates and manages Kafka Topics within the cluster.
+
+    * **User Management** - Creates and manages Kafka Users within the cluster.
+
+    * **Connector Management** - Creates and manages Kafka Connect connectors.
+
+    * **Includes Kafka Mirror Maker 1 and 2** - Allows for morroring data between different Apache Kafka® clusters.
+
+    * **Includes HTTP Kafka Bridge** - Allows clients to send and receive messages through an Apache Kafka® cluster via HTTP protocol.
+
+    * **Cluster Rebalancing** - Uses built-in Cruise Control for redistributes partition replicas according to specified goals in order to achieve the best cluster performance.
+
+    * **Monitoring** - Built-in support for monitoring using Prometheus and provided Grafana dashabords
+
+    ### Upgrading your Clusters
+    
+    The Strimzi Operator understands how to run and upgrade between a set of Kafka versions.
+    When specifying a new version in your config, check to make sure you aren't using any features that may have been removed.
+    See [the upgrade guide](https://strimzi.io/docs/operators/latest/deploying.html#assembly-upgrading-kafka-versions-str) for more information.
+
+    ### Storage
+
+    An efficient data storage infrastructure is essential to the optimal performance of Apache Kafka®.
+    Apache Kafka® deployed via Strimzi requires block storage.
+    The use of file storage (for example, NFS) is not recommended.
+    
+    The Strimzi Operator supports three types of data storage:
+    
+    * Ephemeral (Recommended for development only!)
+    
+    * Persistent
+    
+    * JBOD (Just a Bunch of Disks, suitable for Kafka only. Not supported in Zookeeper.)
+    
+    Strimzi also supports advanced operations such as adding or removing disks in Apache Kafka® brokers or resizing the persistent volumes (where supported by the infrastructure).
+
+    ### Documentation
+
+    Documentation to the current _master_ branch as well as all releases can be found on our [website](https://strimzi.io/documentation).
+
+    ### Getting help
+
+    If you encounter any issues while using Strimzi, you can get help using:
+
+    * [Strimzi mailing list on CNCF](https://lists.cncf.io/g/cncf-strimzi-users/topics)
+
+    * [Strimzi Slack channel on CNCF workspace](https://cloud-native.slack.com/messages/strimzi)
+
+    ### Contributing
+
+    You can contribute by:
+
+    * Raising any issues you find using Strimzi
+
+    * Fixing issues by opening Pull Requests
+
+    * Improving documentation
+
+    * Talking about Strimzi
+
+
+    All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/strimzi/strimzi-kafka-operator/issues). Issues which 
+    might be a good start for new contributors are marked with ["good-start"](https://github.com/strimzi/strimzi-kafka-operator/labels/good-start)
+    label.
+
+
+    The [Hacking guide](https://github.com/strimzi/strimzi-kafka-operator/blob/master/HACKING.md) describes how to build Strimzi and how to 
+    test your changes before submitting a patch or opening a PR.
+
+
+    The [Documentation Contributor Guide](https://strimzi.io/contributing/guide/) describes how to contribute to Strimzi documentation.
+
+
+    If you want to get in touch with us first before contributing, you can use:
+
+    * [Strimzi mailing list on CNCF](https://lists.cncf.io/g/cncf-strimzi-users/topics)
+
+    * [Strimzi Slack channel on CNCF workspace](https://cloud-native.slack.com/messages/strimzi)
+
+    ### License
+    
+    Strimzi is licensed under the [Apache License, Version 2.0](https://github.com/strimzi/strimzi-kafka-operator/blob/master/LICENSE).
+  displayName: Strimzi
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA1MTIgNTk1IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTk1OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6IzE5MkM0Nzt9Cgkuc3Qxe2ZpbGw6dXJsKCNTVkdJRF8xXyk7fQoJLnN0MntmaWxsOnVybCgjU1ZHSURfMl8pO30KCS5zdDN7ZmlsbDp1cmwoI1NWR0lEXzNfKTt9Cgkuc3Q0e2ZpbGw6dXJsKCNTVkdJRF80Xyk7fQoJLnN0NXtmaWxsOnVybCgjU1ZHSURfNV8pO30KCS5zdDZ7ZmlsbDp1cmwoI1NWR0lEXzZfKTt9Cjwvc3R5bGU+CjxnPgoJPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIyNTYsNSAxLDE1Mi4yIDEsNDQ2LjcgMjU2LDU5My45IDUxMSw0NDYuNyA1MTEsMTUyLjIgMjU2LDUgCSIvPgoJPGxpbmVhckdyYWRpZW50IGlkPSJTVkdJRF8xXyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSIxMDkuNDk5NiIgeTE9Ijg0Ljk2MjIiIHgyPSI0NDAuOTUxNyIgeTI9Ijc5My44MTAyIj4KCQk8c3RvcCAgb2Zmc2V0PSIwIiBzdHlsZT0ic3RvcC1jb2xvcjojRkZGRkZGIi8+CgkJPHN0b3AgIG9mZnNldD0iMSIgc3R5bGU9InN0b3AtY29sb3I6IzU0QkFEOCIvPgoJPC9saW5lYXJHcmFkaWVudD4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0yNTYsNTYxbDIyNi41LTEzMC44di0yNi4zYy0zNy42LTcuMy04NC45LTE0LjMtMTQzLjUtMTkuM2MtMTk5LjItMTcuMi0xNC44LTU2LjYsNjguOS0xMjcuMQoJCVMxMzAsMTY1LjcsMTMwLDE2NS43czE0Ny42LDMxLDEzMi44LDUwYy0xMC41LDEzLjUtMTM0LjMsNDMuNS0yMzMuMyw4OC4xdjEyNi41TDI1Niw1NjF6Ii8+CjwvZz4KPC9zdmc+Cg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          # The cluster operator needs to access and manage service accounts to grant Strimzi components cluster permissions
+          - serviceaccounts
+          verbs:
+          - get
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - "rbac.authorization.k8s.io"
+          resources:
+          # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
+          - rolebindings
+          verbs:
+          - get
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          # The cluster operator needs to access and manage config maps for Strimzi components configuration
+          - configmaps
+          # The cluster operator needs to access and manage services to expose Strimzi components to network traffic
+          - services
+          # The cluster operator needs to access and manage secrets to handle credentials
+          # The entity operator user-operator needs to access and manage secrets to store generated credentials
+          - secrets
+          # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - "kafka.strimzi.io"
+          resources:
+          # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+          - kafkas
+          - kafkas/status
+          # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
+          - kafkaconnects
+          - kafkaconnects/status
+          # The cluster operator runs the KafkaConnectS2IAssemblyOperator, which needs to access and manage KafkaConnectS2I resources
+          - kafkaconnects2is
+          - kafkaconnects2is/status
+          # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
+          - kafkaconnectors
+          - kafkaconnectors/status
+          # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
+          - kafkamirrormakers
+          - kafkamirrormakers/status
+          # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
+          - kafkabridges
+          - kafkabridges/status
+          # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
+          - kafkamirrormaker2s
+          - kafkamirrormaker2s/status
+          # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
+          - kafkarebalances
+          - kafkarebalances/status
+          # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
+          - kafkatopics
+          - kafkatopics/status
+          # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
+          - kafkausers
+          - kafkausers/status
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          # The cluster operator needs the extensions api as the operator supports Kubernetes version 1.11+
+          # apps/v1 was introduced in Kubernetes 1.14
+          - "extensions"
+          resources:
+          # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
+          - deployments
+          - deployments/scale
+          # The cluster operator needs to access replica sets to manage Strimzi components and to determine error states
+          - replicasets
+          # The cluster operator needs to access and manage replication controllers to manage replicasets
+          - replicationcontrollers
+          # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
+          - networkpolicies
+          # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - "apps"
+          resources:
+          # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
+          - deployments
+          - deployments/scale
+          - deployments/status
+          # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
+          - statefulsets
+          # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          # The cluster operator needs to be able to create events and delegate permissions to do so
+          # The entity operator needs to be able to create events
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          # OpenShift S2I requirements
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/scale
+          - deploymentconfigs/status
+          - deploymentconfigs/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          # OpenShift S2I requirements
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - builds
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+          - update
+        - apiGroups:
+          # OpenShift S2I requirements
+          - image.openshift.io
+          resources:
+          - imagestreams
+          - imagestreams/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          # The cluster operator needs to access and manage routes to expose Strimzi components for external access
+          - routes
+          - routes/custom-host
+          verbs:
+          - get
+          - list
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions
+          # that a Strimzi component experiences, allowing for higher availability
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        serviceAccountName: strimzi-cluster-operator
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - "rbac.authorization.k8s.io"
+          resources:
+          # The cluster operator needs to create and manage cluster role bindings in the case of an install where a user
+          # has specified they want their cluster role bindings generated
+          - clusterrolebindings
+          verbs:
+          - get
+          - create
+          - delete
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          # The cluster operator requires "get" permissions to view storage class details
+          # This is because only a persistent volume of a supported storage class type can be resized
+          - storageclasses
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          # The cluster operator requires "list" permissions to view all nodes in a cluster
+          # The listing is used to determine the node addresses when NodePort access is configured
+          # These addresses are then exposed in the custom resource states
+          # The Kafka Brokers require "get" permissions to view the node they are on
+          # This information is used to generate a Rack ID that is used for High Availability configurations
+          - nodes
+          verbs:
+          - get
+          - list
+        serviceAccountName: strimzi-cluster-operator
+      deployments:
+      - name: strimzi-cluster-operator-v0.19.0
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: strimzi-cluster-operator
+              strimzi.io/kind: cluster-operator
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                name: strimzi-cluster-operator
+                strimzi.io/kind: cluster-operator
+            spec:
+              containers:
+              - args:
+                - /opt/strimzi/bin/cluster_operator_run.sh
+                env:
+                - name: STRIMZI_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+                  value: "120000"
+                - name: STRIMZI_OPERATION_TIMEOUT_MS
+                  value: "300000"
+                - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+                  value: docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
+                  value: docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+                  value: docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+                  value: docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
+                  value: docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_KAFKA_IMAGES
+                  value: |
+                    2.4.0=docker.io/strimzi/kafka@sha256:df7007f48fb49969499b5191188ab299ff460d3bd04b2942b81e44088e5c47b7
+                    2.4.1=docker.io/strimzi/kafka@sha256:19fe5726d2702b8d2a80e1eeb3c2330c1efb528d275b9671cbc3dabe8fd25940
+                    2.5.0=docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_KAFKA_CONNECT_IMAGES
+                  value: |
+                    2.4.0=docker.io/strimzi/kafka@sha256:df7007f48fb49969499b5191188ab299ff460d3bd04b2942b81e44088e5c47b7
+                    2.4.1=docker.io/strimzi/kafka@sha256:19fe5726d2702b8d2a80e1eeb3c2330c1efb528d275b9671cbc3dabe8fd25940
+                    2.5.0=docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
+                  value: |
+                    2.4.0=docker.io/strimzi/kafka@sha256:df7007f48fb49969499b5191188ab299ff460d3bd04b2942b81e44088e5c47b7
+                    2.4.1=docker.io/strimzi/kafka@sha256:19fe5726d2702b8d2a80e1eeb3c2330c1efb528d275b9671cbc3dabe8fd25940
+                    2.5.0=docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
+                  value: |
+                    2.4.0=docker.io/strimzi/kafka@sha256:df7007f48fb49969499b5191188ab299ff460d3bd04b2942b81e44088e5c47b7
+                    2.4.1=docker.io/strimzi/kafka@sha256:19fe5726d2702b8d2a80e1eeb3c2330c1efb528d275b9671cbc3dabe8fd25940
+                    2.5.0=docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
+                  value: |
+                    2.4.0=docker.io/strimzi/kafka@sha256:df7007f48fb49969499b5191188ab299ff460d3bd04b2942b81e44088e5c47b7
+                    2.4.1=docker.io/strimzi/kafka@sha256:19fe5726d2702b8d2a80e1eeb3c2330c1efb528d275b9671cbc3dabe8fd25940
+                    2.5.0=docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+                - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+                  value: docker.io/strimzi/operator@sha256:d8fed9eb28c6d024670b060527681e21c6744a6c7dd2bf48450ce577382d3646
+                - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+                  value: docker.io/strimzi/operator@sha256:d8fed9eb28c6d024670b060527681e21c6744a6c7dd2bf48450ce577382d3646
+                - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+                  value: docker.io/strimzi/operator@sha256:d8fed9eb28c6d024670b060527681e21c6744a6c7dd2bf48450ce577382d3646
+                - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
+                  value: docker.io/strimzi/kafka-bridge@sha256:07625a283342ae26f94aa002362bf7a7729553a9a1693e6a9e1648e7f12b7bc2
+                - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
+                  value: docker.io/strimzi/jmxtrans@sha256:1f4c19182a6bff0ad0f358284e1da3cbdc042b13623f23e19802400542bef89d
+                - name: STRIMZI_LOG_LEVEL
+                  value: "INFO"
+                image: docker.io/strimzi/operator@sha256:d8fed9eb28c6d024670b060527681e21c6744a6c7dd2bf48450ce577382d3646
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthy
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                name: strimzi-cluster-operator
+                ports:
+                - containerPort: 8080
+                  name: http
+                readinessProbe:
+                  httpGet:
+                    path: /ready
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                resources: {}
+              serviceAccountName: strimzi-cluster-operator
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  relatedImages:
+    - name: strimzi-cluster-operator
+      image: docker.io/strimzi/operator@sha256:d8fed9eb28c6d024670b060527681e21c6744a6c7dd2bf48450ce577382d3646
+    - name: strimzi-kafka-240
+      image: docker.io/strimzi/kafka@sha256:df7007f48fb49969499b5191188ab299ff460d3bd04b2942b81e44088e5c47b7
+    - name: strimzi-kafka-241
+      image: docker.io/strimzi/kafka@sha256:19fe5726d2702b8d2a80e1eeb3c2330c1efb528d275b9671cbc3dabe8fd25940
+    - name: strimzi-kafka-250
+      image: docker.io/strimzi/kafka@sha256:961419d795036f5f491817a5652c8f30c531a7b3cafd245d9473812a6a632c19
+    - name: strimzi-bridge
+      image: docker.io/strimzi/kafka-bridge@sha256:07625a283342ae26f94aa002362bf7a7729553a9a1693e6a9e1648e7f12b7bc2
+    - name: strimzi-jmxtrans
+      image: docker.io/strimzi/jmxtrans@sha256:1f4c19182a6bff0ad0f358284e1da3cbdc042b13623f23e19802400542bef89d
+  keywords:
+    - kafka
+    - messaging
+    - kafka-connect
+    - kafka-streams
+    - data-streaming
+    - data-streams
+    - streaming
+    - streams
+  labels:
+    name: strimzi-cluster-operator
+  links:
+    - name: Website
+      url: https://strimzi.io/
+    - name: Documentation
+      url: https://strimzi.io/documentation/
+    - name: Mailing list
+      url: https://lists.cncf.io/g/cncf-strimzi-users/topics
+    - name: Slack
+      url: https://cloud-native.slack.com/messages/strimzi
+    - name: GitHub
+      url: https://github.com/strimzi/strimzi-kafka-operator
+  maintainers:
+    - email: cncf-strimzi-users@lists.cncf.io
+      name: Strimzi
+  maturity: stable
+  provider:
+    name: Strimzi
+  replaces: strimzi-cluster-operator.v0.18.0
+  selector:
+    matchLabels:
+      name: strimzi-cluster-operator
+  version: 0.19.0

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/strimzientityoperator.clusterrole.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/strimzientityoperator.clusterrole.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-entity-operator
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
+      - kafkatopics
+      - kafkatopics/status
+      # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
+      - kafkausers
+      - kafkausers/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      # The entity operator needs to be able to create events
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      # The entity operator user-operator needs to access and manage secrets to store generated credentials
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - update
+      - delete

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/strimzikafkabroker.clusterrole.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/strimzikafkabroker.clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-broker
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      # The Kafka Brokers require "get" permissions to view the node they are on
+      # This information is used to generate a Rack ID that is used for High Availability configurations
+      - nodes
+    verbs:
+      - get

--- a/upstream-community-operators/strimzi-kafka-operator/0.19.0/strimzitopicoperator.clusterrole.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/0.19.0/strimzitopicoperator.clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      - kafkatopics
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create

--- a/upstream-community-operators/strimzi-kafka-operator/strimzi-kafka-operator.package.yaml
+++ b/upstream-community-operators/strimzi-kafka-operator/strimzi-kafka-operator.package.yaml
@@ -1,4 +1,7 @@
 channels:
-- currentCSV: strimzi-cluster-operator.v0.18.0
+- currentCSV: strimzi-cluster-operator.v0.19.0
   name: stable
+- currentCSV: strimzi-cluster-operator.v0.19.0
+  name: strimzi-0.19.x
 packageName: strimzi-kafka-operator
+defaultChannel: stable


### PR DESCRIPTION
This PR adds Strimzi 0.19.0 to the upstream community operators for Kubernetes. The CSV has been already tested manually on Minikube and Kubernetes running on AWS and all seems to work fine.

### Updates to existing Operators

* [x] Is your new CSV pointing to the previous version with the `replaces` property?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo