### PR TITLE
Revert "fix prometheus-operator image sha from 0.32.0 to 0.37.0"

### DIFF
--- a/community-operators/prometheus/0.37.0/prometheusoperator.0.37.0.clusterserviceversion.yaml
+++ b/community-operators/prometheus/0.37.0/prometheusoperator.0.37.0.clusterserviceversion.yaml
@@ -202,7 +202,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/coreos/prometheus-operator@sha256:51c4b3180aa4cb819ae918da49776dba9a17e11d5a5d1eb22d878e1141aa23c9
+                image: quay.io/coreos/prometheus-operator@sha256:ed3ec0597c2d5b7102a7f62c661a23d8e4b34d910693fc23fd40bfb1d9404dcf
                 name: prometheus-operator
                 ports:
                 - containerPort: 8080


### PR DESCRIPTION
This reverts commit 7f1b0d64cf2403a6194a35ee50c0872ec64d74d3.

Reverts the bump in Prometheus Operator version from 0.32.0 to 0.37.0 since the corresponding CSV changes for RBAC were not included.

### Updates to existing Operators

* [/] Is your new CSV pointing to the previous version with the `replaces` property?
* [/] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
* [/] Have you tested an update to your Operator when deployed via OLM?
* [/] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?