### PR TITLE
Update WildFly Operator 0.4.0 for upstream-community-operators

### DIFF
--- a/upstream-community-operators/wildfly/wildfly.package.yaml
+++ b/upstream-community-operators/wildfly/wildfly.package.yaml
@@ -1,4 +1,5 @@
 channels:
 - currentCSV: wildfly-operator.v0.4.0
   name: alpha
+defaultChannel: alpha
 packageName: wildfly


### PR DESCRIPTION
Set the defaultChannel to `alpha` in the package file

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
