### PR TITLE
community: Add OKD Pipelines Operator

### DIFF
--- a/community-operators/okd-pipeline-operator/1.2.3/Dockerfile
+++ b/community-operators/okd-pipeline-operator/1.2.3/Dockerfile
@@ -1,0 +1,15 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=okd-pipeline-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.17.2
+LABEL operators.operatorframework.io.metrics.project_layout=go
+
+LABEL com.redhat.openshift.versions="=v1.2.3"
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/community-operators/okd-pipeline-operator/1.2.3/manifests/openshift-pipelines-operator.clusterserviceversion.yaml
+++ b/community-operators/okd-pipeline-operator/1.2.3/manifests/openshift-pipelines-operator.clusterserviceversion.yaml
@@ -1,0 +1,363 @@
+--- 
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata: 
+  annotations: 
+    support: OKD working group
+    alm-examples: |-
+        [
+          {
+            "apiVersion": "operator.tekton.dev/v1alpha1",
+            "kind": "Config",
+            "metadata": {
+              "name": "name.must.be-cluster"
+            },
+            "spec": {
+              "targetNamespace": "openshift-pipelines"
+            }
+          }
+        ]
+    capabilities: "Seamless Upgrades"
+    containerImage: quay.io/jomeier/tektoncd-pipeline-operator
+    description: >-
+        OKD Pipelines is a cloud-native CI/CD solution for building
+        pipelines using Tekton concepts which run natively on OpenShift, Kubernetes and OKD.
+    createdAt: '2021-01-31T18:16:25Z'
+    repository: 'https://github.com/jomeier/tektoncd-pipeline-operator/tree/okd-v1.2.3'
+  name: okd-pipelines-operator.v1.2.3
+  namespace: placeholder
+spec: 
+  apiservicedefinitions: {}
+  customresourcedefinitions: 
+    owned: 
+      - description: "Config is the Schema for the configs API"
+        kind: Config
+        name: config.operator.tekton.dev
+        version: v1alpha1
+  description: |
+      OKD Pipelines is a cloud-native continuous integration and delivery
+      (CI/CD) solution for building pipelines using [Tekton](https://tekton.dev).
+      Tekton is a flexible Kubernetes-native open-source CI/CD framework, which
+      enables automating deployments across multiple platforms (Kubernetes,
+      serverless, VMs, etc) by abstracting away the underlying details.
+      
+      ## Features
+      * Standard CI/CD pipelines definition
+      * Build images with Kubernetes tools such as S2I, Buildah, Buildpacks, Kaniko, etc
+      * Deploy applications to multiple platforms such as Kubernetes, serverless and VMs
+      * Easy to extend and integrate with existing tools
+      * Scale pipelines on-demand
+      * Portable across any Kubernetes platform
+      * Designed for microservices and decentralized team
+      * Integrated with OpenShift Developer Console
+      
+      ## Installation
+      _OKD Pipelines Operator_ gets installed into a single namespace (openshift-operators) which would then install _Red Hat OpenShift Pipelines_ into the openshift-pipelines namespace. _Red Hat OpenShift Pipelines_ is however cluster-wide and can run pipelines created in any namespace.
+      ### Components
+      - Tekton Pipelines: v0.16.3
+      - Tekton Triggers: v0.8.1
+      - ClusterTasks based on Tekton Catalog 0.16
+      
+      (warning: uninstalling the community operator will delete all Pipelines, Tasks and Pipelineruns.)
+      
+      To uninstall the community operator:
+      - delete the instance (`name`: `cluster`) of the CRD `config.operator.tekton.dev`
+      - uninstall the community version of this operator from OperatorHub
+      ## Getting Started
+      In order to get familiar with _OKD Pipelines_ concepts and create your first pipeline, follow the [OpenShift Pipelines Docs](https://docs.openshift.com/container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html).
+  displayName: "OKD Pipelines Operator"
+  icon: 
+    - base64data: |
+          iVBORw0KGgoAAAANSUhEUgAAAGUAAABlCAYAAABUfC3PAAAQrElEQVR4Xu2dd3wU1RbHfymkQBom
+          kAYEiICCSFDkw3uACaIi0mJBKT4JRgSehSAoyEMMykMUpfgBBaSEjw8BfX4oL4ogQmjqB5CignQS
+          SgrpZdOTeZ8zYdbdzczO3dm5uxtx/oLMnXvPOd97bj33rhuawFOTeVmoPnsC1edOoC4rHbWZ6aLU
+          9P/6smJZDTzDo+AZ3l58531vHNz9g+DVOQa+vQa4ubrKLilg1dnjQnnaVlT9nGbV8FqNS8AIEMFq
+          HhePZhEdXMoOLiOMYe8WoWLfVhAMpdqvFYLadwTJNzYefsMS4N2lp9Nt4lQBqFkq+XwJDKkpDgeh
+          BIoA+Y9OQuCYqU6zjVMKrji6VyhelYzKY/vUKrFT3/sNHYfAF5Id3rw5FEpTgWFZExwNxyFQqOMu
+          /DDJ5T1DzS39R01B8PSl3G3GvYD8D6YIpZuWqunbZN67+wWKTRrPPocbFGqq8ucmoDYro8kY3BZB
+          fe6JRXByCpf+hguUP5t3KMEir2k5bQn8h43X1Y66ZkZD3Nxp8ag+f9KWStfk09JAICR5vW621C0j
+          aq5yp8e7zHzD0aS9OvVAxMaTuthTl0xK/7dOyJ873tF2cLnyaOLZ6oOtdq8K2A3lLyDmdYP6mdCV
+          aXaBsQvKX0DkndWtRQCC522EX/8hmuyr6SMSxVWA0PK8z71x8IxoWKan5fzKn9NQX1rklOZNAFBS
+          A9TDDR3f34jAQaNstrHNH7gKEFp6p+EozRfkHpqwFq1KdigcCUgd/QOAm5s2MDZDoSX23Ncec0ot
+          lAr1G5qA4LfWqcpQdeFX5E4dirrsK6pp7U1gCUTKz8PTEz2O1dpkZ5sS0xpWzsQ4pw57yUPCNxxX
+          taEgCCgpKYFQVYniIWGq6e1JoAREyrOZjy+6H65gtjVzQiogc3QPwdkTQxrZKDVZkhEkIHV1dQ3N
+          yO+HUZI02B67K36rBkT6sEW7aHRJvchkb6ZElPGNaSOE8n3buCjGmimLl1gCobzdhXoUP9KKtRjm
+          dKxApAwjE2cidMoCVZurJnCVjp3kCBidhJavLlautTebLMlDTBNWTh+Gml9/YDa4WkJbgUgdf+eU
+          /WjRs79Vu6tCofWsrDExTu1HJAMF0ZL5hLdk7SXnIaYJa1fPQcWXy9VszfReCxApY++AIHQ7WGQf
+          FGc3W7R0EZj4Jnz7DoFHiHyHrQaEDOLv1wJuN66h9ItlKNm4hMn4consASLlF/p4IiKT1yiCsUrM
+          mcNf7x79EJKcAs/IjhCqK1Hx407UXD6NwPGzzGzFAkRsOjYvRouBT8Ar+i7x+/IDqShclGTTfo8e
+          QKRmrOdJQRuUa8OiBEdvUpFnhH78PTzbRKP22kUUfPAKKg59IxqSZu+R2y8bobACsezoW770Lvye
+          mAT3FoGgwQvLvEsvIJLwAXfG4PbNJ2TBKNIq/nyxULhoqmY31/Jhq4Vb0Dx2BGpvXEPev8ag6uTB
+          RtkEv5UC2r9gBUIZCLs3oWzhi43yooFD0Ivzxb8XLZ9l1qzRBNWrSwwKPkyC3kAkQbqsPyDb6StC
+          uRIXKDgqKI68IzzlMNwDb0Ph0testvkUfhqxPR1ldYDcKMvS8u6VBhSPaGe1joR+9C18/jYIVcf2
+          IXtiHKQVA5qTZY6JEdeypKUTLZVN6RuluYssFN5eIi0iUk30+ftgNGvXGbWZl5EzaQBTG+/9wJPw
+          nrFSrMHWHvfaGpQl9mZaZmnx0NM3l24EuHk3N2b7S4wbFyDWvEUWCo++hEBQFIi4ohse1ciW1K5T
+          yCrr4xHWDn4Lt0No3bYRHFEpDbP4215dLEZHmj7nEweg7Ggaq1g2p5PzlkZQeC7JS/2BnOQZ96lO
+          mRQV9h35IjzadxXf16Wf1jQfUZIte8VcZH2SbLOxWT+glWTLkVgjS2S/ECvwDCeVU14cAU2PZ9VD
+          93TWVp0NJw7h3Lh+updpmmHwwHhELd5qZGEGhWbv14d34CoAzT/CVh8wK4P298tSU7iWq5Y5DSAo
+          8t4rNh4BcSOMyYW6Wpy4p5na53a9t1xFNoPCu4MnydsdLBcP/dQV3jCu9lJFqM1qOAjkrMdy2Bv4
+          QDxaPvwUgh58AqU/7MTFV4ZzFS164SbjLqUZFN5L82Er0+DVrTeu9GsunqyiZXh6aG3NmY+1eUhA
+          v0cRvfxrpL8+CoU7N3MT03QyaYTCu+ny7fsoWi/5GnmzRsHwXYNy0pE32lN31sMyMey0Jg3Nu/fG
+          yd5/DJX1lte0CTNC4d10td1biJpzJ8XJmas8LEAkWWOOVqEg9TNcSX6em/jSDN8IhedqsLgPMnUR
+          ro+gvsM1Ar5tAUIUWo1NQpvXFuHU4A6o5qSDtHpshMJzWcXVvMRWIJJr3H2wEEW7v+LmLdJEUoRC
+          ARFZY3tycUtxCPzpfpfxEq1AyDhtZn6EkKcmcxsiS5EvIhSes3iKPHFv7o/rj93OBbotmdoDxNi3
+          HKtBxhvPcBuJ3fML3EQohSvfEoo/nWuLfsxpo36qQf6CySjbupr5Gx4J9QBCct2xuSG86czTfFqW
+          qBmLIULRe2mFFh8pjNSn1wBxKzejtzsPOzPnqRcQKjD0uRkIf/nfuDDhQbF8vRcraclFhKLXpJFu
+          b6CVYDqrYfmUpa4HHdN29MxdLyB+veIQPjkZfr0ah8kWbF8vLlpW37yehLm2yCRseV9sA5T0Xqpb
+          E6rlWFsBlj6mTbOcpKGoltlRVC1AQwK9gLR5fQlajZ1iVYK6smJkrngbeZ8t0iDpH59QtIsuUFiA
+          ULFVVVUoNxhQ9d5EVO35r13Cq32sFxDyjrBJ8mFNpjKQbgaDASUr5qBws/ZQJhEKHYujHT+tD21a
+          ha7Yq/q5JDQlpB1BnvG9egHximiPbjv+CNRQUtJUNzehHukPaI/G1AUKHSejYAdrj6nQUjo9g+NM
+          y9YLCOUZ9U4Kbhs+zmbdKndtQs67jQM1VGvuzQR2e0rUEes75XJAqGweQdd6AiEZu32bDi+ZrWvJ
+          uEq64cZVZDytfeWbKxRFoakJY4gyYa1ZlE5vIJRnz5PKFc6abm6VBqQPth5BY003blCsCS32KzpC
+          4QHEGhQ13VwSiprQIpQrZ1A8oa8tziCblhcQpeaLRTe34nykx3fWrJvdnmLZ0bMILTY3ClGLtmjC
+          E4hcR8+qW81Pu5D5xmhbVDFLazcUmsVTuCk9rELrcYiHNxDSh2bxndY0DPdZdaOJ3/XRPVGj8Zwl
+          7UDqMnkkb/Ho84g4eWJ56r9aBsMq9QmZUl6OACKVTbP5gCcnMetmr5foNqOnvXb/TWdQ76keimNv
+          s+VIIBKYqA1HgIiO6vXNzqEwFWCEoleYasCSHcCdvWUX0qjJql6TrCl6UbKGM4AYPWbZDnh2k9eN
+          ZvFlX36MvE+0e79UDkW16L50TzG+vv+YAffIjvBs3UY89FO67HW7YPCah6hXffMUzcLaofXL8+E/
+          8HGUHW24lLTy1GFdYEglGVeJeV6aFnW4HtkT7pc9a8JqFGd6iKWMHRdvgU+n7jg9lM9OqnGTi2d4
+          UeSWC6gvykPW+D6sDMzSuRIQEqzH4XLkbliKzKVvaNJH7SMKMxKbL3tXiq0VJIYXTVmIjD7qgwDL
+          fFwNSPDjz6PdnFU4HsNnJ1WKwDeGGOmx0aUEh/bpaecxfx57IJurASHduqZeQE3ONZxP5BNQ6NMq
+          DF2/z24InKBH7316U0DBs1eL5xRZvcUVgbTo2Q+dUw7gXEJ/GI43Poup1iyxvJeORBih8IxoIYFY
+          vcUVgZD83fflovLCKW5eQmVIkfdGKDwD8qhAltBVVwFCO46mQRBhL8xG+D/f5hqyanoFldlRCL0m
+          kUqu2mZHlvjq2uDwRklcBYiHfxAoPPXS1MdQvGeruMnVbccl5Kx7n9uIi4xhevbRDArP+QoVTAdQ
+          I7ZcQNXRvSheN1+8VpAeVwFCstBhIZqLUHTK+efiEP3xDlHG3wY2rkgs/QRrGtMbjsyg8G7CRKUT
+          ZyNo0juirBRyRCeCCw+noXDPVtQ56d5HU8OZ7svT0ToKIj39aDS3SHsq2/L2vEYHUXk3YbR42XZP
+          oWwFKt67DdfeT9IlqI21hlqmu/tQETz8Ao1/rq8sx7ln+6Li7AmtWap+Z3klSCMoPGf3knSR29Nl
+          z9JTpGHGmwmqSvBKYLp/YloGNWVnRsZwqyyW14HIHl7neVaFlJUL3suYMx4F22w7IUydcvCIBHEz
+          iv5ND9Xo0qNpYidt62MtEpJXhZEmjKayykLh2eFTp+4xOAFt3za/LTV/yxqbDuO0fiYJYZOTzZoa
+          U8XotNWlKfHMzQ5Bveu7q3D39ROzoVVgCt4uP3sCZUfSuPV3tAAZPNb8979kofA6lCqNsuguyDu+
+          aDhSQB7i4RckHl2ryc/BuWf6qHaqLEFyoteUFCFn2WzVMFJa02o7azlqC/Nw9Z2JKN6faquTaUqv
+          dEueLBQqQW9vsRz2UqAbdepSM0Pzgc7/+QnNgkNR+O0mpM8cI6uoNGRVs4K0p25tz5zK7LhkK3y7
+          9EDpj7twYfIjatnq+l7OS6gARSj0Uq++RW4eQs2F3BCYDnxGTlsoKk/tuOVpXLWoRfquUZCDxTYt
+          wYiatx5+994veufl6SO5rWcpUbR2l6RVKHqsh2mdGLZLXm2M4608/xty1i4QDShFlygpKxd1Qkqm
+          DwhGxJR3EfTQSHi3jUZNXjZy1r6H3A3a75O0x22ULmBT9RRKYM+BIq1ATJUlz2k1+iV4t6HABQFw
+          U97LsBYGFBgQAHc3wHD8EDKXzXa4Z5jqRFu+HdbsU3QIq54idpYaj0roAcSyJnb8aDsCY4fJVlC1
+          uKyq1BRkfzjNnsqty7csd9+rQtHS6fMAQnIoHeBRA0Lf2nuYRxcitIUhMwS2zJsJii3NGC8gJIPc
+          yIsFSIP82qMW9QKi1mxJ5TBDYflFCJ5ASGAasdHoS1qbYgVib8C1HlBs+WUIZigkmLXLo3kDkQwj
+          NWGsQFyh6ZK7ktAaaJugUEZyw2RHAZEU6bTtLKoDQpgqsJB+BlfG23/kgqkwmURafm3IZihUbl7y
+          OIGiU+hxNBAqkyIVI1fshhAYbNVWdacO49pLfH43hRWS2r32cvlogiKBKU1dz+0iZRalQybPhd+g
+          0WZwSCHhxlUUfDoPpbv5HgtXk1ELEMpTMxT6+OJTPYTiM7fWT9KqgZDeawViNxTK4OzQaMFw5SKr
+          rLdEOnuA6ALlLzDm9cxeILpBoYwuJ8YKhUcajgfcio+WUZaSnezqUywzzVk6U8hc+574Mxq30kMT
+          w44rd6n+1harTXSFQoUajh8QLk18GDWVFawyNOl0tvxUIKuiukORCv6zN2fUXEU8N4PpJwJZYUjp
+          uEGhAop3bhKuvDn+T+c1chEothreWnquUKSCM6bGCwV7tjX5vob6jogp8xtFn+gJRNfRF4tg1KQV
+          Hd3f5ODQxlTI8HFWfwaQRX/WNA7xFEthmgocR8NwSJ+iVjOuJycKBd987nJ9DvUZwcMTuHTiajZx
+          ePOlJBANCHLXLoDh/G+oq61lkVv3NNRfBPQdhJBnp+k239AqpFOaL2vCEqCCLz5B+dmTqCop0qqX
+          6nc0pPUOCUVg/yEIGpHgdBCmArscFEtrEqSyH79Dxe8/o+p6OmrLy2z2JvG+E28f+LbvguZ3/w1+
+          9w9xKQiWOrs8FDWvqs1rOLJn+fh07eXShrem1/8BWjy0OmdfIfEAAAAASUVORK5CYII=
+      mediatype: image/png
+  install: 
+    spec: 
+      clusterPermissions: 
+        - rules: 
+            - apiGroups: 
+                - ""
+              resources: 
+                - configmaps
+                - endpoints
+                - events
+                - namespaces
+                - persistentvolumeclaims
+                - pods
+                - pods/log
+                - secrets
+                - services
+                - serviceaccounts
+                - limitranges
+              verbs: 
+                - "*"
+            - apiGroups: 
+                - apps
+              resources: 
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                - deployments/finalizers
+              verbs: 
+                - "*"
+            - apiGroups: 
+                - monitoring.coreos.com
+              resources: 
+                - servicemonitors
+              verbs: 
+                - get
+                - create
+                - delete
+                - update
+                - patch
+            - apiGroups: 
+                - rbac.authorization.k8s.io
+              resources: 
+                - clusterroles
+                - clusterrolebindings
+                - rolebindings
+                - roles
+              verbs: 
+                - "*"
+            - apiGroups: 
+                - apiextensions.k8s.io
+              resources: 
+                - customresourcedefinitions
+              verbs: 
+                - get
+                - create
+                - update
+                - delete
+            - apiGroups: 
+                - admissionregistration.k8s.io
+              resources: 
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
+              verbs: 
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+            - apiGroups: 
+                - build.knative.dev
+              resources: 
+                - builds
+                - buildtemplates
+                - clusterbuildtemplates
+              verbs: 
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+            - apiGroups: 
+                - extensions
+              resources: 
+                - deployments
+              verbs: 
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+            - apiGroups: 
+                - extensions
+              resources: 
+                - deployments/finalizers
+              verbs: 
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+            - apiGroups: 
+                - policy
+              resources: 
+                - podsecuritypolicies
+              verbs: 
+                - get
+                - create
+                - update
+                - delete
+                - use
+            - apiGroups: 
+                - security.openshift.io
+              resources: 
+                - securitycontextconstraints
+              verbs: 
+                - get
+                - update
+                - create
+                - use
+                - delete
+            - apiGroups: 
+                - operator.tekton.dev
+              resources: 
+                - "*"
+              verbs: 
+                - "*"
+            - apiGroups: 
+                - tekton.dev
+              resources: 
+                - "*"
+              verbs: 
+                - "*"
+            - apiGroups: 
+                - triggers.tekton.dev
+              resources: 
+                - "*"
+              verbs: 
+                - "*"
+            - apiGroups: 
+                - console.openshift.io
+              resources: 
+                - consoleyamlsamples
+                - consoleclidownloads
+              verbs: 
+                - "*"
+          serviceAccountName: openshift-pipelines-operator
+      deployments: 
+        - name: openshift-pipelines-operator
+          spec: 
+            replicas: 1
+            selector: 
+              matchLabels: 
+                name: openshift-pipelines-operator
+            strategy: {}
+            template: 
+              metadata: 
+                labels: 
+                  name: openshift-pipelines-operator
+              spec: 
+                containers: 
+                  - command: 
+                      - openshift-pipelines-operator
+                      - "--recursive"
+                    env: 
+                      - name: WATCH_NAMESPACE
+                        valueFrom: 
+                          fieldRef: 
+                            fieldPath: "metadata.annotations['olm.targetNamespaces']"
+                      - name: POD_NAME
+                        valueFrom: 
+                          fieldRef: 
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: openshift-pipelines-operator
+                    image: "quay.io/jomeier/openshift-pipelines-operator:v1.2.3"
+                    imagePullPolicy: Always
+                    name: openshift-pipelines-operator
+                    resources: {}
+                serviceAccountName: openshift-pipelines-operator
+    strategy: deployment
+  installModes: 
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords: 
+    - tektoncd
+    - openshift
+    - build
+    - pipeline
+  links: 
+    - name: "OKD Tekton Pipeline GitHub Repository"
+      url: "https://github.com/openshift/tektoncd-pipeline"
+    - name: "OKD Pipelines Operator GitHub Repository"
+      url: "https://github.com/openshift/tektoncd-pipeline-operator"
+  maintainers: 
+    - name: "OKD working group"
+      email: jo.meier@gmx.de
+  maturity: stable
+  provider: 
+      name: OKD working group
+  version: "1.2.3"
+

--- a/community-operators/okd-pipeline-operator/1.2.3/manifests/operator_v1alpha1_config_crd.yaml
+++ b/community-operators/okd-pipeline-operator/1.2.3/manifests/operator_v1alpha1_config_crd.yaml
@@ -1,0 +1,73 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: config.operator.tekton.dev
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: Config
+    listKind: ConfigList
+    plural: config
+    singular: config
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            targetNamespace:
+              description: namespace where OpenShift pipelines will be installed
+              type: string
+          required:
+          - targetNamespace
+          type: object
+        status:
+          properties:
+            conditions:
+              description: installation status sorted in reverse chronological order
+              items:
+                properties:
+                  code:
+                    description: Code indicates the status of installation of pipeline resources.
+                    type: string
+                  details:
+                    description: Additional details about the Code
+                    type: string
+                  pipelineVersion:
+                    description: The version of OpenShift pipelines
+                    type: string
+                  triggersVersion:
+                    description: The version of OpenShift triggers
+                    type: string
+                  version:
+                    description: The version of OpenShift pipelines operator
+                    type: string
+                required:
+                - code
+                - version
+                type: object
+              type: array
+            operatorUUID:
+              type: string
+              description: UUID of the operator that installed the pipeline
+          type: object
+  additionalPrinterColumns:
+  - JSONPath: ".status.conditions[0].code"
+    name: status
+    type: string
+    description: status of pipeline installation
+
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/okd-pipeline-operator/1.2.3/metadata/annotations.yaml
+++ b/community-operators/okd-pipeline-operator/1.2.3/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: okd-pipeline-operator
+

--- a/community-operators/okd-pipeline-operator/ci.yaml
+++ b/community-operators/okd-pipeline-operator/ci.yaml
@@ -1,0 +1,3 @@
+---
+# Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
+updateGraph: replaces-mode


### PR DESCRIPTION
Built from branch **okd-v1.2.x** of https://github.com/jomeier/tektoncd-pipeline-operator.git

@LorbusChris 
As promised ;-) Could you review that one, please? The operator image is in my personal quay.io registry. 

It would be great to get a review by the devs of the original operator. The differences in the CSV file compared to the original operator from Red Hat are minimal. 

During the creation of the CSV file described in the docs/release.md file in https://github.com/jomeier/tektoncd-pipeline-operator.git some unnecessary rolebindings were added to the CSV. I deleted them manually.

In addition I added the missing description, maintainer, icon (we should discuss, if we must create a different icon but I haven't done that yet) to the CSV.

The process of how to automate the CSV and how to take care about updates from older versions in the CSV is not clear to me. 

We should clarify/discuss that.

Greetings,

Josef