### PR TITLE
add notice that operator metering is no longer under active development

### DIFF
--- a/upstream-community-operators/metering-upstream/4.2.0/metering-operator-upstream.v4.2.0.clusterserviceversion.yaml
+++ b/upstream-community-operators/metering-upstream/4.2.0/metering-operator-upstream.v4.2.0.clusterserviceversion.yaml
@@ -138,7 +138,9 @@ spec:
       kind: HiveTable
       name: hivetables.metering.openshift.io
       version: v1
-  description: 'Operator Metering is a chargeback and reporting tool to provide accountability
+  description: 'Important:  Operator Metering is no longer under active development.
+
+    Operator Metering is a chargeback and reporting tool to provide accountability
     for how resources are used across a cluster. Cluster admins can schedule reports
     based on historical usage data by Pod, Namespace, and Cluster wide. Operator Metering
     is part of the [Operator Framework](https://coreos.com/blog/introducing-operator-framework-metering).


### PR DESCRIPTION
Update the existing community metering operator to note that it is no longer under active development.
