### PR TITLE
[DOC] Fix some typos and issues in the Manual Testing doc

### DIFF
--- a/docs/testing-operators.md
+++ b/docs/testing-operators.md
@@ -264,8 +264,8 @@ COPY upstream-community-operators manifests
 RUN /bin/initializer -o ./bundles.db
 
 FROM scratch
-COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
-COPY --from=builder /build/bundles.db /bundles.db
+COPY --from=builder /etc/nsswitch.conf /etc/nsswitch.conf
+COPY --from=builder /bundles.db /bundles.db
 COPY --from=builder /bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
@@ -627,14 +627,14 @@ The process to test on OpenShift Container Platform and OKD 4.3 or newer is exac
 
 ### 1. Create the CatalogSource
 
-Create a `CatalogSource` instance in the `openshuft-marketplace` namespace to reference the Operator catalog image that contains your Operator version to test:
+Create a `CatalogSource` instance in the `openshift-marketplace` namespace to reference the Operator catalog image that contains your Operator version to test:
 
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: my-test-catalog
-  namespace: olm
+  namespace: openshift-marketplace
 spec:
   sourceType: grpc
   image: quay.io/myaccount/my-test-catalog:latest


### PR DESCRIPTION
There seem to be some issues and typos which I found in https://operator-framework.github.io/community-operators/testing-operators/#testing-operator-deployment-on-kubernetes and which I try to fix here (_I hope I got it right that this what the website is generated from_).

1) There does nto seem to be an `nsswicth.conf` file in this repo. So when following the guide, the container build fails. So instead of copying it from the localhost, I copy it from the builder container.
2) The bundle database seems to be copied from `/build` subdirectory which does not exist. It is in the toor directory in the builder container.
3) Typo in the namespace and wrong namespace in the CatalogSource YAML in the OpenShift part of the guide.