### PR TITLE
Cockroach - multiple channels without default not supported, removed stable

### DIFF
--- a/upstream-community-operators/cockroachdb/cockroachdb.package.yaml
+++ b/upstream-community-operators/cockroachdb/cockroachdb.package.yaml
@@ -3,7 +3,5 @@ channels:
   name: stable-3.x
 - currentCSV: cockroachdb.v2.1.11
   name: stable-2.x
-- currentCSV: cockroachdb.v2.1.11
-  name: stable
 defaultChannel: stable-3.x
 packageName: cockroachdb


### PR DESCRIPTION
@dmesser we removed stable channel as multiple channels without default one will not be supported anymore due to bundle support introduction. Feel free to open a PR if you wish different channel to be deleted.