### PR TITLE
Set opm index label on upstream catalog

### DIFF
--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -7,6 +7,7 @@ FROM scratch
 COPY --from=builder /build/bundles.db /bundles.db
 COPY --from=builder /build/bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+LABEL operators.operatorframework.io.index.database.v1=/bundles.db
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]
 CMD ["--database", "/bundles.db"]


### PR DESCRIPTION
Pulling this image with `opm` currently gives:

```
Error: index image quay.io/operator-framework/upstream-community-operators:latest missing label operators.operatorframework.io.index.database.v1
```