### PR TITLE
Add kubevirt hyperconverged-cluster-operator (HCO) to community-operators

### DIFF
--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/cdi.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/cdi.crd.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.cdi.kubevirt.io: ""
+  name: cdis.cdi.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: cdi.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: CDI
+    listKind: CDIList
+    plural: cdis
+    shortNames:
+    - cdi
+    - cdis
+    singular: cdi
+  scope: Cluster
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/cna.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/cna.crd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/common-template-bundles.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/common-template-bundles.crd.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtcommontemplatesbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtCommonTemplatesBundle
+    listKind: KubevirtCommonTemplatesBundleList
+    plural: kubevirtcommontemplatesbundles
+    singular: kubevirtcommontemplatesbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/hco.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/hco.crd.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hyperconvergeds.hco.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: hco.kubevirt.io
+  names:
+    kind: HyperConverged
+    plural: hyperconvergeds
+    shortNames:
+    - hco
+    - hcos
+    singular: hyperconverged
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/kubevirt-hyperconverged-operator.v0.0.1.clusterserviceversion.yaml
@@ -1,0 +1,1432 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: >-
+      [
+        {
+          "apiVersion": "hco.kubevirt.io/v1alpha1",
+          "kind": "HyperConverged",
+          "metadata": {
+            "name": "kubevirt-hyperconverged",
+            "namespace": "kubevirt-hyperconverged"
+          }
+        },
+        {
+          "apiVersion": "cdi.kubevirt.io/v1alpha1",
+          "kind": "CDI",
+          "metadata": {
+            "name": "cdi"
+          }
+        },
+        {
+          "apiVersion": "kubevirt.io/v1alpha3",
+          "kind": "KubeVirt",
+          "metadata": {
+            "name": "kubevirt",
+            "namespace": "kubevirt"
+          }
+        },
+        {
+          "apiVersion": "networkaddonsoperator.network.kubevirt.io/v1alpha1",
+          "kind": "NetworkAddonsConfig",
+          "metadata": {
+            "name": "network-addons"
+          }
+        },
+        {
+          "apiVersion": "kubevirtcommontemplatesbundles.kubevirt.io/v1",
+          "kind": "KubevirtCommonTemplatesBundle",
+          "metadata": {
+            "name": "common-templates"
+          }
+        },
+        {
+          "apiVersion": "kubevirtnodelabellerbundles.kubevirt.io/v1",
+          "kind": "KubevirtNodeLabellerBundle",
+          "metadata": {
+            "name": "node-labeller"
+          }
+        },
+        {
+          "apiVersion": "kubevirttemplatevalidators.kubevirt.io/v1",
+          "kind": "KubevirtTemplateValidator",
+          "metadata": {
+            "name": "template-validator"
+          }
+        },
+        {
+          "apiVersion": "kubevirt.io/v1alpha1",
+          "kind": "NodeMaintenance",
+          "metadata": {
+            "name": "node-maintenance"
+          },
+          "spec": {
+            "nodeName": "nodename",
+            "reason": "node maintenance reason"
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: OpenShift Optional
+    certified: 'false'
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
+    createdAt: 2019-07-16 16:35:09.376495024 -0400 EDT m=+0.028392606
+    description: Creates and maintains a HyperConverged KubeVirt Deployment
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    support: 'false'
+  name: kubevirt-hyperconverged-operator.v0.0.1
+  namespace: placeholder
+spec:
+  displayName: KubeVirt HyperConverged Cluster Operator
+  description: >
+    **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+    Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+    Containerized Data Importer (CDI), and Cluster Network Addons (CNA) operators.
+
+    **KubeVirt** is a virtual machine management add-on for Kubernetes.
+    The aim is to provide a common ground for virtualization solutions on top of
+    Kubernetes.
+
+    # Virtualization extension for Kubernetes
+
+    At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+    additional virtualization resource types (especially the `VirtualMachine` type) through
+    [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+    By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+    resources alongside all other resources Kubernetes provides.
+
+    The resources themselves are not enough to launch virtual machines.
+    For this to happen the _functionality and business logic_ needs to be added to
+    the cluster. The functionality is not added to Kubernetes itself, but rather
+    added to a Kubernetes cluster by _running_ additional controllers and agents
+    on an existing cluster.
+
+    The necessary controllers and agents are provided by KubeVirt.
+
+    As of today KubeVirt can be used to declaratively
+
+      * Create a predefined VM
+      * Schedule a VM on a Kubernetes cluster
+      * Launch a VM
+      * Migrate a VM
+      * Stop a VM
+      * Delete a VM
+
+    # Start using KubeVirt
+
+      * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+      * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+    # Start developing KubeVirt
+
+    To set up a development environment please read our
+    [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+    To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+    You can learn more about how KubeVirt is designed (and why it is that way),
+    and learn more about the major components by taking a look at our developer documentation:
+
+      * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+      * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+      * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+    # Community
+
+    If you got enough of code and want to speak to people, then you got a couple of options:
+
+      * Follow us on [Twitter](https://twitter.com/kubevirt)
+      * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+      * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+      * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+    # License
+
+    KubeVirt is distributed under the
+    [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+
+  keywords:
+    - KubeVirt
+    - Virtualization
+  version: 0.0.1
+  maturity: alpha
+  maintainers:
+    - name: KubeVirt project
+      email: kubevirt-dev@googlegroups.com
+  provider:
+    name: KubeVirt project
+  links:
+    - name: KubeVirt
+      url: https://kubevirt.io
+    - name: Source Code
+      url: https://github.com/kubevirt/hyperconverged-cluster-operator
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAARgAAAEYCAYAAACHjumMAABam0lEQVR4nOydB3gb9fn4v3faw5Js2fKSvO0kkrMTsCFgBQKEslqIzB+6AAcocVpIKD9aWrBSaKEtJKUQEjLKKO0PLFo2hG1DEpvEcZYl7ynZkqf2lu7+jx2HXxLfOZJO077P8+Qp1ffu9Fo6vfd+30kFJCTTKBQKLgBgoUKhKAEA5AIAssRicVp5efnk62wAADL9zzv5r6GhwarT6QYAAL0qleqEVqs92djY6I3130FCQhJHVFRUcFpaWl5CUdSPEmMMRdFdCoUiP9Z/EwkJSYxRKBRFhw8f3o6iqImgYrkQF4qiHz/33HO3SqVSONZ/JwkJSRSpqKjgTlss0aCttrZ2baz/ZhISkgijUChKDh8+/DcURc1RUi5nmdx6ff3cc88ppFIpJdafAwkJSRipqKjgtbS0vBxlpYJHV21t7bWx/kxIogMUawFIIkdZWZl4+/bt/1NeXn4XACAp0PMQAGxDTqel3Wpnj7s9DA+CuLwIgkyaIQgAKAwgiEWBqRwqlV3M5TiKkzhUOgxzgxANBQAc2r59++4dO3a8qdPp/KH9hSTxDqlg5iBSqZS1c+fOR+Ry+f8AADiBnudDENsjp1qtz3f2pKEABJzCQIEgz63ZmdpfLyhkXJIiEAcp7mGlUnn/tm3bWoI8jyQBIBXMHGLSYtm6dWuVQqHYCAAI+Ifeb3eYdnX3gZd7+hkmr48V6vtDAHivzxCNVhfloT/ITBcBAGgBnopqtdoP9u/fv2v//v2fkxbN3IFUMHMAqVTK2blz5//I5fJfTyfEBcSkxbL1pNr2QldfRrhlKuUl9e9ZtRSUC5Nzgzz1u2mL5mS4ZSKJPqSCSWDKyspypi2We4KxWHpsdtPunn6wu7ufafX5mBEU0XdNetrIpsJc9IfZmWkAAHqgJ2q12o+mLZpPdTqdL4IykkQQUsEkIFKplLtz587fyOXyrQCAgLc0XgSxPXi8xbarpz/sFsvFKOZytPtWLfVfmSbMC/LUY0ql8hfbtm1ripBoJBGEVDAJhEKhyFUoFBunLZasQM/rstlNL3f3o7u6+1h2vz+SFsvF8MvThCObCvMQhSRLCAAIWBatVvvptEXzsU6nI+udEgRSwSQACoUiqba29jEAwEPB/Ch9COLc1Hzasrd3ID2yEgZPDps1tH/VMte69NSCIE89qVQqN23btu1whEQjCSOkgoljtmzZkl9VVXWvTCa7CwCQGeh5Q06X/ZU+rXdfTz+tz+EMOEwdA5AfZmXoHyjMg67NSJu0aBiBnqjVar+ctmg+0Ol0nsiKSRIqpIKJQxQKBa+2tvZxAMAvg/nReRHE8df2bstTrZ3JTr8/4PPigbKU5MG9q5Y4Svm84iBPbVEqlZu3bdtWHyHRSAhAKpg4QqFQ8Lds2bKxvLz8EQBAwNuaQafL/o/eAe++3gHaQHxbLBcDvT5DpK8uygPXZ6anwMH5aOp37NixTaVSHdbpdO7IikkSKKSCiQMqKiqgnTt3/lImkz0TTFTIgyCOP7d1Wf7U2pniQpCAQ8CJwMpkwdDuFUtsq1L4JUGe2lZZWXm7SqU6FSHRSIKAVDAxRKFQJE9bLA8AAAJu0qR1OKcslv29AzSt05XIFstFuVqUOrS5KB+6KStdQIGgQJWvBwDw0fbt26cygzUaTYSlJMGDVDAxYNpieUgmk/0pmKiQy++3P9PWZX26rSvFM8cslouxhM/Tv7RisfXy1JTiIO/b71Qq1QOVlZXHIygeCQ6kgokiCoUiZcuWLfeVl5f/YrrnbUAMOJz2/T393v19Wvqg0xVwKcBc5MrUFP3monz0h9kZAhoMB/pZeAEAB7Zv3/7S/v37D5AWTfQgFUyEEYvFUFVVVVlVVdUmiURyezAFgF+PjBlf7OqD3xsycP0oSjZoP4dsFtN4T36OsypPwsjlsIVBnNrb0NCwa8eOHftUKpUxgiKSkAomstTU1OQolcpdAIAfBHPeSZNlYlPzKd/hcaMoctLNDagQ5Pz1gkLtE9KSNBaFkhzEqS61Wv276urqHfX19WgERZzXkAomzExbLJdNWyyVIPC+KugJk9m8u7sf2dc7wPejKNlaMggymAzT1pIC123ZmbQCLicYi2agoaFh944dO/aoVKrxCIo4LyEVTBipqanJUyqVuwEA1wVznsnjndjYdBL5z6A+NXLSzQ9gANx/X764p7oorzCY6m0AgEetVtdUV1f/pb6+HomgiPMKUsEQZNpiuaKqquoBiUSyIQiLBWk2mi27u/uQV/q0PB/pYwkruWzWyP2Fucimwjwqn0YLRnEPNjQ0vLxjx46XVSrVSARFnBeQCoYACoUivba29g0AwLpgzpvweMarjp5E3x0ykBZLhIEBcP1lyaLehxcU5QeTEgAA8KrV6icrKyv/qNFoSIsmREgFEwJbtmwpnbRYZDLZnQAAQYCnIUcnTJaXe/qRV/u0pI8lymSxmGO/KMj1bSrKg4V0ejDO89Mqlerl7du3/6uxsdEUQRHnJKSCCQKFQpFZW1v7DADgxwCAgBXEmNszds/RE9AH+uFgnI8kkcHzpGxh9++lxTnBNEQHAAzX1dX9rrq6+lWNRkP2DA4QUsEEwJYtW5ZMWyx3AAD4AZ6GfDdhtOzu6kde79fxEUBaLPGEiEEff6Awz/tAYR6UzmQE0y+nddqi+WdjY+NEBEWcE5AKZhYUCkVWbW3tXwAAd5zZzgfGsMs9es/RE/DHhhHSYol/fI8tKup8snSRGA5idtSkYVpXV/dEdXX1Xo1GQ/YMxoFUMBhs2bJl2bTF8v8AALwAT/M3jButu7v7kDf6dQIkCIVEEnuS6TTjpsI89y8KcoGYzQqmZ3HHtEXzemNj41gERUxISAVzDgqFQlxbW/vs5H8GY7Hona6Re5pOUg8YRlIiKyFJFEAeKi7oeHapNIMCQYE68CeZqKur+0N1dfUujUZDdtibhlQwZyyWFdMWy+3BjFhts9gsT7V2+P49MChASYtlTpFEpZo3FeY5tpQUMNOZjGBKELpVKtWe7du3v9rY2Djv82jmtYJRKBQ5tbW1zwEAbgvmsxh3e8yPnW517u0dEJGKZW7DoVAsNbIFhq0lBZkUCArGR2Ouq6t7qrq6+gWNRjNvO+zNSwWzZcuWVVVVVZtkMtnkVijgoe2tFqtlV3c/8s9+HdPk9cZy/AdJlMnjsIwb83Ncd+flMLJYzGC2wr0qlWrf9u3bX2lsbNRHUMS4ZF4pmIqKCtbOnTv/JJPJHgzmbx91u82/OdXqfKVPm47Os8+M5HyYMGz73aLioUcXFqXTYDjQlIVJrHV1dc9UV1fv0Gg0zgiKGFfMix+LQqHI37Jly6by8vIqAEDA+2n1pMXS1Ye8MaBjmr0RHbFKkmBIWCzjPfkSZ1V+DlPCZgVj0Qxs37796f3797+u0WgcERQxLpjTCqaiooK9c+fOZ2Qy2S+DOW/Y5TY9ekrjeq1flz7XPyMSYtAgyPHowiLd7xYVi5gUSjBRJ5NKpXqosrLytQiKF3Pm5I9HoVAUnmOxBGzGnjZbzbu6e9F/9Q+yLD5fQs0VIoktWUyG6a78HOfG/Bx6fnAd9jTTzclf0Wg09giKGBPmjIIRi8W0qqqqH0y3TQi4HwsCgOetgUHbru4++NuxiWCeQCQkM4AB8NyQlT6+uTAfuTYjLT2I9h3OhoaG13fs2LGroaHhpE6ni7Ck0WFOKJiamppypVL5EgBgWTDnfTY8Olx19ART53QF46wjIQmI5QJ+7+6VS6iXpAgkQZ76plKp/NW2bdtGIyRa1EhYBSMWi+lVVVU3TLemDLgfCwKA93/7dZMWC3Ro3EhaLCQRBQLAtz4jbXRTYT5yY1a6KIim7y6tVvuv6fnbxxLVoklIBVNTU7NGqVTuBAAsCeY8jcVquLfpJOPwuDGYzEwSkrAg5SX17125BFyWmhLwyJpp/jM9f9sQIdEiRsIomGmL5aZpi+WqQM+btFg+04/YX+ruQz/QD5OKhSTW+O+UZBt+UZgLX5EmTA3CovFotdp/T1s0RxLFokkIBVNTU1OhVCpfBACUBnPeabNFf2/TKeZ3E6TFQhJ/rE1L1f5j9VJfHocd8NjgaT5QKpWbtm3bFvdaJq4VzJYtW+RbtmypkUgk8kDPQQDwHNAPO3Z29aEfG0ZIxUIS7/g3iDMNDxTmQVeJUlODmITg1Wq1b+3YseOpHTt2tEdYxpCJSwWjUChKa2trdwIArgzmvOMms+H+plOMo0YTqVhIEo41qSm6fauWuhckcQuDOM0HAPhHZWXl71UqVdxFneJKwWzZskVWVVX1qEwmqwQABJTo5keB5xP9sP3Frl7o0+FRMipEkuggN2Wl6zcV5sHXZYhSoAB/BwCACbVa/a/9+/dPWjWHIixjwMSFgpFKpWDnzp33yeXyvwEAWIGe1zRhMtzffIrZbDSTioVkznFpSvLgnpVLHEsEvOIgTz1QWVl5l0qlGo6QaAETcwUjlUqFBw4c2C6RSH4WyPF+FPV8ODTs2NnVCz4fGSMVC8lcB12fkaavLsoHP8hMT4EDn+00qFKpfrd169Z/6nS6mM11iqmCqampKVEqlQcBAGkAAD0AIHO24xsnjIYHmk4xT5gtpGIhmXesEPCHdq1cbL8kJTlgi0atVu8sLS3dHFnJ8ImZgqmpqVmiVCr/AwAomn7JON2u8rzaDR+CuD/QDztf7OoDX5EWCwkJuEqUqt9cmIfenJ0hoEAQO4BTnpBIJE/pdDo0CuKdR0wUTE1NTb5SqTyF0U3OdO6kxA6rzaJoOIacIi0WEpIZLOYn6d8qW4ks4iVlz3LY5IM7Wa1W/7a0tPSZKIo3RdQVjFQqZR04cOBriURyKcbyBAAgxeByef7c1u3b29NPt/v95FB4EhIcqBDkvk2cOfr4ohKajJ+ENUDOON1kzadWq59Yv379M9G0ZKI+bXBkZOQ1Pp9/Pc4y47jR3Hd1fQP3s+FRlhdFyYbaJCSzgABAVVusvN3dfdQsFuvEymR++jkjd2zTiXu0yddEItHVEolEq1KpjkdLvqgqmOeee+628vLyJ/HW//T1N947PzwwYOJOmXwxj3CRkCQKKADUD/TDWV02u3Z9hgihwTALADA2uSM49ziZTLYGAPBpfX19VELYUf0Royh6anLriLX2dN233sc++5I2pZQXLuoBLHZRNGUjIZkr5HJY2kNr1ziyWcwFOIfoZTLZQo1GY4m0LFHbgrz11lv34SmXN0+1+B777Evq9zKNj0fd201CMlfotzslD7dqPFYf7sjszH379v0mGrJEZYsklUpZL7300gGAkSTk9vnA9a++gdg8nv+TxelAQHqGDUBQwDOLSEhIzgBBoI3HpwsbLSbWDUIRTIFmblQkEskqAMCe+vr6iE42iIoFU1VVddO54edz+WntOy6D1XZ+pAhF04B2oDcaspGQzDGQElFSH4BARpfTTtk12I+XxctSKpUvicXiiAoTFQWjUCh+gvX6p51dPlWLGjv1eXxsJXA4SCVDQhIESQzqKSGH/n0L2doRPfzB2DCektmgUCiC6lgQLBFXMBUVFZBEIsH8I145Nmu0jAbGRvwRE4yEZA6SKWCiF2bD/6W/G4x43Jh+zaqqqjsiKU/EFYxcLr8SazaRD0HQzzq7cb1QUxiNycDvH4+kfCQkcwUWjXJKyGHkXPg6AgD87ugwpoKRyWTXS6XSiEWTI65glErlLVivv6tpMxmdrtkrQxFECIwTxkjJRkIyh0DyUzl6CADMoW+fG8fwtkm5CoVihlIKF9HwwWAOQfv3ydOBRYjGRqnTXbtISEhw4DKoGgGLthZvfcjtonY47Ji/I6lUuiZSckVUwSgUikltKr3w9UlV+kl7Z2A9KpzOPGAyRS21mYQkEcnkM30X6+f7tXEccytUWVm5PlJyRVTBiMXipVivtw6PeF3BzH4e1AkBikY865CEJBFhUuFWIYc+W0X1FA1mI17Q5BqxWBwRXRBRBVNeXo45yvXU8HBw7+txFwCTcSRccpGQzCXyhBwtDEFpFzuu02mnO/yYOia9vLw8LxKyRdqCwZy8eHzIEHz4eXSULH4kIbkADp3SmsKhXxHo8W0OG6YfpqysLKi57oESEwtGPTwS6DS7/8NuywN2O+mLISE5hww+yxNMo/xupwOzv5JEIlkeVsGmiZiC2bBhAxsAsBBr7dig3hvCJSlA288CKOoiLh0JSeJDhSFDKoeO1WQKl3Z8CwbTX0qUiCkYmUx2BdZso0GLBQzbbIFOrzsfp3MhsFgGwyEfCUmik8pljFBgKCOYc7qdDszffMJZMAqF4lqs199vbSdWvTk2SrZyICEBwJnBYwY6wuR7epwO1I1gZoiIa2pqcsMi2TlE0oLBjK1/3dMXeHgaC4tZDNzuNkLXICFJcNK4jMNsOqUk2PN8KEo5YbXgJa5iJsUSISIKZjrBbob/BUFR8GlHVyj+l3NhgoF+L5ndSzJfgSFoNDeFHXJ6/3cWI2ZEVqlUhj3hLlIWzBKsa3eOT/gsbnfQZt0MbNbFwGYdIHwdEpIEJJVLN9CpcLDjZL/nsNmE93C+RiqVhlUnRMqCwQxPn9Qbwvcm4+MxG4dJQhJDPJk8ZmhBkmm0bifD5MPcSHBlMhlm5DdUIqJgpFIpZoLdiVAS7PCYGBcBv5+0YkjmFUIO/RCHQcVr5h0w7Q47pobBMw5CJSJDzWQyGaaQLcPD4Xw/Hhjo776u7FJRNos5rxpTddkcrm/GxjHL8ucDV4lSO+8vyL0w4oFavT672mKF39QO0vUudyAjVRMKCAITeULOrPPbA6XbaadeysPsYjv52/13ON4DRELBlJWVcQAApVhrh/q13rA2GjcZlxYAtPOl1csIa/REwuL1ORd9+vXAkNMVsT4e8UoKnTb2dvkqZjKdhrVNmIpQPr14kWtXd5/p6bZO5ojbQ8jnx6NSXVeJUr2rUwSubBaTQoWgqA8rPMvXlon+Vo8tLPkqp21WBKTP/C0qFIrycFz/LGFXMBKJpBTruh1j4/4Jp5O4g/d84NeajtGevewSD5tKIbQvTSR4NGrqC8tKG25raJp3CuauXIkxmU6b1cHJoMDMh0oKmOXC5LGyrw4yQp3/tVzAt3y05hI0k8XkAwCSQhY6PPg+VI+GzSrrdNjx8smWSaVSoNFowvI+YffBKBQKzJTjD9s6POF+r0kc4+PC3zSdmHe+mFvFmStXJQu6Yy1HlLH/ojAv4IfUpcLk1P+UrzJAZ1oQBcX/k2SNflFRRp9WLjHn84mxpgGXM+i8FzwMHjdlwovr6A05QnUhkXDyYvpfvuruiYxpiaL8F+u/NescTqL5NYkG/eGSgnmVC/RQcf7p4iSOJJhzbhVnZv4gQxRUL6EyocD0v2UrhSl0ergt7pDwA2D6c39XWMcpowBADWajG2tNKpWGzdEbCQtmRgTJ6/eDr3p6IxZWRs2mxfs0bbpIXT9eUUiyMhfzkzpiLUc0EDHoI0+VLgxpS3ibODi/6NOLFyHRnHp6MT4eG55wIkhQijUQmqxmTLcCXpAmFML6IVZUVEz+z4wtUuvomNvp9UXyaUDfe+SYHw3BFE5kKBDE27tqqfHMQ25uc09+jolDpWaFcm65MDlg63ZBEndEnpaaEsr7RIoPx8Iaff2ew+YJTLdFOEPVYVUwcrn8ksk93IWvnzZE5gM6l6GhoeTnWzu0kX6feOPSlORL1qendcZajkgCA2C5ryA3ZAdnHocd8P33k5zsmEWJsDhqMXW12G0RGb9o8/sZOpcT66EctwoGs4L62JAec68XVhBE+LvPvzLafPgTv+co0MMLCud0hfmjC4s0+Rx2yD8yGIICvs+XCHjOUN8nAnj+3N/NjOR2rcOJGU3KqqmpyQ/H9cOtYDCLpTTDo8QqqAPEYTAUvdbeNRyN94on1qWn5a8VCU/GWo5IkMVkDtdISwjd7L12R8BbSCGdHjfbzW9NE+N6jzuiw6M7HdjdU6RSaVgKH8OmYBQKBQsAUIa11jQ4GHkL5gzcvU3N9ii9VzzB/PelKydNe1usBQk3GwtyLAwKJaiubRdybMIUsP+vw2qLmwzg90YNwbeWDZIupx1TB4RrlEk4LZglWFm6PRNG37jDGbUv7WR3L/89XTirKhODDCajdGN+zpzKB6JB0MS9+TmE7x2VTh/wsYfGjXERKOhw2MYaLSbMXP7wvo8d7++Vl5WVEVZw4bRgMAscP2hrj+6e1udNrz7w2aAfRePG1I0Wm4vyoDMpDnODx6Ul7WI266Lzfmaj1+6wvDdkCFhJvd6nS3H6/TG3BHdoe31ohGoFz2XM66GMeDA3GDyJREK4BCdsCgZvyNrXPX1RT+Ef7O3L+0/vwLybo7RUwC+5Iyf7cKzlCAc5bJb+t4uKCWWuIgD47z5ynBaMxvWiCO3Frt6YJm2etFpMp2zWoHrtEuGw2Yj594ZjlEnYFAzWiJLJL/bTjq7oWxIoKtx/7HjMn0IxgPL66uUSBgwnvKP7voJcKxWCCFWMf2kYddePTQQ80uMsT7S0czqstgki702Ed8cMUQ2VH7WYMbdCEokkPhSMVCqlYFVQt46MuF0+X0ycZl9q2rhNRtO8GzdLhaGch4oLxmMtBxFYFHj0nvwcHtHr/L2rJ6TtogtB6Jd9dZD5wZAh6krG4HHb6ozBK0UiHLGYvH505kcVjoS7sOzxFArFCgDAjKKw04aRmCUt+d2uzF99/tXRw5W3riZ6rU8No8O/b2mLitl8qVDge3H5YkJjPKuL8uh/bu9yAADiJiISDE/KFnZnMhmYEclAaTaazR/qR0IuVBz3eNk3HzrKfrA437BNugDm02kiIvIEyku6Pp8HRSLuezkXB+KnaV1OJI/FvtDgiBsFg5lg1zyo90WqqVUgNJxWZ9dfuWa0IkN00bm9s3FZajK3126fvOk44ZMOm2ajCflVUYG1JIkTcnsACZtV9Li05OsnNR1rwytd5CnksAe3LCgk1LbRh6Dee5tOhiXE+3xnb8bznb2ghMsZz+GwUDoEz1pwyKTAyNuXreZDAATte+x2OlxfGscFlBjUfnQ47CCPNeN5JKypqVm8bdu206FeNyxbJJlMhjnuQDM6GtseLX5/1t5jxwlvk5KoVM4T0pKobLcQAOCdXb2E768/yBasyGYxe8MjVfS4vzDXDgNAKDz7vt7gbjaZw2q9ddjswi+Gx1I/NowIZ/v330FD2ueG0ZACDO+MGuBkKi0mhWWd2Bm9QC6XExplQljBlJWVTX6Rl2KtHdVFLcEOl/+ePEUfsDsIy7GpME8gZjGj4jh+tU/L1DtdZoKX4VcX5REbchdleFSq4a68HML9V57v6IlpJfSWEy1cp98fVHrGoNvl+s5spLqR2GRXdDmwJz7K5fLriVyX8BchkUhkAMMc1FutyLDNHlVnFRZOm13y24ONp4hehwrDrJ/kiqNS52Tx+ZgPnWghnD/0UHGBAALAGB6pIs8zSxb1pTGCm7V8IafNFvs3YxMx9T1prDbBX9u6rYEe7/Ij3q0dmkkTAnZgT12MOO1OG55mu0KhUIS8EyGsYPA62L2naYublP03G78TacwWE9Hr3JUnidqTsVanz2iaMBFSDiwKJXtzUV5C9MlZkMTVPVCYJyNyDZff734xDNvLcPBUa0fyM21deh+CuGY7bsztcd178uSYzuMS6rET3qKC2eejal2YzzTadJZ+SBD+wYjFYswmwf9Vt8VN2Tviduc+8+3hMaLXWZDE5T26oDBqw/cfPaUh3MHs0YVFAgYMx33pRI20xE607+0Lnb3+/b0DM9qFxAIvitJ+e7o1c8ln9Y5d3X2GHptjUtFPaRAvgpjrR8cntp5QG7M++Ix22mWNi2jf58YxTAudSCNwwjcwiqJNAICV577mRxDAfOIpjw9B4qYRN4PDGdD++sH0NAadUGW3F0GsvHc+obsQJCoV4l9VlBvWilIJZXVu7+j+8uGTmqvDJ1V4yWGz2vpvWCcBABCJ0vlzP/rCNeBwRjzSR4BxDpXitPv8GWejq6lcur5ElBSWUSREKeUm+V9esHiGYaBWq/9RWlpaFco1CVkwGzZsYAIApBe+fsow7Iwn5TKJ224XP1x/kHBjJhoMJ92dL4na9u8Xx06xXEE6DC9ka0nhimIuJ14jSt7XLlnuJqhcwHuDBlucK5dJhHafX3xWucAQ8OSmsOOi7+8krTYb5PTP3GESaaFJSMHIZLLLJrf6F76uHolxeBob+J/fHEpqt1oDdr7h8bNcSdiaL1+MDpud/6Z2aNZ9fAAkby7Kj8vSibVpwj55mhDTjxcMf+/qjZseuoGSymE4GFRKcqzlOIsfoHCn0461TSqtqKgI6TdN6EvBS7Br0g3FPDyNCeLP3dd0nHCdTpkwmVeRJoxaOv7zHT2TTzxCEay78iRp2Sxm3I052VyUT1gxfD0yNvHVyFis5xYFTTqPGXeV791OB1ZiLF0ul8tDuR5RCwYzCadtdCxuzL4L2d/UTA9DKwfKi8tLiVoVAXPCbEn6Z5+WkJOaR6NmvLC8NK62SekMuuNWcSahbvkIAJ6fHzkR8cZM4SaZTTckMalxY72cpd1hw3yQKZXKkBLuQlYwCoVCAABYjLV2RKeL2o8vWIxGU+bbXT2ErZhSPi/7ylRh1HJMtp7SJE14vIR8Pz/KzrxiVbIgPCP7wsCNmel0rByqYPhXn9apdToTynqBAPDmCePH93IuOBbMJCEl3BGxYDA72BmsVp/R6YqLsBsOtH1HjoVlC3dvQfQmt465PZxXegeIFlwyHi4piJsBdWVC4g/wF7v6wiJLNBFy6XYWjRLxbnWh0Omw+3FS/RYpFIrUYK9HxILBTL45NqiPmxsYj6/bO/hHx8YJWzG3ijPpAho1ah37Xuruo3kRhND7KSTZuYv5PMKZzeEglUEnVAj7zqB++IjRFPXRrhAA4Lr0NOcfZAssr65eZnt19TLHYwuLvfI0oY8KXdz/nxGHvpezeFGUMuB0YOoYsVgc9OD9kBUM3njJ08MjUYuwhIrf50v51cefE+54x6ZQOApxVtQUTI/dwflrexehjGQKBAR7Vy2dmLyXwidZaGD1IAmUSUV7z9ETUd8aLeXzbNobr5k4cGUZ63FpCe/neRLuz/Mk7D8uXkj7Wn4ZtWndlf58Dhv3D2PRKCYekxZ3vpdz6XBg78TLy8uDjvaFrGBkMhnmm53QG+JewUzS2NaWV6cbIpzhWpUfvW3SJH/QdAoH7E5CIedLUwRXrk8XqcMnVWgMOkN31e3pGfCYvNFtZnZLVvpwnfwyajaLiTv5camAR2lbvxa9Q5KFaQWk8xhx//vAq6wOpYVmSAqmoqKCgufgPTGkT5TBZ0n7mo4T9sVcKkxOWSNMiVr5gBtB6Lt7+oh+xvCvFxSESaLQaRwP2UeO7uzqjeo2Y2Uyf+zdyy9JFdBpF3XO0mEYfvWS5aCIyzlPycAQ8GQkMeOmhAaPLqcDU0aJRBKdLZJcLr8CADAjVd7m8SCd4xPxmGSHyTunWzgDdgfhPi/bl8noIIpzsff1DtBNHi8hua9OT1uwNk0Y0wbhHxtGgNET/E6tdmDQ2Wq1RdVJ+sSiEgdWUAOPSSXzweWrUfo5/anyhZwxGIbiolZqNjocuJXVxRs2bAjK5xWSglEqlZgJdp+0dxkRFE2YnASH05n6my/r+oleZ3WKIG2tSEi4WjtQRt0e9m9OtxLt9cJ6s2zl5EOCaN+ZkDF7fWBnV3CpOcMuN7j32Kmobo0KOGz1zdkZQXdFXMhLolwtSpv6sTKoFEs6j0moFUW0MPl8FLzKaplMdlUw1wrVB4OZdPNNX3+814LM4M0jTZnq8QnCldZ35Uqi2shjT0+/SG22ErJiREzGynsLcnrCJ1XwPNPWBVTaoYCOtXp94GdHjgNLdMeP+/auWurBKokJhPLpUHwGb8rgj/vt0VkazEa8hLugJj4GrWAUCkUSAGAF1tq7mta46QETKCiCpO5vPkk4EnRHjpjNplCi9vejAMB/7+oh3Ptkc+FUqn7MeqjY/X5Q2XgMPN3aMetx3TY7WPZ5PfhseDRqsk1ymTC55ypRatC+h7MUctgIBAFfOi8qxfdh44jVjJdCEFkFgzdgbcRu9+rMlrgOv+HxRvNxhsXrJZR9TIMh9o5lsqiOuXijf5DTZ3cQ2potEfBK75Bkfxk+qULjsZZ2sOyzevCUpgN8PjwKjhvNoGF8AvyzTwvuPnp8Srn02KPfAfQeglFCCIJATjJnmArDhMewRJNmi9nvxe6ul6NQKAKethl0ohPWgDUw1X93yEO05D5WjJotoj83HFH/8crLCXVUu68gN2ObpsM85HRFJfnL4ffTq4+fnvhoDWZL5EChvFG2ovC/g/pBN4IQGtNKlJNmy9S/eIEJw6N35+cQmkhh9HmN2QImoWvEAjeKUPpcTqSYzZlhhEil0kmLLqDIadgsmNaR0YTZX2Lxt/pvU4fsDqKtHGj35Emiut34WD+ScXBsnJDlBANQ+FBxQcJPgww3DxTmGWEACFnlWp+LQrTeKlZ04iTcBdMfJmgFU15ejtk+r2FAG/cJRLPhcLrStx9qJBxR+WVxPo0Jw1Ed+P/oqVYq0TD5IwsKRSl0Wty1c4gVFAiYtpQUELLIxz0eS4PVGPPG96Fy2m7FS7gLuIVmUAqmoqKCDQDAHIp1bFAfnz1gguCVpmaqB0E8RK4hYjCSHl5QGNVO/ofHjbwPh4YJlT4IGXTx35aWtoZPqsTm1wuK2iVsFqEt457BAZsXoPFc+DsrXU474YS7oBSMXC6/GivUZnQ6fQMmU0L6X85lwmbL+OOhRsLlub9dWMQR0mlR9UhuPn6aY/f5CL3nT/PE8qV8XsxLCGJNGp0+UrOohFCfmgGX0/rRxEjQ1cfxRLfT4feimIZxZk1NTUCp4EEpGLwEu/da241oAsX4Z+OPn34hGHO7CdX6cKhU/u2S7Kj2xOl3OJP+2a8jZH0BALgPlRREdXsXj/wkV2xiUSlZRK7xwdiwH01Q38tZ3AhCUdtteBMfAwpXB+uDwVQwh/oHEt56OYsfQUT7jzYTzsqtys+Jekn+C129NAQAQkrmxznZuQuSuCfCJRMEAFidLDBvEGf6FOJM5Lr0NFMyjRa3DckAAK77CnIIJa24/H7ngfG47EsdNI1mI6YJE+jEx4AVjEKhEAEASrDW3lG3zamn3r6m49QzuWyhsyKZL1wnShsIn1QXR2OxcfZ09xHqFUyD4bTdKxfrifYAnmSDOMs6fPO1xiPrruCryldRa8tXwQeuLBPob7oW2bFMNsKiUOLOb3dXnuTEQl5SLpFrvDE8aJ3weRPW93IujWbcZ+3VUqn0oruWgBUMXnhaZ7a4xh0OYaDXSQS6RkZEr51SE65R+uvSRUwoylmyj55uFQy73IQyiq9IFV7GplBCLp8Q0ukeVdlKs6p8JTuNwZgR5mVQYPZDxQWi5nVXuHLYrLiZdsCmUIx/Kl1EqF5ozONx/NswFPUmWJGiy2mHrNilGSyZTDZjZNGFBKxg8JrNHBsais0w3cgCb/3gY5rb7yf0hF0m4IuuSU+LWhHkJBavj7Wvt59QM6nn2rtHHH5/yMPe9q1aatsgyeJfrPZmIS+J/+7lqy1ErcVwUSnJGs1kMfKJXOPA+IjPjUZnKF80QAGAO512zIekQqG4aD4MYQvmtIFwY7i4ZMJuz/7fFg3hcPNdedEtgpzk5e4BmsvvD8mK0Tmcphp1e8gOzrvzJCM/zM4IuJXCcgE/6y9LFhEeiBcGkE2FeYSmbCAAeD8YH0mYbgKB0o3TH2byGXqxcwlbMKcMw4T6qsYze48cI5w8WCnJ4vJp1Ki2RNA6nZw/aDpCyrnf0zvgdiFISE77FDrNsXfVMm6wwYNHFhTlZzIZhCvaiXBtelrT6hQBoS5cH4wabDq3K2ET6/Bod0TYgtmwYcPkTbMAa+34UOIn2OFxuLcv+ave/sB6CeBAgSDW35ctjnrPlb+2d6d12+xBlT7YfT7Tvp7+kH8gm4vyvRQIhOLcpP0gUxSzbRIMgP1vy2R8Ii1k7X6/a8+Qds4pFzDlh7HhfS5LpVLprA/hgD5QmUxWgVVP4fB6ka7xiTnhLceBvvmDj70owTT8n+WJs3LZrKhm9/pQlPpSV3CtNX/f0m7Uu9whVf1CACCbi0J3X5SlJMesZcQt2RlDi3hJmA/QQPlyYsxv8nnjctYRUXocThQn4U6oUChKZzs3IAWDNyL2vdb2iURqohMKrYbh3AOd3UTHxFLvjkFezCt9WpbZ6w0ou7fDajP+vbNHHOp7Pb14kT6NQQ85esKlUWP249xUmEf0u0HeHTXM2d+BH6Bws8WC+QCQSqWzJtwFasFgXuRw/0BCTdQLlT1HjhG+xsYYOHuNXi/z9b7Asnt3dvX5EABCclDmsFiWRxcWiUI59yx+hMAMEwIs4SedWJeelkfkGodMRnu70z4nrZezfGcxYeqKyspKYgpGoVCk4SXY/belNW5yGCLJR23tSa1j44RaqWWzWan35EmimngHpiYf9tL8KDpr5qzB5Z54rV8bcjZ2ddGUBUAoetJiscYi3cGza8USmEg7BS+CeF/Q9c7ZQMdZGizYGb0AgMvKyspwfU+BWDCY0aNhm901ZLXOqQQ7PLx+P/PhTz4jnK38/PJSFgWCojrwrMNm5zzf2Tur/2fLCbXdHOKMIQYMe6qL8ghvD+pHie5Cg+cqUWr/ZakpmBNKA+Vb84RPOwcjRxcy4HJSTD7MW5cpkUhwG7UFYsFgKpgm3WDMnHKx4JPWdnHTkJ6Qo5ZLpabdmZMdVWfvJI+3tCUPOp2YeTHNRtP4m9rBkCuHd61YMsqhUgmN4mgcN441jBuj/rC6MyebsNX07uhwQvdBCoYOhx3z85otXH1RBSOVSjEVTMvISFxkX0YReM+RY4RvyJ/nigklc4WCw+9n7u3BHpz/fGdwY0PORcrjmu7OlxCqOgYA+O5pOhmLH6m3UpxF6Ltod9gsx6zmOe17OZcupx3v8wpdweC1xzs+NHe95ni8daqFNepwEmoauzY9jbcqmR/d1vhnxpzQbT7feT6zdqtt4i3tUMiO+s2FU2FpQsrhPzq9pdUS/a02l0o9mUSjhlzUiADge3agZ85l7c5G2C2YDRs2pE4+qLDWDvcPEO09knBYXC72z1XvOIm0p4QBoL92yXIEDkO1cjDoXW72nY3N7rOyexDEddvhJsiNICE5OFcI+Kb7CnMJ5UChAPgeb2mLSd3OAi7XSsS5++XEqFdjt81538u5tNhw8zZXbtiwAfNemFXByGSy1Vh5Lg6P1zdosc6rD/csn3V0JndPGAlVK0t5SWkrkvlEG4wHzUeGYUG71TYl+6GxCbvaYg25oXWNtMRFgSBCPU9OmSz2VqstJr2EDG4XIdnrTVGdUBMXjHg8wO7HfC4yZTIZpitlVgWjVCoVWK+/earFiKDonGioEyx+FKU/++1hopEg+DcLi6MaTZoEQQHl8Zb2yff1/+ZUa8jm/Y2Z6cabszNCrrY+y+9Ot8asEn/Q6Vpu9flCaslxymax1RnH590D1g9Q+BvTBF5dUiXW6xfzwWCOiD08oJ3L5QEX5dVjx9l2r5dQDtCPxJm8NAY96o9BlW4o5cETLYNHjKaQB4E9WEyoo8EUzUaz4SPDSCwH9bE/1o8EvU1FAfA/N9BDnW8RjrMcsZgwfa94ybi4CkahUOQAADAjBO9o2uZsgWMguHw+5q8//oyQgoEBYL6wvDQmU8b+3tkb8rhCKY9rX5eeRiiD24eg7o1NJ2MefXmhs3dShqB8id8Yx3xdTkfMZY8V31lMfhyzc+F0Uu554CoYvPB0v8lkm3A4UghJOQfY/d3RjAGzmVCV9O2S7JwiLiembQqCAQIA+WVRvjeUiaDn8v6QwXHcZA64Z0ykODQ+kf0HTcfsQ7HPwYMg3p26/qg65+MNs89HGXJjJ4ZLpdIZ0SRcBYPntDk+ZIh6Hke8svfIMaKfBXxXriRhErXuzBGbfpIrJux7+1tnT9zcQzXqdtlTrR1DF7NkOqw27+3NzSODHvecaXAfKh127HA1VkrLbBYMZgr1Sb1h3oWn8dh7tBlGCYab7y3MQYhOZYwWvyzKg7hUKiH/2+fDo4ZvxybiqWct9HhLe9aKz78xnTZbDBcu+hDEu7en31H29UH3MPDMe8sdnOkPg/lQxLJgcE1dvAS7U4bhOdNvlCjDNhvng9Z2882LFoT8gxExGGnVhXl9O7v7CFX0RprVyQLrpcJkQorB5fc7NzWfjsvoy3GTWbTks3p0VbJgNJ/D4jFgmGr3+32HxiYoI24PWyxgmSEIECqJmCt0OrA7gARswdTU1CQDAIqw1o4NDs2pESVE2XOU8DYJPLtUmkSDoHieFQQeLM73E+n4Nslb2iFXl80eT9bLhUBNRlOaSqdnvDEwSHln0MAYcXumHsLpvHnr151BhxN7GBsAYGFNTc15ShjvhrkGKwXc5HS5B0zmkMObc5ED7Z2cU4ZhQtEgJoUi/FmeOOptNQNlYRLXrJBkEf2F+Z7vTMzU+kw+c4RBheNZMUaVMa8XNngwA8nwhcMZMRWMUqnEzH95t7VtHCUYQZhr+FEUfujDA4QjCz/LlcSN4/NCdq9c4qTDMCEF8+bA4NhxkyXhthgUGHLnpbDnvWP3QhrMRsx7XqlUnpcPM+OmFounuiZeg3XyIQJNieYyX/f0pjQMaAml/l+ZJhSUC5OHwydVeFidzLdWpAkJZe2avV7HlpPqhFMuk6QnMV0QBJH3/QUcsZjwDI1rp3XIFDMUTHl5+eQqZn+Q/7Zo4tpPEEv2HGkiaoHQdiyVEapxigS3iTMJRw1f79N5DC53QiqYDB4jYdIIoskR/IS73GkdMgWWBYMZPRq0WOwTTiehsZpzGdVpDUNvsRJSEJcKkwvKU5LjKvGumMshFPVBAHDv7OpNSN8Ln0WzMmkU0ueIgQtBKP1OB6azVywWLz/731gWDGb+S5NuaL6WXwSE3eulPvb5l4QLGO8tiP70gdng02iEOhe+1NU70W6zJ+QWI4OMHM1KJ3aTxPOGNM5QMGVlZZgWTMvwSEIkg8WS146dELSPjhHaRt4mzmJwqZSARo1EA5cfCXnrN+xy2x873RazkgA6DPvWiVKN9+bnuB9ZUGjfmJ/jXytKdVGhi+962DSKNYVNI3O+ZqHTga1gysrKvrdgZjhqJBIJ3ojYedmeIRjQqezeY+izP8AMwgUEj0bl3ZqdOfp6vy4uKtZH3FOFJyFZIPt7B7xWny8mCuaGTJHxpRVL4Bw262zF9lllQemx2T0/OXIcNIwbce/p/DSOB4KgeTGWJ1Q6nQ5MTS2RSL43Us57Om3YsCEFAIA5n7d5UE8m2AXAGydOUeweD6HP6t78nLixFj8fDq27p9uPOF7u6Y+J7+Wl5YtNH665VJDDZmHmrhRwOfTDV62h/n5RMWYyRxKTauczafNiYgYROh02vPs0r6amZspfe56CkclkV2NZNS6fz9s1MUFq8wAYttnpz9QfJBR5WZMmTFsp4Ed9hhIW/xk0cE0eb9AzRWo07aYBhzPqvpd78iSWB4ryBAH0CoafLF3IuDtPMiNJMpPHjCs/WLxi8vngARfms/T7hLvzFIxSqcQcEfuOunWUaIn+fOLZbw9zBy0WIr4Y+PnlpXA8FEF6EIRxw8HvILvPF/Dfc3BswvyXti7CHe+CpSJN6HpCWhKU32T3yiWMBUnc731eTBrFnsKhJ2TUKxY0mLEHsp1NuPtewYjFYgoA4IdYB3/U3km604PA5fNRdhxsIJTde3lqivimzPSoTx/A4vC4MeWWQ0dd4+6Lbv2Q/+r0plsOHWGhBOuWQuHpxQv9uRx2UAqGDsOMTYW5Z5UnWpLORWAIIp27AfKVEde4vamsrIz+/U1QXl5eAABIxTryXU3rvBqyFg72Hm2mexGEkC/m7vz46RXz5ciY4PKvDvr+d2BwcNqffR52n99615HjttsamgQTHm/UAwKL+UmOcmFKSFuyNakpU99TMptu59KppCsgCNR2K+REMI2YJIlEsuD7bU9ZWRlm9Kh7fMJs93hntMIjmR2L201/4vOvxp++bl3IiWo3ZqZzizickS67ndBg+XDRbrMn3fldc9LTbZ2WUj6PlUqnu90IQu21O7x1I2NsL4rGbFbWxvyckJVxKZ83dW4Gj0H6XoIEBQDqctiQxVweVsrL8u8VDF54+oTBQO5HQ+SZ+oPCLZeXW0VcTkhPRRoMs/+4eOHw7Y3Hwi8cAU6brbzT5qnSq7P3Rky30EwY9m/MD3mG2uQ2icqmU6zJbHpCJgTGmi6nA17MnZnwPKlTvtc6eBbMiSEDWX9EgJePNBHa5lRKsrIXJXGjPs86kXhuqczIplJCthT1LpezMHWqVCpuK9rjmQ6HHdPyUygUy7//QPEsGM3IaFwkfCUq+442TyoYIiUE9Hvyc+b1FIfZyGGz7JuK8giNP2l32GlJTNL3EiqdTjveQ/SMBVNTU4NbQX1ENxh3Fb6JxIDZzNn13dGg80jO5c6cbAYNgshERwzuzZ+awELI93PQPBGXbTwThR6nA/FiO3pTzlowV2MlJlncbofObInlcKw5wcMffSp0EhjUlsViJj9YnD+jIfV8Z/KGvb8wj1CE0+H3O74wjpEV0wRwIwistmPf3lMKRqFQYJYHqE6rTeS+lDhOn4/2j6bjhJLmfi8tSeJTqYSGvc01freo2JDGoBNSDi/q+pBYRr/mCt9ZTJj395TykMlkJViLJ/XDCdkkKB7Z39RMSMHwabRUhSQrbqqsY00yjeZUyhYS6pOrd7tc742R93g4GHS7MA2Rsy9iThA42D8Q9dnJc5XjeoPg/dZ2PZFrbMyPr14xseS+ghw3BQKEfCcfjA3HTSJjomP0eTG3qmcVDOaTYNBsIb+AMPLAex8mIQgSctj/UmGy6HJhSk94pUpM7ivII6RsEQD8748Nk1ujMOHw+3DHDIBzemWch4dAsyGSmQxZrNy31a1EtjnQ9mUyOgCAcOkGm0IxXpee1qsQZw0qxFm6K1JTugAACRExvCdPoi/gsgkFH/5tGPQafT6ygDdM+NGZ5SPgnAppzEUUoKQFE2b2HDkGKhfLQj7/khSBWJ4mHK4bHQ+pPzIFghxPSEu6H1lQmM6iUPLPXXP4/d33HztlfqNftyJkASMMHYbdL6xYTChz2OrzefYODZAFvGGERaFg6pCzFgrmuAwRlxPzdgFzja+6ewTfaXWExpP8PFcS0vagmMsZPXr1FaYnpCWLWRTKjPomNoVS+M9Lli/5/MqyjiwmMy4HwW3Ml1jYFAoh6+X9sWHYh5LurHAiotExFfZZBYPpfKzIzyVzYMIMCgC8+f2PCGX3/iQ3m8OmwEEpAAmbNX7y2gpkeTI/6yKHUtelp5X857JVplDliyRVBIoap0HfGzWQ2iXMFLDYmPfzlIJRq9VqrMVlmRlk9mgEaBrUi77u7g3ZQqDCcNKOZaUjwZzzx9IFDhaFEvC2qkyYnDu5lQpJwAhxU2a6fkWyIIXINd4fG3YOetxkAW+YWcThYnZxnFIwKpWqEWvxpoULyEbfEeLlI02Ezr+vIDcnk8kIqARBykvq/2muJGifzTbZAomQTiM0sTJcQAD49q1aihJJ/HQhiPcFbR9ZWxdmIAC8S7g8zEj0WQtmUsHM6MCWI+ALioUphAa7k2DzrqaN3zNhJOKLYVTl51y0a97kl79/1dLJbUUoDwv69ZnxMWvvDkn2mIjJuNj2blY+HhsBDoTsnRZuFnG4LiaMrfenXn377bdHAQBHsA74kWxRhMWbn7j9ftqdb71NQVA05LyYzUX5dAYMzxpavjtfMlwmTM4J9T3KUwSER8eGAeSxRcWEQspeBPH+a1hHRkUjQIVAiKe1Nd+rnYaGhpNYR1xdiFmmRBIGvtMOpp42DIe8BUlnMpJvFWfOagXdLs4O9fJTcKjUmCejrUlN0cv4SYTKAg6ZjR6Dx0PmvYQf5BKeAFNxa7XaE98rGJVKVYt10LXFhbyK/DyyZCBCPF33LaGIxt6VSwQpdBrmNvbSFMHwtRlphLYVJi/habiEYFFg+5uXrqCc0z0vaExer/fp/i6yJUMEuF6Y1l3C5mAqf5VK9d/vFcynn376DQBAh3Xg7h/eSIMAFNs7bY6iatGkGqzW/lDP51CpKbeLszGzgx8szvcRrYY/abLEtI3k9RkiYzabRWgEyoGJUcTm95NZ6WGGCcPjj+YU4n039v3793/8/Yeu0WiQ2traJ7COXJiWmrRx9XJSwUQABEXh+9/9kEokL6aqYGavsEVJXP0GcRahsa1+ALxfDI/GNNnyBxkiQvcdAoDv/dFhUrlEgJ9miM00GMbsBKhWq3doNBrneR/87bff/goAoB3rhN+vraAyKBSydWMEeL+1Pfuk3hBy17uVyYKMq0Wpnee+tmvlEgsNhglZH6/09Du1TldMZwSJmAxCTuYDY8PufreTzHsJMwUsdvPPMsWYY44AABPV1dVPASzzefv27S9gnZEj4NO/2PhzKIlBJzRQjASbvUebCfli/rpEyoKmUw0q0oT6ijQhZo+fQBlzezyPnmqNud9CxAhdwdj9Pu/uoQFyiFqYSafTtX8tWiSEAcBs9tXQ0LCvvr5+yhiZoWD279+/BwDQhXXimtwc+mPyK+MhbDnneLX5eLLT6w25X8zyZL54XXrq1CTIh4rzkQBmM8/KK70D/gmvN+ZP/jG3J+TtzZfGcf+410tGjsIL8tvcotEMOgNvToxrx44d28/+nxlfnkaj8SqVyg0AAMzw6dY15azbSqVk68YwY/d4mb/99AsnkVYMd+VK0BUC/uBN2ZmE0uk9COLZ3dMf8/D0JOMeT6g+GP97o4a4+BvmEJ77snK+Xc0TLMNZR2pra+9TqVTfp05gfgH19fXDMpnMKpPJfnDhGgWGoQ2LZfT/tmicI3Z7zJ9wc4nvtIPJ961eMZzEYIQ0QkPKT4LKhSmWTCaD0CTIv7R32d/W6eMipZ5BgQc3iLOCDrUfNE043xzRky0Zwsg1KanHH5LkX4ZnHavV6v1XXXXVU+e+hqvhGxoamq+77roCkUi05MK1yauX5YjRfx4/5fchCPmUCCNcOt26tiA/JAUDQxA9g8kgVAGvdTg9ioZjDB+KxkXkpdNmpynEme2pDEZmoOc4/X7/Yz3tsMXvI+/NMCFhsDpq8ktSORQK3r156pZbbvmpTqc7r0Aa9ybS6XS+6urqnwEAjmKtr8jKpP/nx7f7z0QCScLF/qZmLoqzPY0Ge3r6/U6/P25+mB4ESbv50FHEj6IBj21RjeidOreLtK7DBAOCh15cIEPT6HQ8JT8il8uvbmxsnBEJnfUpVV9fj1ZWVm4EAGC2Fri+pIj1P1deTrZ0CCODFivvk/bOmBSYWn0+177egbhRLmfptNlXbTjcpLd4fb2zHYcA4P1YPzKybzD+/oYExveb3MLRVBp9Ac46olKpHqivrx/DWryoGaxSqU7V1dX9CM/5+Mdrr+aszM5KiF6uiQLRVg6hUtPS7jW43HHZouPdIcPylPc+hQ4YRj/BSkq0+/zjN3773fDdJ06w/QSnDZD8Hzemig5cK0yb4SY5S11dnbKysvK/eOsBhzIPHz78h/Ly8sex1sYdDk/5rn1I5/gE6VQLA1QY9p341QM9MlEaoVyWYOiw2lzST+uY/vhvJekv4LDbViYLaAIaDfUgfqbJ66N9MTzK9kEoq0TE9SUxaTEtb5grlPEF6ueKpPkAAEyHv1ar/c/69esVGo0G96YJWMFIpVKKWq3+BgBwGdb6N339roo9r5AKJkxcV1zYd+Dun2YAAKLymT50osX5fGdvQj/5c5LZdnEyi1QuYQAGkE61eIUvg87IwzlkrLKycqFKpZo1Az3gSIFGo/HLZLIbAQCY7TWvzMtlvnTLDVYoDCM1SAD4tLM774h2EHNfG26GXW7na326hHaKQgAgoiQGmVQXBjgwZXTfoiXG2ZSLUqm86mLKBcwWpsZidHTUBQA4IZfLq7DWV4uzGYMWi6t5SJ/QN2u8gAJgvnnRAkJ9UALhgWOnXEeMpoS2XoQcuiOdx0zovyFeqMqStF+VnIqXTAdUKtUvN2/e/Gkg1wo612Hbtm2H1Wp1FVaLTTDl9F1HE/N5ZFFkGFCdVqeN2OwRneR43Gh2vjEwGFLeTTyRwWOS6RJhYDE3qe3HGWK8iBFQq9Uvbd269dVArxdSMlVpaek/1Gr1Pqy1NA6b9tLNN5AFkWHA4nYzH//iKy+eMg8HL3T1xr1X92JwGVQTn0Ujh9gTZ/y3uUUUGAA8P1ZdaWlptU6nC1iZh5ytuXHjxscmH4BYazctWsBRrpNbyCQ84uw72lzUOTZOaGg+Ht02u/NN7WCiVxujBakcCtHizvkOFYKMfy+R9eYyWcU4h4xUVlbeH+x1Q1YwjY2NRplMdiUAADNpo+YqOW/rmnIyP4YgCIpSnv32MBpuZe1FEO9tDU3A6U/sUg9REsPKZVATfosXY3yP5RYNrEzir8JZ1ymVynKVStUR7IUJ1ZtoNBqbUqnciHfz/3n9NdzlmZlxMVcnkXn9+MkMq9vTGc5rvjdk8J00WeLGKVrC5YCrRUJQnpIMWJTAb8v0JCZpuRDkB0LRgetmSaZTKpUPbtu2LSRfYFi+nLfeemtDZWXlv7Bm74za7e7yXfuQ7glj3NzMich9q1e2vfyjm/LClRez5quD7kPjxphuj9IYdPCEtAQoxFkgnfl/ovhRFNSNjIG9PQPg7cEh4MfxEglYNKs0k8ch+qCcz5TxBOrniqWT9xWm30WtVj+5fv36J3Q6zHbdFyVs2r+lpeVZmUz2MNZaXU+fY+2+V+Oi/D+R6X3kwd685OR8otc5oB+xXn/wu5huK9IZDHDoqstBIXf2vLg93f3g/uZTmGsrc5LHGVRYGCER5zwwBHS1shW+TAYTM99FrVa/U1paeiuR9wjb/ru5ublh48aNVwAAZgz5yksW0IRslumTji4a+bQJHQ6dbrm6sIBQI2+Hz++58dAR2BjDTm+FHDZy8Ko1IJ/DvugDbmWKAKTS6eCA4fxR3EIO3ZzOYxJqTTGfYcOUsV0LF4/ms9h4Ien+zZs3V2o0GkKFt2H7sTc2Nlrlcvl6AMAA1vovyy8V3LNyBVl5TYD9Tc1CP4IQyot5Uzvo77E7YlrSUSMt8eWwWQFbz5uL88GNmef30Ernkb4XIvw0I3tgIZu7GGfZrlQq16pUKi3R9wlrBKG/v9/L4/HU5eXld2Ipr/IcMfiwrcM15nDEZcVuvGP3eOlcOl17eW5OSijfHQqA7+6jx6FhtydmkaMl/CTnC8sXU2EICurhxqFQwZvaoan/5jGpFkkKe9L8Ia3hELgqWXjowZyCUghnXrlKpdq8efPmL8PxXhF5CrS0tOyTyWSY5QRjdodrwfYXwITTSRZGhgAVhr3jjz86yGPg1ongsr9nwLzx2MmIlx7MRp38MktFmhCzG/1s2H0+wHvnk6lw5TKxYIRNpxBqCzpfKWCxW/4pXVY0S7DgSwiC1oXr/SLyBNi4ceNvAACnsdZSOWzmS7fcQHbCCxEfgtD2HW0OOrN31O12P3JKE9NI3uXCZFcoygWcmWAJSvlJIJlNM5PKJTToEGRQ5hezZlEuw5WVlZvC+Z4RUTCNjY1jcrn86kmDBWv99iWlnN9UrBmNxHvPB/Y3NScDAAaDOqdX6zd6vTHdmj5QmEeoLEHEYID0JNLwDRHnc8XS7kIWpxBn3VNXV3d9KMl0sxGxPWx9ff2oSqV64MzWfyZ/um5d+k0LF5BJeCGgGRkV1p5qGQ3UCnT5/a5d3X0xzdjNY7Ndt4ozCclgQX2mZDadzKcKgZ9mZGtWJPEvx1tXqVS/Xbt2LWbpDxEi6iSrrKx8u66u7k9YaxAAYO+tN9G4dDo5YykENn/wcaEXQQKqUXqytdM54HDGNKnu2aWLPCwKJWQLyoMgTi8ddUMQtmOSBJ/F3KSGX2TnLpzlkPeVSuX2SLx3xL3w1dXVj2u12vew1tK5XGb9fXfDySwm2d4hSEbtjiTVKfVFLcBum93517aumDp2lwp47tvEWYSqnZstZhOLQU0Pn1Tzg2wGs+evRYty8TJ1tVrtdzKZ7A6NRhOR94+4gtFoNOjDDz98HwDAiLW+IiuTvW3dWkek5ZiL7G06ljypa2Y75qWuPr83xjOOflGQ6yd6r31mHEv4thIxwP2HghJ7EoWKN7jOt3///iqNRhOx319U9uUajcYOAPhcLpcrAJjZ8X1VdhZDa7ZMnNAbyHKCIOg3mjjrCgvacgR8zBvI7PW67jp6nOqK4XC8VDrds3fVUohJoYScOWzwuIeeHegW+AEgOyUGjuORnIJjawQpq3HWXbW1tRs2b958MJJCRO3Jtm3btmaVSvV7rDUKDMP/uO0W4Spxlila8swFUACgX374iQQFANMX82qf1mv0+mLqs3iqdKGLT6MR8v/s1PWbPShKPnyCoFKU2fbDtIw1eOtqtXr77bff/kGk5Yiq6bx169Y9arX6Fbz11zb8iCFgMsntUhAcH9KLvurumTEYz4eg7he7+mLaBLuYy3FvLMglFPXpdjoGvzaO4bZwJJlJAYut/nmmWDLLIV+sX78eM/gSbqKqYHQ6nb+6uvoeAEAD1rpUlMZ6/+d3eiGMwVok+Lz83bHJH/F5Dt/tHd3mLps9piHdu/IkHgpEbFvz3qgBRcmSgIBJptL69y1ckiSg0tJwDumWy+U36nS6qDSDi/oXV19fDyorK3Gdvlfk5vCV69aSoesgeK+1LatrfOL7MIDW4XQoNe2Eqq7DwQ2ZIkLZ2mafV//ZxGhImb/zFOcjuYVWBgzP6GgwjXv79u331NfXRy1qG5Mng0qlaqmrq7sZbxzt41dVJK/Jy4nKTKC5gMfvpz3yyWdZZyNKL3f3e51+JNb5It7FAj4hGf6h141b/X5SwQTIL7Jyv6wQpJTirdfV1d378MMPfxNNmWJmeq5du/ZgQ0PDH7DWIADAxz//cVJpuojM9A2QdzVtkhNDBrPZ67Xu7e2PtXIBGQyGHsaIGAbKoNs19O6oIWqjcxOdtQLhyZ9mZl+Ht67VanetXbv2n9GVKsZ728rKyifVavXzWGtJDAbj3Z/eQRMwySS8QHm6/lvq//v6sGXE7Yl5Or3Z56XgWaiB8C/DoMeHojFXlInAIg732O/yiyQAJ4yvVqvfvuyyyx6KvmRxMuoBRdHPAADXYK3tONgwsfXjT1OiL1WCAlNQULoYApTYDwuw/ej6fg6Vmhv0eX5/z00nj2Z5UISsbLwI2Qxm91ulK3gQAHhO3RNyuXxlfX19TLoXxIV3frpE3IC19qvLLhX8dPnSkehLlaAgfggYJ2ItxRQf60dCyb71/13b6yaVS0DYH8kp8MyiXGxbt26tipVyAfGiYFQqVVddXd16AMCM7RAFhuHXFT8SrcjKxIw6kWAwFh/+8Vf6tEErGK3LafhkfGRRZCSaW/y/9Mz21TwB3meF1NXVKXbs2NEcZbHOIy4UDDjj9D2pUqkew1t/TfEjehKDQQ5yCwSnAwCTKea1O58YRsS7u/uPB9pWAgHA84K2z0d2Irs4hSz26Z9l4CfTNTQ0/Hnt2rUHoivVTOLCB3MWqVQK1Gr1ewCAm7HW63v7jPK9r3LxnFkk50Cno0BaCgEo5l8x+urqZeqf50lww6fgzCwk10+OHm8foLgWAgASfZxtRBHS6H1vl66g0mFYjHPIEZlMdrlGo4n5jPjYewLPYXR0dHK79P7NN9+8js/nz/jw8pIFLBRFTfW9/WRdysXw+yHAZALAinlACfpAP5w06HRpCzhsu4jJOC+vxYeirs+GR+13Hz3hHwAuhEmjpMZO1ITA8UR+8XABi12Es94qk8nWTRcYx5y4UjDgjJLx8ni8Rrlcfj/WFq6iIJ/5RVf3qNZsmX1iFwkAPj8KhMLYmzAA0I4Zzckvdffx/juo7+y1O1yHxiag94aGJ+46epy+p2cgyYz6JnJS2HgZqCRnQH8lzvv8hlQRbhGjUqm87e23326Lrlj4xPzmw+Ott976YWVl5ZtY5rLZ5XKW797nbR0ZI7M8L8YiGQqY8T9DqFjEHUzjMrJjLUc8c3Vy6sk/FJTIAABYRaw+tVr9QGlp6b4YiIZL3Dh5L+T2229/V61W78Ba4zOZrFc3/Aglksg1bxiP/0ZNNApsSOUwyCmNs8Cj0lofzS0U4SgXoFar98ebcgHxrGAmWb9+/VOTnx3W2iXibP4rG344BgHIE33JEoiJcQj441sPF6VxbBAESL8aDkIaTb97QSmFQ6Fk4hxyfOPGjbgR2FgSdz6Yc7FYLF4AwEm5XH4P1vqyzAzuhNNl/k6ri7knM25BEAhAEAKSkuJym8RlUIfyhJygs33nE1skBe2reQK8Ma8jcrn80kOHDsVHduUFxLUFA850wjukVqs3Tu4xsdaVV1ewl2ZmjEdfsgRiZBgCnvg09NJ5ZER6Fvw/Ts+uvyFVtARnHVGpVPfV19fHpXIBiaBgJiktLd0/ucfEWktmsZgH77+HlZHEtURfsgRh0ooxTsSdLwaGIKuIyyAd9Tgs5/JPbBLnXgFwZkir1eq3KisrMSd2xAsJoWDAmXG0k3vME1hrXDqdvfuHN05aOGQnPDzGxgBA40vHZPAYVgiCCI0zmauk0ei9v88vSp/lN9q5bdu2h6MsVtAkjIJpbGycmB5Hi1n4eMuihSl/vf4aXfQlSxA8bgiMj8VVFj45BhYbCIDxvxYvMmfQGXiZuma5XL5WpVIFNHgvliSMggFn2m1OqFSq+/FqW359xeX5isWy+Kj0i0f0QwD4Y549PkUal9HJolPw5vXMZ5CHcwoGilmcZXgHqFSqzfX19UHNJo8VCaVgwJnWDu/W1dVtw1vf88ObWEI2m3T6YuHzwWDCGHMrBgLAUZjGIX0vGFzGT/78R2kZeE7dSf5WWVn5RhRFIkTCKRhwZhztk1qt9j9YawIWk/PNfXdTRRxOXNRixB3jsffFpPOYRhiCyDGwF7CEy2v7c9GiS/HSR7Ra7ScymezX0ZcsdBJSwWg0GrSysvJuAMAhrHWpKI3/5h0b3DAEOaMvXZzjdMBgbDSWVowrW8AknS8XkMNkdTxZUMKHAcCbBtFcWVn5Y41GE99ZkxeQkAoGnHH6WuVy+XWTih1rfW1Bfsq/br9tONBeJPOKoUE0Vtm92QLWAINKEcbkzeMUBgwPvVhSiqbS6HiZusNyuXxdY2NjwjVdi+tM3ovR39/v5fF46vLy8juwlGVpukgwZLHom4f0SbGRME5BURjQaH7A4UT1AUODIfOC9CQmDEFkWcD/4X08r6i/lJskw1lHVCrVT5599tmTUZYrLCSsBXOWhx9++LO6uroteOsv3nxDyiJR2lB0pUoAxsaiXjqQlsR0UGCItF7O4Za0jAPXpKQtxVuvq6v7XWVl5fvRlSp8JLyCAWfabb6o1Wpfx1qjUyjMT+/+CSuHz0848zKiuJwwMEY1ouRJ5zHIToTncBk/ueV/cgrW4a1rtdq3qqurn4muVOFlTigYcKby+pcAAMxEOwmfn7zvtpvJcbQXotOi0YooZfCYfSyyW933UADU/0hOweTWHa9Qd3j9+vUPaDSaKEsWXhLaB3Muo6OjbgDAh3K5fAMAYIbPpTAlhc+mUTu+6OrhzaW/mxAIAgMGEwEsVkS3SxQYsi5KT6LBMER2IZy8OSnU0d0LFxtzmKxinENGlErlVW+//TZmACORmFM/tOmq0iG5XH4b1vr/Z+/cY5vIrj9+Zvy2Y8exYycmHhIT5+UbFtj9/bZh2WLz0MarLoiXYyo1iFKkPuSqgnYl1G5F/uhDLaWvVdltRaS2Yllqt6W7qLTsrpSkXZEAKktK7PAOyZgCedIEEtuZeCoTR03ZGW8S7LEzMx8JCelYo+PJ9XfOPXPuOWtKlxp7Rh70dd69JzY3mmGKioOxMKORbJFOOWzUKMS6lyR7lxBXXAVG1rxLIBD4is/n+4BbrzIDrwQmwc2bN4P19fVqs9m8hsm+mrBK3u68/Ggslv3xqjlBLIaBVhsHuSJTIjNlN+VFZBJcjF4en5DWdR8os9tTjHn9eWNj46HR0dHcOpm6QHKyCVE6oGn6NAC8zGT7Q1fo5o7j/nLuvcpRlEoKqh3STIw4MeUprlWY88Qh9tP0n0Crxgilim3tvY9h2Esc+5RReJPkfZKGhgZfYrvEZNte67B9e73zstjTN0kkIoXR0bS/UcIx7FGpQS2eOQIAOY4Pv1G1/E4KcbmXHKHMK3i3RZohFAqNAMCZZLvNJxslY+uW2You3b13/erAoPhmAx7PUYqDwZDWB45Zqxw0aRVs1amC4vMW6xW30bSKxRxtampyHjlypJtjtzIObwUGppO+AwihMYQQ41bpxdKl2DvdV4ZHJiLiUzYWA8jXx0EmS5fIxO0mzbhcigu+odRqnb79G6Xl1ThgjP1BA4HAqz6fL6c70y0U3uZgZkiOow0AwA4m++2RBz3VP3ldG6WmxEgmT0tBRSXjWIz5YtDIr1YXaavSca3FjE2p6j6GVhGJu8vykT8ihLYv9noXNnibg5kh8YdDCDWSJNnOZC8r0Nt+tXXzsJiPAYCHY1J49PCpczEYBuNlBrHfiwSw/tfKKqRs4pJYkwihz/FVXEAIAgPTIhNpbm7+AlvP3l2rVlTufm7V37j3LAcZfPpBbYV5igdKGS703Ev0cIWju1qTx1ZMN5lYk6FQiNctRXidg5lNW1vboMPhuIgQ2spUg7DFUV18jgz33BgaFvZhvGgUwGCkQSJZ8Pa5vFAzppBKBH2CvcFs6dxmLl7NYp7w+/3bfD4fY1TNJwQRwczg9Xr/HAwGD7OYVW9ueUUlxfFF0es0Y8TjONy9s+Btkl4lu6ZVygTda9ehzjv/NcLGWvsTDAZ/5PV6T3PrVXbgfZL3SaxWq5okyQ4AYJyUd/Ffd7vXH/216d+RqJCTvnGodgCoVPN6AGEAkZVW/ZBKLhHsEHuLXHH7aM0zUr1UxjYRoJMgiBfC4fA4x65lBcFskWZIjqO96HK59jLZLVqtCQP86gc3bwk5h4ABhk2BLn9eAmPUyPuL85WCFRcAmPxxheNOikOMdFNT0+ZTp071cuxX1hCcwMB0PuaOx+PpMZvNm5i2iWvKlub3jIyc67x7f2l2PMwBYlEaCk044HPXmGWFmlGlTCLUt0cT+5YuO+/SG59nsU/6/f5dPp/vDMd+ZRVB5WBmU1tb+9tAIHCAyYYBqH+zY2tdw3L0Efee5QgUJYG+3jkPtDZq5LfyVTLBRn1fKikN7TAVf5rNHggEXvV6vce59Sr7CC4HM5tkEd67ALCJyT4Wjd6xHfrZyND4eC333uUI1TUUqNSfVHwX+VSZYViCY4JM7j6rzW99vRKtBgC2Sf6/Rwh5+FzvwoZgIxj4bxHeTpIkzzPZtQpFyd+/uEdi0WqFO5J2Dr17i7SKIaGKS7lKff2wvcbBJi4kSZ5FCDUKUVxA6AID0yIz3tzcvJetkrfGVFjz/fqNfdx7liMMD9EQT/3WukinFOo6enjQVknJcdzMYp8ppotw7FfOIMgk75O0tbX1OxyOywihLQwnr2GlpbgoRlHvfdjbZxOcKNM0DvF4FHT5jNukArWst0SvsgjtvmAAo98trwo+q81nOyE94ff7t/p8vg6OXcspBLUoUuH1ek8Gg8Gfspjl36vfWP9Shf1Djt3KDQb6ZRCLMUV4k3bT42M2gntQ7bJYb7j0xjo2ezAY/KHX6/0Lt17lHqLAzMLtdn8nEdCwmPFjDdsqd65Y3gIAc367whNwGPr4GSVTnqJfJsFLs+NS9ngmT9uyq7gk1fc+43a7f8ChSzmLKDCzCIfDD10u18sAcJvJbtKol7zt3e56bd3a9xObB+49zCKDgx8bcVKky1gf35zFrtK890bV8pVKnHX87TWXy7U5HA7z+hDjXBFcaPtJ9Pb2Ujqdris5jpbp/mDry222/ytZcqmjLxx7EImwDSvnF/G4BFRqCpTTCd18pZQkCtRmAa2hh26D+Z1v2uw1GgnrUYjI/v37t584cYLxASVEBF0Hk4qWlpYvu1yuI6k+Q8Xjg9vf8l96t/vKekFEgzrdJJTapCCVxp8j9L0KmWRZtl3iiN4DpeUnNxUWfTWVoLa2tu5ct27d77h1LbcRytNn3ly4cOEfZrM5ghDawCbEOIapP7ui1vqZqoqgWi4fuDE0NDQxSRl5K9zRKIBMRhnMhv5inZL3uRcFjl/0mCwt3yqzTzyv07NFtI9pb28/tHbtWraXBIKFnz+ENNLS0rLb5XIdnaMYT5y+ev3sW5f+SR/vvFwFAAQHLnKLQkE5NrwwoOffsQAaAEgACK43FJ6zKTQTe5aUvAIArOX/s2hFCG0MhUJiV8QnEAVmDvj9/i0ej+eXAMBWUMXEwOV79+/fGB7Jo6amaP4khbF4gaXwI4kE70827lrka+jxMChMplLhLyrViegzEZlVppgZ/T+QJHnC7XbvDoVC0cz7uvhY5IuDO5xOp6G1tfWvAPD/2fYly0zO6gg4lfxHpziHw2eOIYR2i5ELO/xPTKaJtra2YYIgXIFA4OsAcC/b/uQIiW2jPCkucQCgkjVCU8n/85WRQCCwB8OwRlFcRNKOx+Mx0DT9Jk3TFC08YvP4bCR5j6IZ9Idr/uR0OguyvQZFBMC+ffscZ8+e/QVN0wPZXvUcMh+Bmc2M2FBPcY1s8aivr+/4wYMHN1itVjGtIMItTqcT9/v9m2iaPknT9ES2fw0ZJl3iMCM0kTRdLxOQXV1dB5xOp+CnUy4UUY3TTF1dnYogiOq6ujoHQRAEAFgAgE/VvlMZqJ+iEtd0OBwShBDBcX1W4vuMB4PBR8l55j0kSd7q6Ojoam9v7w6Hw089iE7I/CcAAP//LazR1LfsgEMAAAAASUVORK5CYII=
+      mediatype: image/png
+  labels:
+    alm-owner-kubevirt: kubevirt-hyperconverged
+    operated-by: kubevirt-hyperconverged
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-hyperconverged
+      operated-by: kubevirt-hyperconverged
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: true
+    - type: AllNamespaces
+      supported: true
+  install:
+    strategy: deployment
+    spec:
+
+      permissions:
+        - serviceAccountName: cluster-network-addons-operator
+          rules:
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - patch
+              - update
+              - delete
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - replicasets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - patch
+              - update
+              - delete
+
+
+      clusterPermissions:
+        - serviceAccountName: hyperconverged-cluster-operator
+          rules:
+            - apiGroups:
+              - hco.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - networkaddonsoperator.network.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              - pods
+              - serviceaccounts
+              - services
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - delete
+            - apiGroups:
+              - batch
+              resources:
+              - jobs
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - daemonsets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - rbac.authorization.k8s.io
+              resources:
+              - clusterroles
+              - clusterrolebindings
+              - roles
+              - rolebindings
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+              - update
+            - apiGroups:
+              - security.openshift.io
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - privileged
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - patch
+              - update
+
+
+        - serviceAccountName: kubevirt-operator
+          rules:
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - kubevirts
+              verbs:
+              - get
+              - list
+              - watch
+              - patch
+              - update
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - serviceaccounts
+              - services
+              - endpoints
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - delete
+              - patch
+            - apiGroups:
+              - batch
+              resources:
+              - jobs
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - daemonsets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+            - apiGroups:
+              - rbac.authorization.k8s.io
+              resources:
+              - clusterroles
+              - clusterrolebindings
+              - roles
+              - rolebindings
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+              - update
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+            - apiGroups:
+              - security.openshift.io
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - privileged
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - patch
+              - update
+            - apiGroups:
+              - admissionregistration.k8s.io
+              resources:
+              - validatingwebhookconfigurations
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - admissionregistration.k8s.io
+              resources:
+              - validatingwebhookconfigurations
+              - mutatingwebhookconfigurations
+              verbs:
+              - get
+              - create
+              - update
+            - apiGroups:
+              - apiregistration.k8s.io
+              resources:
+              - apiservices
+              verbs:
+              - get
+              - create
+              - update
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - ""
+              resources:
+              - pods/exec
+              verbs:
+              - create
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachines
+              - virtualmachineinstances
+              - virtualmachineinstancemigrations
+              verbs:
+              - get
+              - list
+              - watch
+              - patch
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachineinstancepresets
+              verbs:
+              - watch
+              - list
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - limitranges
+              verbs:
+              - watch
+              - list
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - get
+              - list
+              - delete
+              - update
+              - create
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - policy
+              resources:
+              - poddisruptionbudgets
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - configmaps
+              - endpoints
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - update
+              - create
+            - apiGroups:
+              - ""
+              resources:
+              - events
+              verbs:
+              - update
+              - create
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - pods/finalizers
+              verbs:
+              - update
+            - apiGroups:
+              - ""
+              resources:
+              - nodes
+              verbs:
+              - get
+              - list
+              - watch
+              - update
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - persistentvolumeclaims
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - k8s.cni.cncf.io
+              resources:
+              - network-attachment-definitions
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachineinstances
+              verbs:
+              - update
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              - persistentvolumeclaims
+              verbs:
+              - get
+            - apiGroups:
+              - ""
+              resources:
+              - nodes
+              verbs:
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - events
+              verbs:
+              - create
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - create
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - version
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - virtualmachineinstances/console
+              - virtualmachineinstances/vnc
+              verbs:
+              - get
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - virtualmachines/start
+              - virtualmachines/stop
+              - virtualmachines/restart
+              verbs:
+              - update
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachines
+              - virtualmachineinstances
+              - virtualmachineinstancepresets
+              - virtualmachineinstancereplicasets
+              - virtualmachineinstancemigrations
+              verbs:
+              - get
+              - delete
+              - create
+              - update
+              - patch
+              - list
+              - watch
+              - deletecollection
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - virtualmachineinstances/console
+              - virtualmachineinstances/vnc
+              verbs:
+              - get
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - virtualmachines/start
+              - virtualmachines/stop
+              - virtualmachines/restart
+              verbs:
+              - update
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachines
+              - virtualmachineinstances
+              - virtualmachineinstancepresets
+              - virtualmachineinstancereplicasets
+              - virtualmachineinstancemigrations
+              verbs:
+              - get
+              - delete
+              - create
+              - update
+              - patch
+              - list
+              - watch
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachines
+              - virtualmachineinstances
+              - virtualmachineinstancepresets
+              - virtualmachineinstancereplicasets
+              - virtualmachineinstancemigrations
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - authentication.k8s.io
+              resources:
+              - tokenreviews
+              verbs:
+              - create
+            - apiGroups:
+              - authorization.k8s.io
+              resources:
+              - subjectaccessreviews
+              verbs:
+              - create
+
+        - serviceAccountName: cdi-operator
+          rules:
+            - apiGroups:
+              - rbac.authorization.k8s.io
+              resources:
+              - roles
+              - rolebindings
+              - clusterrolebindings
+              - clusterroles
+              verbs:
+              - '*'
+            - apiGroups:
+              - security.openshift.io
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - privileged
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - patch
+              - update
+            - apiGroups:
+              - ""
+              resources:
+              - serviceaccounts
+              - services
+              verbs:
+              - '*'
+            - apiGroups:
+              - ""
+              resources:
+              - nodes
+              verbs:
+              - get
+              - list
+              - watch
+              - update
+              - patch
+            - apiGroups:
+              - extensions
+              resources:
+              - deployments
+              verbs:
+              - '*'
+            - apiGroups:
+              - extensions
+              resources:
+              - ingresses
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - watch
+              - create
+              - delete
+              - get
+              - update
+              - patch
+              - list
+            - apiGroups:
+              - batch
+              resources:
+              - jobs
+              verbs:
+              - create
+              - delete
+              - get
+              - update
+              - patch
+              - list
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - create
+              - delete
+              - get
+              - update
+              - patch
+              - list
+              - watch
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - daemonstes
+              verbs:
+              - create
+              - get
+              - list
+              - delete
+              - watch
+              - update
+            - apiGroups:
+              - admissionregistration.k8s.io
+              resources:
+              - validatingwebhookconfigurations
+              - mutatingwebhookconfigurations
+              verbs:
+              - get
+              - create
+              - update
+            - apiGroups:
+              - apiregistration.k8s.io
+              resources:
+              - apiservices
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - storage.k8s.io
+              resources:
+              - storageclasses
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - ""
+              resources:
+              - events
+              verbs:
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - persistentvolumeclaims
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - ""
+              resources:
+              - persistentvolumeclaims/finalizers
+              - pods/finalizers
+              verbs:
+              - update
+            - apiGroups:
+              - ""
+              resources:
+              - services
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+            - apiGroups:
+              - ""
+              resources:
+              - namespaces
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - route.openshift.io
+              resources:
+              - routes
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - route.openshift.io
+              resources:
+              - routes/custom-host
+              verbs:
+              - create
+              - update
+
+        - serviceAccountName: cluster-network-addons-operator
+          rules:
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - privileged
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - networkaddonsoperator.network.kubevirt.io
+              resources:
+              - networkaddonsconfigs
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - '*'
+              resources:
+              - '*'
+              verbs:
+              - '*'
+
+        - serviceAccountName: kubevirt-ssp-operator
+          rules:
+          - apiGroups:
+            - kubevirt.io
+            - oauth.openshift.io
+            - template.openshift.io
+            resources:
+            - '*'
+            verbs:
+            - '*'
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - clusterroles
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - patch
+            - update
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - clusterrolebindings
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - patch
+            - update
+          - apiGroups:
+            - extensions
+            - apps
+            resources:
+            - deployments
+            - replicasets
+            - daemonsets
+            - statefulsets
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - serviceaccounts
+            - configmaps
+            - nodes
+            - endpoints
+            - events
+            - secrets
+            verbs:
+            - create
+            - get
+            - patch
+            - update
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - services
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - admissionregistration.k8s.io
+            resources:
+            - validatingwebhookconfigurations
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - watch
+          - apiGroups:
+            - security.openshift.io
+            resources:
+            - securitycontextconstraints
+            verbs:
+            - '*'
+            resourceNames:
+            - privileged
+
+        - serviceAccountName: node-maintenance-operator
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - services
+            - endpoints
+            - events
+            - configmaps
+            - serviceaccounts
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - get
+            - list
+            - update
+            - patch
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - pods/eviction
+            verbs:
+            - create
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            - daemonsets
+            - replicasets
+            - statefulsets
+            verbs:
+            - '*'
+          - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - servicemonitors
+            verbs:
+            - get
+            - create
+          - apiGroups:
+            - kubevirt.io
+            resources:
+            - '*'
+            verbs:
+            - '*'
+          - apiGroups:
+            - oauth.openshift.io
+            resources:
+            - '*'
+            verbs:
+            - '*'
+
+      deployments:
+        - name: hco-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: hyperconverged-cluster-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: hyperconverged-cluster-operator
+              spec:
+                containers:
+                - command:
+                  - hyperconverged-cluster-operator
+                  env:
+                  - name: OPERATOR_IMAGE
+                    value: quay.io/kubevirt/hyperconverged-cluster-operator:v0.0.1
+                  - name: OPERATOR_NAME
+                    value: hyperconverged-cluster-operator
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  image: quay.io/kubevirt/hyperconverged-cluster-operator:v0.0.1
+                  imagePullPolicy: Always
+                  name: hyperconverged-cluster-operator
+                  resources: {}
+                serviceAccountName: hyperconverged-cluster-operator
+
+
+        - name: virt-operator
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                kubevirt.io: virt-operator
+            strategy:
+              type: RollingUpdate
+            template:
+              metadata:
+                annotations:
+                  scheduler.alpha.kubernetes.io/critical-pod: ""
+                  scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly","operator":"Exists"}]'
+                labels:
+                  kubevirt.io: virt-operator
+                  prometheus.kubevirt.io: ""
+                name: virt-operator
+              spec:
+                containers:
+                - command:
+                  - virt-operator
+                  - --port
+                  - "8443"
+                  - -v
+                  - "2"
+                  env:
+                  - name: OPERATOR_IMAGE
+                    value: kubevirt/virt-operator:v0.17.4
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.annotations['olm.targetNamespaces']
+                  image: kubevirt/virt-operator:v0.17.4
+                  imagePullPolicy: IfNotPresent
+                  name: virt-operator
+                  ports:
+                  - containerPort: 8443
+                    name: metrics
+                    protocol: TCP
+                  readinessProbe:
+                    httpGet:
+                      path: /metrics
+                      port: 8443
+                      scheme: HTTPS
+                    initialDelaySeconds: 5
+                    timeoutSeconds: 10
+                  resources: {}
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: kubevirt-operator
+
+        - name: cdi-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: cdi-operator
+                operator.cdi.kubevirt.io: ""
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: cdi-operator
+                  operator.cdi.kubevirt.io: ""
+              spec:
+                containers:
+                - env:
+                  - name: DEPLOY_CLUSTER_RESOURCES
+                    value: "true"
+                  - name: DOCKER_REPO
+                    value: kubevirt
+                  - name: DOCKER_TAG
+                    value: v1.9.4
+                  - name: CONTROLLER_IMAGE
+                    value: cdi-controller
+                  - name: IMPORTER_IMAGE
+                    value: cdi-importer
+                  - name: CLONER_IMAGE
+                    value: cdi-cloner
+                  - name: APISERVER_IMAGE
+                    value: cdi-apiserver
+                  - name: UPLOAD_SERVER_IMAGE
+                    value: cdi-uploadserver
+                  - name: UPLOAD_PROXY_IMAGE
+                    value: cdi-uploadproxy
+                  - name: VERBOSITY
+                    value: "1"
+                  - name: PULL_POLICY
+                    value: IfNotPresent
+                  image: kubevirt/cdi-operator:v1.9.4
+                  imagePullPolicy: IfNotPresent
+                  name: cdi-operator
+                  ports:
+                  - containerPort: 60000
+                    name: metrics
+                    protocol: TCP
+                  resources: {}
+                serviceAccountName: cdi-operator
+
+        - name: cluster-network-addons-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: cluster-network-addons-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: cluster-network-addons-operator
+              spec:
+                containers:
+                - env:
+                  - name: MULTUS_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
+                  - name: LINUX_BRIDGE_IMAGE
+                    value: quay.io/kubevirt/cni-default-plugins:v0.8.0
+                  - name: LINUX_BRIDGE_MARKER_IMAGE
+                    value: quay.io/kubevirt/bridge-marker:0.1.0
+                  - name: SRIOV_DP_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829
+                  - name: SRIOV_CNI_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973
+                  - name: NMSTATE_HANDLER_IMAGE
+                    value: quay.io/nmstate/kubernetes-nmstate-handler:v0.3.0
+                  - name: SRIOV_ROOT_DEVICES
+                  - name: SRIOV_NETWORK_NAME
+                    value: sriov-network
+                  - name: SRIOV_NETWORK_TYPE
+                    value: sriov
+                  - name: KUBEMACPOOL_IMAGE
+                    value: quay.io/kubevirt/kubemacpool:v0.3.0
+                  - name: OPERATOR_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addons-operator:0.11.0
+                  - name: OPERATOR_NAME
+                    value: cluster-network-addons-operator
+                  - name: OPERATOR_VERSION
+                    value: 0.11.0
+                  - name: OPERATOR_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: WATCH_NAMESPACE
+                  image: quay.io/kubevirt/cluster-network-addons-operator:0.11.0
+                  imagePullPolicy: IfNotPresent
+                  name: cluster-network-addons-operator
+                  resources: {}
+                serviceAccountName: cluster-network-addons-operator
+
+        - name: kubevirt-ssp-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: kubevirt-ssp-operator
+            template:
+              metadata:
+                labels:
+                  name: kubevirt-ssp-operator
+              spec:
+                serviceAccountName: kubevirt-ssp-operator
+                containers:
+                  - name: kubevirt-ssp-operator
+                    image: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.4
+                    ports:
+                    - containerPort: 60000
+                      name: metrics
+                    imagePullPolicy: Always
+                    env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: WATCH_NAMESPACE
+                        value: ""
+                      - name: VIRT_LAUNCHER_TAG
+                        value: v0.17.4
+                      - name: OPERATOR_NAME
+                        value: "kubevirt-ssp-operator"
+
+        - name: node-maintenance-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: node-maintenance-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: node-maintenance-operator
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: node-role.kubernetes.io/master
+                          operator: Exists
+                containers:
+                - env:
+                  - name: WATCH_NAMESPACE
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: OPERATOR_NAME
+                    value: node-maintenance-operator
+                  image: quay.io/kubevirt/node-maintenance-operator:v0.3.0
+                  imagePullPolicy: Always
+                  name: node-maintenance-operator
+                  resources: {}
+                serviceAccountName: node-maintenance-operator
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+
+  customresourcedefinitions:
+    owned:
+      - name: hyperconvergeds.hco.kubevirt.io
+        version: v1alpha1
+        kind: HyperConverged
+        displayName: KubeVirt HyperConverged Cluster Operator Deployment
+        description: Represents the deployment of a KubeVirt HyperConverged Cluster Operator
+
+      - name: kubevirts.kubevirt.io
+        version: v1alpha3
+        kind: KubeVirt
+        displayName: KubeVirt deployment
+        description: Represents a KubeVirt deployment.
+      - name: cdis.cdi.kubevirt.io
+        version: v1alpha1
+        kind: CDI
+        displayName: CDI Application
+        description: Represents an instance of a CDI application
+      - name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+        version: v1alpha1
+        kind: NetworkAddonsConfig
+        displayName: Cluster Network Addons
+        description: Cluster Network Addons
+      - name: kubevirtcommontemplatesbundles.kubevirt.io
+        version: v1
+        kind: KubevirtCommonTemplatesBundle
+        displayName: KubeVirt Common Templates
+        description: KubeVirt Common Templates
+      - name: kubevirtnodelabellerbundles.kubevirt.io
+        version: v1
+        kind: KubevirtNodeLabellerBundle
+        displayName: KubeVirt Node Labeller Bundler
+        description: KubeVirt Node Labeller Bundler
+      - name: kubevirttemplatevalidators.kubevirt.io
+        version: v1
+        kind: KubevirtTemplateValidator
+        displayName: KubeVirt Template Validator
+        description: KubeVirt Template Validator
+      - name: nodemaintenances.kubevirt.io
+        version: v1alpha1
+        kind: NodeMaintenance
+        displayName: Node Maintenance
+        description: Node Maintenance

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/kubevirt.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/kubevirt.crd.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  scope: Namespaced
+  version: v1alpha3

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/kwebui.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/kwebui.crd.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kwebuis.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KWebUI
+    listKind: KWebUIList
+    plural: kwebuis
+    singular: kwebui
+  scope: Cluster
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/node-labeller-bundles.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/node-labeller-bundles.crd.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtnodelabellerbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtNodeLabellerBundle
+    listKind: KubevirtNodeLabellerBundleList
+    plural: kubevirtnodelabellerbundles
+    singular: kubevirtnodelabellerbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/nodemaintenance.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/nodemaintenance.crd.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: nodemaintenances.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: NodeMaintenance
+    listKind: NodeMaintenanceList
+    plural: nodemaintenances
+    singular: nodemaintenance
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            nodeName:
+              type: string
+            reason:
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          properties:
+            phase:
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/template-validator.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/manifests/template-validator.crd.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirttemplatevalidators.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtTemplateValidator
+    listKind: KubevirtTemplateValidatorList
+    plural: kubevirttemplatevalidators
+    singular: kubevirttemplatevalidator
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}

--- a/community-operators/community-kubevirt-hyperconverged/0.0.1/metadata/annotations.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.1/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: 0.0.1
+  operators.operatorframework.io.bundle.channels.v1: 0.0.1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: community-kubevirt-hyperconverged

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/cdi.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/cdi.crd.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.cdi.kubevirt.io: ""
+  name: cdis.cdi.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: cdi.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: CDI
+    listKind: CDIList
+    plural: cdis
+    shortNames:
+    - cdi
+    - cdis
+    singular: cdi
+  scope: Cluster
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/cna.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/cna.crd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/common-template-bundles.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/common-template-bundles.crd.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtcommontemplatesbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtCommonTemplatesBundle
+    listKind: KubevirtCommonTemplatesBundleList
+    plural: kubevirtcommontemplatesbundles
+    singular: kubevirtcommontemplatesbundle
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  subresources:
+    status: {}

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/hco.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/hco.crd.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hyperconvergeds.hco.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: hco.kubevirt.io
+  names:
+    kind: HyperConverged
+    plural: hyperconvergeds
+    shortNames:
+    - hco
+    - hcos
+    singular: hyperconverged
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/kubevirt-hyperconverged-operator.v0.0.2.clusterserviceversion.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/kubevirt-hyperconverged-operator.v0.0.2.clusterserviceversion.yaml
@@ -1,0 +1,1700 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: >-
+      [
+        {
+          "apiVersion": "hco.kubevirt.io/v1alpha1",
+          "kind": "HyperConverged",
+          "metadata": {
+            "name": "kubevirt-hyperconverged",
+            "namespace": "kubevirt-hyperconverged"
+          },
+          "spec": {
+            "BareMetalPlatform": false
+          }
+        },
+        {
+          "apiVersion": "cdi.kubevirt.io/v1alpha1",
+          "kind": "CDI",
+          "metadata": {
+            "name": "cdi"
+          }
+        },
+        {
+          "apiVersion": "kubevirt.io/v1alpha3",
+          "kind": "KubeVirt",
+          "metadata": {
+            "name": "kubevirt",
+            "namespace": "kubevirt"
+          }
+        },
+        {
+          "apiVersion": "networkaddonsoperator.network.kubevirt.io/v1alpha1",
+          "kind": "NetworkAddonsConfig",
+          "metadata": {
+            "name": "network-addons"
+          }
+        },
+        {
+          "apiVersion": "kubevirtcommontemplatesbundles.kubevirt.io/v1",
+          "kind": "KubevirtCommonTemplatesBundle",
+          "metadata": {
+            "name": "common-templates"
+          }
+        },
+        {
+          "apiVersion": "kubevirtnodelabellerbundles.kubevirt.io/v1",
+          "kind": "KubevirtNodeLabellerBundle",
+          "metadata": {
+            "name": "node-labeller"
+          }
+        },
+        {
+          "apiVersion": "kubevirttemplatevalidators.kubevirt.io/v1",
+          "kind": "KubevirtTemplateValidator",
+          "metadata": {
+            "name": "template-validator"
+          }
+        },
+        {
+          "apiVersion": "kubevirtmetricsaggregations.kubevirt.io/v1",
+          "kind": "KubevirtMetricsAggregation",
+          "metadata": {
+            "name": "metrics-aggregation"
+          }
+        },
+        {
+          "apiVersion": "machineremediation.kubevirt.io/v1alpha1",
+          "kind": "MachineRemediationOperator",
+          "metadata": {
+            "name": "mro"
+          }
+        },
+        {
+          "apiVersion": "kubevirt.io/v1alpha1",
+          "kind": "NodeMaintenance",
+          "metadata": {
+            "name": "node-maintenance"
+          },
+          "spec": {
+            "nodeName": "nodename",
+            "reason": "node maintenance reason"
+          }
+        },
+        {
+          "apiVersion": "kubevirt.io/v1alpha1",
+          "kind": "V2VVmware",
+          "metadata": {
+            "name": "v2vvmware"
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: OpenShift Optional
+    certified: 'false'
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
+    createdAt: 2019-09-19 20:56:20.694261504 +0200 CEST m=+0.019236203
+    description: Creates and maintains a HyperConverged KubeVirt Deployment
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    support: 'false'
+  name: kubevirt-hyperconverged-operator.v0.0.2
+  namespace: placeholder
+spec:
+  displayName: KubeVirt HyperConverged Cluster Operator
+  description: >
+    **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+    Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+    Containerized Data Importer (CDI), and Cluster Network Addons (CNA) operators.
+
+    **KubeVirt** is a virtual machine management add-on for Kubernetes.
+    The aim is to provide a common ground for virtualization solutions on top of
+    Kubernetes.
+
+    # Virtualization extension for Kubernetes
+
+    At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+    additional virtualization resource types (especially the `VirtualMachine` type) through
+    [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+    By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+    resources alongside all other resources Kubernetes provides.
+
+    The resources themselves are not enough to launch virtual machines.
+    For this to happen the _functionality and business logic_ needs to be added to
+    the cluster. The functionality is not added to Kubernetes itself, but rather
+    added to a Kubernetes cluster by _running_ additional controllers and agents
+    on an existing cluster.
+
+    The necessary controllers and agents are provided by KubeVirt.
+
+    As of today KubeVirt can be used to declaratively
+
+      * Create a predefined VM
+      * Schedule a VM on a Kubernetes cluster
+      * Launch a VM
+      * Migrate a VM
+      * Stop a VM
+      * Delete a VM
+
+    # Start using KubeVirt
+
+      * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+      * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+    # Start developing KubeVirt
+
+    To set up a development environment please read our
+    [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+    To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+    You can learn more about how KubeVirt is designed (and why it is that way),
+    and learn more about the major components by taking a look at our developer documentation:
+
+      * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+      * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+      * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+    # Community
+
+    If you got enough of code and want to speak to people, then you got a couple of options:
+
+      * Follow us on [Twitter](https://twitter.com/kubevirt)
+      * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+      * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+      * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+    # License
+
+    KubeVirt is distributed under the
+    [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+
+  keywords:
+    - KubeVirt
+    - Virtualization
+  version: 0.0.2
+  maturity: alpha
+  replaces: kubevirt-hyperconverged-operator.v0.0.1
+  maintainers:
+    - name: KubeVirt project
+      email: kubevirt-dev@googlegroups.com
+  provider:
+    name: KubeVirt project
+  links:
+    - name: KubeVirt
+      url: https://kubevirt.io
+    - name: Source Code
+      url: https://github.com/kubevirt/hyperconverged-cluster-operator
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAARgAAAEYCAYAAACHjumMAABam0lEQVR4nOydB3gb9fn4v3faw5Js2fKSvO0kkrMTsCFgBQKEslqIzB+6AAcocVpIKD9aWrBSaKEtJKUQEjLKKO0PLFo2hG1DEpvEcZYl7ynZkqf2lu7+jx2HXxLfOZJO077P8+Qp1ffu9Fo6vfd+30kFJCTTKBQKLgBgoUKhKAEA5AIAssRicVp5efnk62wAADL9zzv5r6GhwarT6QYAAL0qleqEVqs92djY6I3130FCQhJHVFRUcFpaWl5CUdSPEmMMRdFdCoUiP9Z/EwkJSYxRKBRFhw8f3o6iqImgYrkQF4qiHz/33HO3SqVSONZ/JwkJSRSpqKjgTlss0aCttrZ2baz/ZhISkgijUChKDh8+/DcURc1RUi5nmdx6ff3cc88ppFIpJdafAwkJSRipqKjgtbS0vBxlpYJHV21t7bWx/kxIogMUawFIIkdZWZl4+/bt/1NeXn4XACAp0PMQAGxDTqel3Wpnj7s9DA+CuLwIgkyaIQgAKAwgiEWBqRwqlV3M5TiKkzhUOgxzgxANBQAc2r59++4dO3a8qdPp/KH9hSTxDqlg5iBSqZS1c+fOR+Ry+f8AADiBnudDENsjp1qtz3f2pKEABJzCQIEgz63ZmdpfLyhkXJIiEAcp7mGlUnn/tm3bWoI8jyQBIBXMHGLSYtm6dWuVQqHYCAAI+Ifeb3eYdnX3gZd7+hkmr48V6vtDAHivzxCNVhfloT/ITBcBAGgBnopqtdoP9u/fv2v//v2fkxbN3IFUMHMAqVTK2blz5//I5fJfTyfEBcSkxbL1pNr2QldfRrhlKuUl9e9ZtRSUC5Nzgzz1u2mL5mS4ZSKJPqSCSWDKyspypi2We4KxWHpsdtPunn6wu7ufafX5mBEU0XdNetrIpsJc9IfZmWkAAHqgJ2q12o+mLZpPdTqdL4IykkQQUsEkIFKplLtz587fyOXyrQCAgLc0XgSxPXi8xbarpz/sFsvFKOZytPtWLfVfmSbMC/LUY0ql8hfbtm1ripBoJBGEVDAJhEKhyFUoFBunLZasQM/rstlNL3f3o7u6+1h2vz+SFsvF8MvThCObCvMQhSRLCAAIWBatVvvptEXzsU6nI+udEgRSwSQACoUiqba29jEAwEPB/Ch9COLc1Hzasrd3ID2yEgZPDps1tH/VMte69NSCIE89qVQqN23btu1whEQjCSOkgoljtmzZkl9VVXWvTCa7CwCQGeh5Q06X/ZU+rXdfTz+tz+EMOEwdA5AfZmXoHyjMg67NSJu0aBiBnqjVar+ctmg+0Ol0nsiKSRIqpIKJQxQKBa+2tvZxAMAvg/nReRHE8df2bstTrZ3JTr8/4PPigbKU5MG9q5Y4Svm84iBPbVEqlZu3bdtWHyHRSAhAKpg4QqFQ8Lds2bKxvLz8EQBAwNuaQafL/o/eAe++3gHaQHxbLBcDvT5DpK8uygPXZ6anwMH5aOp37NixTaVSHdbpdO7IikkSKKSCiQMqKiqgnTt3/lImkz0TTFTIgyCOP7d1Wf7U2pniQpCAQ8CJwMpkwdDuFUtsq1L4JUGe2lZZWXm7SqU6FSHRSIKAVDAxRKFQJE9bLA8AAAJu0qR1OKcslv29AzSt05XIFstFuVqUOrS5KB+6KStdQIGgQJWvBwDw0fbt26cygzUaTYSlJMGDVDAxYNpieUgmk/0pmKiQy++3P9PWZX26rSvFM8cslouxhM/Tv7RisfXy1JTiIO/b71Qq1QOVlZXHIygeCQ6kgokiCoUiZcuWLfeVl5f/YrrnbUAMOJz2/T393v19Wvqg0xVwKcBc5MrUFP3monz0h9kZAhoMB/pZeAEAB7Zv3/7S/v37D5AWTfQgFUyEEYvFUFVVVVlVVdUmiURyezAFgF+PjBlf7OqD3xsycP0oSjZoP4dsFtN4T36OsypPwsjlsIVBnNrb0NCwa8eOHftUKpUxgiKSkAomstTU1OQolcpdAIAfBHPeSZNlYlPzKd/hcaMoctLNDagQ5Pz1gkLtE9KSNBaFkhzEqS61Wv276urqHfX19WgERZzXkAomzExbLJdNWyyVIPC+KugJk9m8u7sf2dc7wPejKNlaMggymAzT1pIC123ZmbQCLicYi2agoaFh944dO/aoVKrxCIo4LyEVTBipqanJUyqVuwEA1wVznsnjndjYdBL5z6A+NXLSzQ9gANx/X764p7oorzCY6m0AgEetVtdUV1f/pb6+HomgiPMKUsEQZNpiuaKqquoBiUSyIQiLBWk2mi27u/uQV/q0PB/pYwkruWzWyP2Fucimwjwqn0YLRnEPNjQ0vLxjx46XVSrVSARFnBeQCoYACoUivba29g0AwLpgzpvweMarjp5E3x0ykBZLhIEBcP1lyaLehxcU5QeTEgAA8KrV6icrKyv/qNFoSIsmREgFEwJbtmwpnbRYZDLZnQAAQYCnIUcnTJaXe/qRV/u0pI8lymSxmGO/KMj1bSrKg4V0ejDO89Mqlerl7du3/6uxsdEUQRHnJKSCCQKFQpFZW1v7DADgxwCAgBXEmNszds/RE9AH+uFgnI8kkcHzpGxh9++lxTnBNEQHAAzX1dX9rrq6+lWNRkP2DA4QUsEEwJYtW5ZMWyx3AAD4AZ6GfDdhtOzu6kde79fxEUBaLPGEiEEff6Awz/tAYR6UzmQE0y+nddqi+WdjY+NEBEWcE5AKZhYUCkVWbW3tXwAAd5zZzgfGsMs9es/RE/DHhhHSYol/fI8tKup8snSRGA5idtSkYVpXV/dEdXX1Xo1GQ/YMxoFUMBhs2bJl2bTF8v8AALwAT/M3jButu7v7kDf6dQIkCIVEEnuS6TTjpsI89y8KcoGYzQqmZ3HHtEXzemNj41gERUxISAVzDgqFQlxbW/vs5H8GY7Hona6Re5pOUg8YRlIiKyFJFEAeKi7oeHapNIMCQYE68CeZqKur+0N1dfUujUZDdtibhlQwZyyWFdMWy+3BjFhts9gsT7V2+P49MChASYtlTpFEpZo3FeY5tpQUMNOZjGBKELpVKtWe7du3v9rY2Djv82jmtYJRKBQ5tbW1zwEAbgvmsxh3e8yPnW517u0dEJGKZW7DoVAsNbIFhq0lBZkUCArGR2Ouq6t7qrq6+gWNRjNvO+zNSwWzZcuWVVVVVZtkMtnkVijgoe2tFqtlV3c/8s9+HdPk9cZy/AdJlMnjsIwb83Ncd+flMLJYzGC2wr0qlWrf9u3bX2lsbNRHUMS4ZF4pmIqKCtbOnTv/JJPJHgzmbx91u82/OdXqfKVPm47Os8+M5HyYMGz73aLioUcXFqXTYDjQlIVJrHV1dc9UV1fv0Gg0zgiKGFfMix+LQqHI37Jly6by8vIqAEDA+2n1pMXS1Ye8MaBjmr0RHbFKkmBIWCzjPfkSZ1V+DlPCZgVj0Qxs37796f3797+u0WgcERQxLpjTCqaiooK9c+fOZ2Qy2S+DOW/Y5TY9ekrjeq1flz7XPyMSYtAgyPHowiLd7xYVi5gUSjBRJ5NKpXqosrLytQiKF3Pm5I9HoVAUnmOxBGzGnjZbzbu6e9F/9Q+yLD5fQs0VIoktWUyG6a78HOfG/Bx6fnAd9jTTzclf0Wg09giKGBPmjIIRi8W0qqqqH0y3TQi4HwsCgOetgUHbru4++NuxiWCeQCQkM4AB8NyQlT6+uTAfuTYjLT2I9h3OhoaG13fs2LGroaHhpE6ni7Ck0WFOKJiamppypVL5EgBgWTDnfTY8Olx19ART53QF46wjIQmI5QJ+7+6VS6iXpAgkQZ76plKp/NW2bdtGIyRa1EhYBSMWi+lVVVU3TLemDLgfCwKA93/7dZMWC3Ro3EhaLCQRBQLAtz4jbXRTYT5yY1a6KIim7y6tVvuv6fnbxxLVoklIBVNTU7NGqVTuBAAsCeY8jcVquLfpJOPwuDGYzEwSkrAg5SX17125BFyWmhLwyJpp/jM9f9sQIdEiRsIomGmL5aZpi+WqQM+btFg+04/YX+ruQz/QD5OKhSTW+O+UZBt+UZgLX5EmTA3CovFotdp/T1s0RxLFokkIBVNTU1OhVCpfBACUBnPeabNFf2/TKeZ3E6TFQhJ/rE1L1f5j9VJfHocd8NjgaT5QKpWbtm3bFvdaJq4VzJYtW+RbtmypkUgk8kDPQQDwHNAPO3Z29aEfG0ZIxUIS7/g3iDMNDxTmQVeJUlODmITg1Wq1b+3YseOpHTt2tEdYxpCJSwWjUChKa2trdwIArgzmvOMms+H+plOMo0YTqVhIEo41qSm6fauWuhckcQuDOM0HAPhHZWXl71UqVdxFneJKwWzZskVWVVX1qEwmqwQABJTo5keB5xP9sP3Frl7o0+FRMipEkuggN2Wl6zcV5sHXZYhSoAB/BwCACbVa/a/9+/dPWjWHIixjwMSFgpFKpWDnzp33yeXyvwEAWIGe1zRhMtzffIrZbDSTioVkznFpSvLgnpVLHEsEvOIgTz1QWVl5l0qlGo6QaAETcwUjlUqFBw4c2C6RSH4WyPF+FPV8ODTs2NnVCz4fGSMVC8lcB12fkaavLsoHP8hMT4EDn+00qFKpfrd169Z/6nS6mM11iqmCqampKVEqlQcBAGkAAD0AIHO24xsnjIYHmk4xT5gtpGIhmXesEPCHdq1cbL8kJTlgi0atVu8sLS3dHFnJ8ImZgqmpqVmiVCr/AwAomn7JON2u8rzaDR+CuD/QDztf7OoDX5EWCwkJuEqUqt9cmIfenJ0hoEAQO4BTnpBIJE/pdDo0CuKdR0wUTE1NTb5SqTyF0U3OdO6kxA6rzaJoOIacIi0WEpIZLOYn6d8qW4ks4iVlz3LY5IM7Wa1W/7a0tPSZKIo3RdQVjFQqZR04cOBriURyKcbyBAAgxeByef7c1u3b29NPt/v95FB4EhIcqBDkvk2cOfr4ohKajJ+ENUDOON1kzadWq59Yv379M9G0ZKI+bXBkZOQ1Pp9/Pc4y47jR3Hd1fQP3s+FRlhdFyYbaJCSzgABAVVusvN3dfdQsFuvEymR++jkjd2zTiXu0yddEItHVEolEq1KpjkdLvqgqmOeee+628vLyJ/HW//T1N947PzwwYOJOmXwxj3CRkCQKKADUD/TDWV02u3Z9hgihwTALADA2uSM49ziZTLYGAPBpfX19VELYUf0Royh6anLriLX2dN233sc++5I2pZQXLuoBLHZRNGUjIZkr5HJY2kNr1ziyWcwFOIfoZTLZQo1GY4m0LFHbgrz11lv34SmXN0+1+B777Evq9zKNj0fd201CMlfotzslD7dqPFYf7sjszH379v0mGrJEZYsklUpZL7300gGAkSTk9vnA9a++gdg8nv+TxelAQHqGDUBQwDOLSEhIzgBBoI3HpwsbLSbWDUIRTIFmblQkEskqAMCe+vr6iE42iIoFU1VVddO54edz+WntOy6D1XZ+pAhF04B2oDcaspGQzDGQElFSH4BARpfTTtk12I+XxctSKpUvicXiiAoTFQWjUCh+gvX6p51dPlWLGjv1eXxsJXA4SCVDQhIESQzqKSGH/n0L2doRPfzB2DCektmgUCiC6lgQLBFXMBUVFZBEIsH8I145Nmu0jAbGRvwRE4yEZA6SKWCiF2bD/6W/G4x43Jh+zaqqqjsiKU/EFYxcLr8SazaRD0HQzzq7cb1QUxiNycDvH4+kfCQkcwUWjXJKyGHkXPg6AgD87ugwpoKRyWTXS6XSiEWTI65glErlLVivv6tpMxmdrtkrQxFECIwTxkjJRkIyh0DyUzl6CADMoW+fG8fwtkm5CoVihlIKF9HwwWAOQfv3ydOBRYjGRqnTXbtISEhw4DKoGgGLthZvfcjtonY47Ji/I6lUuiZSckVUwSgUikltKr3w9UlV+kl7Z2A9KpzOPGAyRS21mYQkEcnkM30X6+f7tXEccytUWVm5PlJyRVTBiMXipVivtw6PeF3BzH4e1AkBikY865CEJBFhUuFWIYc+W0X1FA1mI17Q5BqxWBwRXRBRBVNeXo45yvXU8HBw7+txFwCTcSRccpGQzCXyhBwtDEFpFzuu02mnO/yYOia9vLw8LxKyRdqCwZy8eHzIEHz4eXSULH4kIbkADp3SmsKhXxHo8W0OG6YfpqysLKi57oESEwtGPTwS6DS7/8NuywN2O+mLISE5hww+yxNMo/xupwOzv5JEIlkeVsGmiZiC2bBhAxsAsBBr7dig3hvCJSlA288CKOoiLh0JSeJDhSFDKoeO1WQKl3Z8CwbTX0qUiCkYmUx2BdZso0GLBQzbbIFOrzsfp3MhsFgGwyEfCUmik8pljFBgKCOYc7qdDszffMJZMAqF4lqs199vbSdWvTk2SrZyICEBwJnBYwY6wuR7epwO1I1gZoiIa2pqcsMi2TlE0oLBjK1/3dMXeHgaC4tZDNzuNkLXICFJcNK4jMNsOqUk2PN8KEo5YbXgJa5iJsUSISIKZjrBbob/BUFR8GlHVyj+l3NhgoF+L5ndSzJfgSFoNDeFHXJ6/3cWI2ZEVqlUhj3hLlIWzBKsa3eOT/gsbnfQZt0MbNbFwGYdIHwdEpIEJJVLN9CpcLDjZL/nsNmE93C+RiqVhlUnRMqCwQxPn9Qbwvcm4+MxG4dJQhJDPJk8ZmhBkmm0bifD5MPcSHBlMhlm5DdUIqJgpFIpZoLdiVAS7PCYGBcBv5+0YkjmFUIO/RCHQcVr5h0w7Q47pobBMw5CJSJDzWQyGaaQLcPD4Xw/Hhjo776u7FJRNos5rxpTddkcrm/GxjHL8ucDV4lSO+8vyL0w4oFavT672mKF39QO0vUudyAjVRMKCAITeULOrPPbA6XbaadeysPsYjv52/13ON4DRELBlJWVcQAApVhrh/q13rA2GjcZlxYAtPOl1csIa/REwuL1ORd9+vXAkNMVsT4e8UoKnTb2dvkqZjKdhrVNmIpQPr14kWtXd5/p6bZO5ojbQ8jnx6NSXVeJUr2rUwSubBaTQoWgqA8rPMvXlon+Vo8tLPkqp21WBKTP/C0qFIrycFz/LGFXMBKJpBTruh1j4/4Jp5O4g/d84NeajtGevewSD5tKIbQvTSR4NGrqC8tKG25raJp3CuauXIkxmU6b1cHJoMDMh0oKmOXC5LGyrw4yQp3/tVzAt3y05hI0k8XkAwCSQhY6PPg+VI+GzSrrdNjx8smWSaVSoNFowvI+YffBKBQKzJTjD9s6POF+r0kc4+PC3zSdmHe+mFvFmStXJQu6Yy1HlLH/ojAv4IfUpcLk1P+UrzJAZ1oQBcX/k2SNflFRRp9WLjHn84mxpgGXM+i8FzwMHjdlwovr6A05QnUhkXDyYvpfvuruiYxpiaL8F+u/NescTqL5NYkG/eGSgnmVC/RQcf7p4iSOJJhzbhVnZv4gQxRUL6EyocD0v2UrhSl0ergt7pDwA2D6c39XWMcpowBADWajG2tNKpWGzdEbCQtmRgTJ6/eDr3p6IxZWRs2mxfs0bbpIXT9eUUiyMhfzkzpiLUc0EDHoI0+VLgxpS3ibODi/6NOLFyHRnHp6MT4eG55wIkhQijUQmqxmTLcCXpAmFML6IVZUVEz+z4wtUuvomNvp9UXyaUDfe+SYHw3BFE5kKBDE27tqqfHMQ25uc09+jolDpWaFcm65MDlg63ZBEndEnpaaEsr7RIoPx8Iaff2ew+YJTLdFOEPVYVUwcrn8ksk93IWvnzZE5gM6l6GhoeTnWzu0kX6feOPSlORL1qendcZajkgCA2C5ryA3ZAdnHocd8P33k5zsmEWJsDhqMXW12G0RGb9o8/sZOpcT66EctwoGs4L62JAec68XVhBE+LvPvzLafPgTv+co0MMLCud0hfmjC4s0+Rx2yD8yGIICvs+XCHjOUN8nAnj+3N/NjOR2rcOJGU3KqqmpyQ/H9cOtYDCLpTTDo8QqqAPEYTAUvdbeNRyN94on1qWn5a8VCU/GWo5IkMVkDtdISwjd7L12R8BbSCGdHjfbzW9NE+N6jzuiw6M7HdjdU6RSaVgKH8OmYBQKBQsAUIa11jQ4GHkL5gzcvU3N9ii9VzzB/PelKydNe1usBQk3GwtyLAwKJaiubRdybMIUsP+vw2qLmwzg90YNwbeWDZIupx1TB4RrlEk4LZglWFm6PRNG37jDGbUv7WR3L/89XTirKhODDCajdGN+zpzKB6JB0MS9+TmE7x2VTh/wsYfGjXERKOhw2MYaLSbMXP7wvo8d7++Vl5WVEVZw4bRgMAscP2hrj+6e1udNrz7w2aAfRePG1I0Wm4vyoDMpDnODx6Ul7WI266Lzfmaj1+6wvDdkCFhJvd6nS3H6/TG3BHdoe31ohGoFz2XM66GMeDA3GDyJREK4BCdsCgZvyNrXPX1RT+Ef7O3L+0/vwLybo7RUwC+5Iyf7cKzlCAc5bJb+t4uKCWWuIgD47z5ynBaMxvWiCO3Frt6YJm2etFpMp2zWoHrtEuGw2Yj594ZjlEnYFAzWiJLJL/bTjq7oWxIoKtx/7HjMn0IxgPL66uUSBgwnvKP7voJcKxWCCFWMf2kYddePTQQ80uMsT7S0czqstgki702Ed8cMUQ2VH7WYMbdCEokkPhSMVCqlYFVQt46MuF0+X0ycZl9q2rhNRtO8GzdLhaGch4oLxmMtBxFYFHj0nvwcHtHr/L2rJ6TtogtB6Jd9dZD5wZAh6krG4HHb6ozBK0UiHLGYvH505kcVjoS7sOzxFArFCgDAjKKw04aRmCUt+d2uzF99/tXRw5W3riZ6rU8No8O/b2mLitl8qVDge3H5YkJjPKuL8uh/bu9yAADiJiISDE/KFnZnMhmYEclAaTaazR/qR0IuVBz3eNk3HzrKfrA437BNugDm02kiIvIEyku6Pp8HRSLuezkXB+KnaV1OJI/FvtDgiBsFg5lg1zyo90WqqVUgNJxWZ9dfuWa0IkN00bm9s3FZajK3126fvOk44ZMOm2ajCflVUYG1JIkTcnsACZtV9Li05OsnNR1rwytd5CnksAe3LCgk1LbRh6Dee5tOhiXE+3xnb8bznb2ghMsZz+GwUDoEz1pwyKTAyNuXreZDAATte+x2OlxfGscFlBjUfnQ47CCPNeN5JKypqVm8bdu206FeNyxbJJlMhjnuQDM6GtseLX5/1t5jxwlvk5KoVM4T0pKobLcQAOCdXb2E768/yBasyGYxe8MjVfS4vzDXDgNAKDz7vt7gbjaZw2q9ddjswi+Gx1I/NowIZ/v330FD2ueG0ZACDO+MGuBkKi0mhWWd2Bm9QC6XExplQljBlJWVTX6Rl2KtHdVFLcEOl/+ePEUfsDsIy7GpME8gZjGj4jh+tU/L1DtdZoKX4VcX5REbchdleFSq4a68HML9V57v6IlpJfSWEy1cp98fVHrGoNvl+s5spLqR2GRXdDmwJz7K5fLriVyX8BchkUhkAMMc1FutyLDNHlVnFRZOm13y24ONp4hehwrDrJ/kiqNS52Tx+ZgPnWghnD/0UHGBAALAGB6pIs8zSxb1pTGCm7V8IafNFvs3YxMx9T1prDbBX9u6rYEe7/Ij3q0dmkkTAnZgT12MOO1OG55mu0KhUIS8EyGsYPA62L2naYublP03G78TacwWE9Hr3JUnidqTsVanz2iaMBFSDiwKJXtzUV5C9MlZkMTVPVCYJyNyDZff734xDNvLcPBUa0fyM21deh+CuGY7bsztcd178uSYzuMS6rET3qKC2eejal2YzzTadJZ+SBD+wYjFYswmwf9Vt8VN2Tviduc+8+3hMaLXWZDE5T26oDBqw/cfPaUh3MHs0YVFAgYMx33pRI20xE607+0Lnb3+/b0DM9qFxAIvitJ+e7o1c8ln9Y5d3X2GHptjUtFPaRAvgpjrR8cntp5QG7M++Ix22mWNi2jf58YxTAudSCNwwjcwiqJNAICV577mRxDAfOIpjw9B4qYRN4PDGdD++sH0NAadUGW3F0GsvHc+obsQJCoV4l9VlBvWilIJZXVu7+j+8uGTmqvDJ1V4yWGz2vpvWCcBABCJ0vlzP/rCNeBwRjzSR4BxDpXitPv8GWejq6lcur5ElBSWUSREKeUm+V9esHiGYaBWq/9RWlpaFco1CVkwGzZsYAIApBe+fsow7Iwn5TKJ224XP1x/kHBjJhoMJ92dL4na9u8Xx06xXEE6DC9ka0nhimIuJ14jSt7XLlnuJqhcwHuDBlucK5dJhHafX3xWucAQ8OSmsOOi7+8krTYb5PTP3GESaaFJSMHIZLLLJrf6F76uHolxeBob+J/fHEpqt1oDdr7h8bNcSdiaL1+MDpud/6Z2aNZ9fAAkby7Kj8vSibVpwj55mhDTjxcMf+/qjZseuoGSymE4GFRKcqzlOIsfoHCn0461TSqtqKgI6TdN6EvBS7Br0g3FPDyNCeLP3dd0nHCdTpkwmVeRJoxaOv7zHT2TTzxCEay78iRp2Sxm3I052VyUT1gxfD0yNvHVyFis5xYFTTqPGXeV791OB1ZiLF0ul8tDuR5RCwYzCadtdCxuzL4L2d/UTA9DKwfKi8tLiVoVAXPCbEn6Z5+WkJOaR6NmvLC8NK62SekMuuNWcSahbvkIAJ6fHzkR8cZM4SaZTTckMalxY72cpd1hw3yQKZXKkBLuQlYwCoVCAABYjLV2RKeL2o8vWIxGU+bbXT2ErZhSPi/7ylRh1HJMtp7SJE14vIR8Pz/KzrxiVbIgPCP7wsCNmel0rByqYPhXn9apdToTynqBAPDmCePH93IuOBbMJCEl3BGxYDA72BmsVp/R6YqLsBsOtH1HjoVlC3dvQfQmt465PZxXegeIFlwyHi4piJsBdWVC4g/wF7v6wiJLNBFy6XYWjRLxbnWh0Omw+3FS/RYpFIrUYK9HxILBTL45NqiPmxsYj6/bO/hHx8YJWzG3ijPpAho1ah37Xuruo3kRhND7KSTZuYv5PMKZzeEglUEnVAj7zqB++IjRFPXRrhAA4Lr0NOcfZAssr65eZnt19TLHYwuLvfI0oY8KXdz/nxGHvpezeFGUMuB0YOoYsVgc9OD9kBUM3njJ08MjUYuwhIrf50v51cefE+54x6ZQOApxVtQUTI/dwflrexehjGQKBAR7Vy2dmLyXwidZaGD1IAmUSUV7z9ETUd8aLeXzbNobr5k4cGUZ63FpCe/neRLuz/Mk7D8uXkj7Wn4ZtWndlf58Dhv3D2PRKCYekxZ3vpdz6XBg78TLy8uDjvaFrGBkMhnmm53QG+JewUzS2NaWV6cbIpzhWpUfvW3SJH/QdAoH7E5CIedLUwRXrk8XqcMnVWgMOkN31e3pGfCYvNFtZnZLVvpwnfwyajaLiTv5camAR2lbvxa9Q5KFaQWk8xhx//vAq6wOpYVmSAqmoqKCgufgPTGkT5TBZ0n7mo4T9sVcKkxOWSNMiVr5gBtB6Lt7+oh+xvCvFxSESaLQaRwP2UeO7uzqjeo2Y2Uyf+zdyy9JFdBpF3XO0mEYfvWS5aCIyzlPycAQ8GQkMeOmhAaPLqcDU0aJRBKdLZJcLr8CADAjVd7m8SCd4xPxmGSHyTunWzgDdgfhPi/bl8noIIpzsff1DtBNHi8hua9OT1uwNk0Y0wbhHxtGgNET/E6tdmDQ2Wq1RdVJ+sSiEgdWUAOPSSXzweWrUfo5/anyhZwxGIbiolZqNjocuJXVxRs2bAjK5xWSglEqlZgJdp+0dxkRFE2YnASH05n6my/r+oleZ3WKIG2tSEi4WjtQRt0e9m9OtxLt9cJ6s2zl5EOCaN+ZkDF7fWBnV3CpOcMuN7j32Kmobo0KOGz1zdkZQXdFXMhLolwtSpv6sTKoFEs6j0moFUW0MPl8FLzKaplMdlUw1wrVB4OZdPNNX3+814LM4M0jTZnq8QnCldZ35Uqi2shjT0+/SG22ErJiREzGynsLcnrCJ1XwPNPWBVTaoYCOtXp94GdHjgNLdMeP+/auWurBKokJhPLpUHwGb8rgj/vt0VkazEa8hLugJj4GrWAUCkUSAGAF1tq7mta46QETKCiCpO5vPkk4EnRHjpjNplCi9vejAMB/7+oh3Ptkc+FUqn7MeqjY/X5Q2XgMPN3aMetx3TY7WPZ5PfhseDRqsk1ymTC55ypRatC+h7MUctgIBAFfOi8qxfdh44jVjJdCEFkFgzdgbcRu9+rMlrgOv+HxRvNxhsXrJZR9TIMh9o5lsqiOuXijf5DTZ3cQ2potEfBK75Bkfxk+qULjsZZ2sOyzevCUpgN8PjwKjhvNoGF8AvyzTwvuPnp8Srn02KPfAfQeglFCCIJATjJnmArDhMewRJNmi9nvxe6ul6NQKAKethl0ohPWgDUw1X93yEO05D5WjJotoj83HFH/8crLCXVUu68gN2ObpsM85HRFJfnL4ffTq4+fnvhoDWZL5EChvFG2ovC/g/pBN4IQGtNKlJNmy9S/eIEJw6N35+cQmkhh9HmN2QImoWvEAjeKUPpcTqSYzZlhhEil0kmLLqDIadgsmNaR0YTZX2Lxt/pvU4fsDqKtHGj35Emiut34WD+ScXBsnJDlBANQ+FBxQcJPgww3DxTmGWEACFnlWp+LQrTeKlZ04iTcBdMfJmgFU15ejtk+r2FAG/cJRLPhcLrStx9qJBxR+WVxPo0Jw1Ed+P/oqVYq0TD5IwsKRSl0Wty1c4gVFAiYtpQUELLIxz0eS4PVGPPG96Fy2m7FS7gLuIVmUAqmoqKCDQDAHIp1bFAfnz1gguCVpmaqB0E8RK4hYjCSHl5QGNVO/ofHjbwPh4YJlT4IGXTx35aWtoZPqsTm1wuK2iVsFqEt457BAZsXoPFc+DsrXU474YS7oBSMXC6/GivUZnQ6fQMmU0L6X85lwmbL+OOhRsLlub9dWMQR0mlR9UhuPn6aY/f5CL3nT/PE8qV8XsxLCGJNGp0+UrOohFCfmgGX0/rRxEjQ1cfxRLfT4feimIZxZk1NTUCp4EEpGLwEu/da241oAsX4Z+OPn34hGHO7CdX6cKhU/u2S7Kj2xOl3OJP+2a8jZH0BALgPlRREdXsXj/wkV2xiUSlZRK7xwdiwH01Q38tZ3AhCUdtteBMfAwpXB+uDwVQwh/oHEt56OYsfQUT7jzYTzsqtys+Jekn+C129NAQAQkrmxznZuQuSuCfCJRMEAFidLDBvEGf6FOJM5Lr0NFMyjRa3DckAAK77CnIIJa24/H7ngfG47EsdNI1mI6YJE+jEx4AVjEKhEAEASrDW3lG3zamn3r6m49QzuWyhsyKZL1wnShsIn1QXR2OxcfZ09xHqFUyD4bTdKxfrifYAnmSDOMs6fPO1xiPrruCryldRa8tXwQeuLBPob7oW2bFMNsKiUOLOb3dXnuTEQl5SLpFrvDE8aJ3weRPW93IujWbcZ+3VUqn0oruWgBUMXnhaZ7a4xh0OYaDXSQS6RkZEr51SE65R+uvSRUwoylmyj55uFQy73IQyiq9IFV7GplBCLp8Q0ukeVdlKs6p8JTuNwZgR5mVQYPZDxQWi5nVXuHLYrLiZdsCmUIx/Kl1EqF5ozONx/NswFPUmWJGiy2mHrNilGSyZTDZjZNGFBKxg8JrNHBsais0w3cgCb/3gY5rb7yf0hF0m4IuuSU+LWhHkJBavj7Wvt59QM6nn2rtHHH5/yMPe9q1aatsgyeJfrPZmIS+J/+7lqy1ErcVwUSnJGs1kMfKJXOPA+IjPjUZnKF80QAGAO512zIekQqG4aD4MYQvmtIFwY7i4ZMJuz/7fFg3hcPNdedEtgpzk5e4BmsvvD8mK0Tmcphp1e8gOzrvzJCM/zM4IuJXCcgE/6y9LFhEeiBcGkE2FeYSmbCAAeD8YH0mYbgKB0o3TH2byGXqxcwlbMKcMw4T6qsYze48cI5w8WCnJ4vJp1Ki2RNA6nZw/aDpCyrnf0zvgdiFISE77FDrNsXfVMm6wwYNHFhTlZzIZhCvaiXBtelrT6hQBoS5cH4wabDq3K2ET6/Bod0TYgtmwYcPkTbMAa+34UOIn2OFxuLcv+ave/sB6CeBAgSDW35ctjnrPlb+2d6d12+xBlT7YfT7Tvp7+kH8gm4vyvRQIhOLcpP0gUxSzbRIMgP1vy2R8Ii1k7X6/a8+Qds4pFzDlh7HhfS5LpVLprA/hgD5QmUxWgVVP4fB6ka7xiTnhLceBvvmDj70owTT8n+WJs3LZrKhm9/pQlPpSV3CtNX/f0m7Uu9whVf1CACCbi0J3X5SlJMesZcQt2RlDi3hJmA/QQPlyYsxv8nnjctYRUXocThQn4U6oUChKZzs3IAWDNyL2vdb2iURqohMKrYbh3AOd3UTHxFLvjkFezCt9WpbZ6w0ou7fDajP+vbNHHOp7Pb14kT6NQQ85esKlUWP249xUmEf0u0HeHTXM2d+BH6Bws8WC+QCQSqWzJtwFasFgXuRw/0BCTdQLlT1HjhG+xsYYOHuNXi/z9b7Asnt3dvX5EABCclDmsFiWRxcWiUI59yx+hMAMEwIs4SedWJeelkfkGodMRnu70z4nrZezfGcxYeqKyspKYgpGoVCk4SXY/belNW5yGCLJR23tSa1j44RaqWWzWan35EmimngHpiYf9tL8KDpr5qzB5Z54rV8bcjZ2ddGUBUAoetJiscYi3cGza8USmEg7BS+CeF/Q9c7ZQMdZGizYGb0AgMvKyspwfU+BWDCY0aNhm901ZLXOqQQ7PLx+P/PhTz4jnK38/PJSFgWCojrwrMNm5zzf2Tur/2fLCbXdHOKMIQYMe6qL8ghvD+pHie5Cg+cqUWr/ZakpmBNKA+Vb84RPOwcjRxcy4HJSTD7MW5cpkUhwG7UFYsFgKpgm3WDMnHKx4JPWdnHTkJ6Qo5ZLpabdmZMdVWfvJI+3tCUPOp2YeTHNRtP4m9rBkCuHd61YMsqhUgmN4mgcN441jBuj/rC6MyebsNX07uhwQvdBCoYOhx3z85otXH1RBSOVSjEVTMvISFxkX0YReM+RY4RvyJ/nigklc4WCw+9n7u3BHpz/fGdwY0PORcrjmu7OlxCqOgYA+O5pOhmLH6m3UpxF6Ltod9gsx6zmOe17OZcupx3v8wpdweC1xzs+NHe95ni8daqFNepwEmoauzY9jbcqmR/d1vhnxpzQbT7feT6zdqtt4i3tUMiO+s2FU2FpQsrhPzq9pdUS/a02l0o9mUSjhlzUiADge3agZ85l7c5G2C2YDRs2pE4+qLDWDvcPEO09knBYXC72z1XvOIm0p4QBoL92yXIEDkO1cjDoXW72nY3N7rOyexDEddvhJsiNICE5OFcI+Kb7CnMJ5UChAPgeb2mLSd3OAi7XSsS5++XEqFdjt81538u5tNhw8zZXbtiwAfNemFXByGSy1Vh5Lg6P1zdosc6rD/csn3V0JndPGAlVK0t5SWkrkvlEG4wHzUeGYUG71TYl+6GxCbvaYg25oXWNtMRFgSBCPU9OmSz2VqstJr2EDG4XIdnrTVGdUBMXjHg8wO7HfC4yZTIZpitlVgWjVCoVWK+/earFiKDonGioEyx+FKU/++1hopEg+DcLi6MaTZoEQQHl8Zb2yff1/+ZUa8jm/Y2Z6cabszNCrrY+y+9Ot8asEn/Q6Vpu9flCaslxymax1RnH590D1g9Q+BvTBF5dUiXW6xfzwWCOiD08oJ3L5QEX5dVjx9l2r5dQDtCPxJm8NAY96o9BlW4o5cETLYNHjKaQB4E9WEyoo8EUzUaz4SPDSCwH9bE/1o8EvU1FAfA/N9BDnW8RjrMcsZgwfa94ybi4CkahUOQAADAjBO9o2uZsgWMguHw+5q8//oyQgoEBYL6wvDQmU8b+3tkb8rhCKY9rX5eeRiiD24eg7o1NJ2MefXmhs3dShqB8id8Yx3xdTkfMZY8V31lMfhyzc+F0Uu554CoYvPB0v8lkm3A4UghJOQfY/d3RjAGzmVCV9O2S7JwiLiembQqCAQIA+WVRvjeUiaDn8v6QwXHcZA64Z0ykODQ+kf0HTcfsQ7HPwYMg3p26/qg65+MNs89HGXJjJ4ZLpdIZ0SRcBYPntDk+ZIh6Hke8svfIMaKfBXxXriRhErXuzBGbfpIrJux7+1tnT9zcQzXqdtlTrR1DF7NkOqw27+3NzSODHvecaXAfKh127HA1VkrLbBYMZgr1Sb1h3oWn8dh7tBlGCYab7y3MQYhOZYwWvyzKg7hUKiH/2+fDo4ZvxybiqWct9HhLe9aKz78xnTZbDBcu+hDEu7en31H29UH3MPDMe8sdnOkPg/lQxLJgcE1dvAS7U4bhOdNvlCjDNhvng9Z2882LFoT8gxExGGnVhXl9O7v7CFX0RprVyQLrpcJkQorB5fc7NzWfjsvoy3GTWbTks3p0VbJgNJ/D4jFgmGr3+32HxiYoI24PWyxgmSEIECqJmCt0OrA7gARswdTU1CQDAIqw1o4NDs2pESVE2XOU8DYJPLtUmkSDoHieFQQeLM73E+n4Nslb2iFXl80eT9bLhUBNRlOaSqdnvDEwSHln0MAYcXumHsLpvHnr151BhxN7GBsAYGFNTc15ShjvhrkGKwXc5HS5B0zmkMObc5ED7Z2cU4ZhQtEgJoUi/FmeOOptNQNlYRLXrJBkEf2F+Z7vTMzU+kw+c4RBheNZMUaVMa8XNngwA8nwhcMZMRWMUqnEzH95t7VtHCUYQZhr+FEUfujDA4QjCz/LlcSN4/NCdq9c4qTDMCEF8+bA4NhxkyXhthgUGHLnpbDnvWP3QhrMRsx7XqlUnpcPM+OmFounuiZeg3XyIQJNieYyX/f0pjQMaAml/l+ZJhSUC5OHwydVeFidzLdWpAkJZe2avV7HlpPqhFMuk6QnMV0QBJH3/QUcsZjwDI1rp3XIFDMUTHl5+eQqZn+Q/7Zo4tpPEEv2HGkiaoHQdiyVEapxigS3iTMJRw1f79N5DC53QiqYDB4jYdIIoskR/IS73GkdMgWWBYMZPRq0WOwTTiehsZpzGdVpDUNvsRJSEJcKkwvKU5LjKvGumMshFPVBAHDv7OpNSN8Ln0WzMmkU0ueIgQtBKP1OB6azVywWLz/731gWDGb+S5NuaL6WXwSE3eulPvb5l4QLGO8tiP70gdng02iEOhe+1NU70W6zJ+QWI4OMHM1KJ3aTxPOGNM5QMGVlZZgWTMvwSEIkg8WS146dELSPjhHaRt4mzmJwqZSARo1EA5cfCXnrN+xy2x873RazkgA6DPvWiVKN9+bnuB9ZUGjfmJ/jXytKdVGhi+962DSKNYVNI3O+ZqHTga1gysrKvrdgZjhqJBIJ3ojYedmeIRjQqezeY+izP8AMwgUEj0bl3ZqdOfp6vy4uKtZH3FOFJyFZIPt7B7xWny8mCuaGTJHxpRVL4Bw262zF9lllQemx2T0/OXIcNIwbce/p/DSOB4KgeTGWJ1Q6nQ5MTS2RSL43Us57Om3YsCEFAIA5n7d5UE8m2AXAGydOUeweD6HP6t78nLixFj8fDq27p9uPOF7u6Y+J7+Wl5YtNH665VJDDZmHmrhRwOfTDV62h/n5RMWYyRxKTauczafNiYgYROh02vPs0r6amZspfe56CkclkV2NZNS6fz9s1MUFq8wAYttnpz9QfJBR5WZMmTFsp4Ed9hhIW/xk0cE0eb9AzRWo07aYBhzPqvpd78iSWB4ryBAH0CoafLF3IuDtPMiNJMpPHjCs/WLxi8vngARfms/T7hLvzFIxSqcQcEfuOunWUaIn+fOLZbw9zBy0WIr4Y+PnlpXA8FEF6EIRxw8HvILvPF/Dfc3BswvyXti7CHe+CpSJN6HpCWhKU32T3yiWMBUnc731eTBrFnsKhJ2TUKxY0mLEHsp1NuPtewYjFYgoA4IdYB3/U3km604PA5fNRdhxsIJTde3lqivimzPSoTx/A4vC4MeWWQ0dd4+6Lbv2Q/+r0plsOHWGhBOuWQuHpxQv9uRx2UAqGDsOMTYW5Z5UnWpLORWAIIp27AfKVEde4vamsrIz+/U1QXl5eAABIxTryXU3rvBqyFg72Hm2mexGEkC/m7vz46RXz5ciY4PKvDvr+d2BwcNqffR52n99615HjttsamgQTHm/UAwKL+UmOcmFKSFuyNakpU99TMptu59KppCsgCNR2K+REMI2YJIlEsuD7bU9ZWRlm9Kh7fMJs93hntMIjmR2L201/4vOvxp++bl3IiWo3ZqZzizickS67ndBg+XDRbrMn3fldc9LTbZ2WUj6PlUqnu90IQu21O7x1I2NsL4rGbFbWxvyckJVxKZ83dW4Gj0H6XoIEBQDqctiQxVweVsrL8u8VDF54+oTBQO5HQ+SZ+oPCLZeXW0VcTkhPRRoMs/+4eOHw7Y3Hwi8cAU6brbzT5qnSq7P3Rky30EwY9m/MD3mG2uQ2icqmU6zJbHpCJgTGmi6nA17MnZnwPKlTvtc6eBbMiSEDWX9EgJePNBHa5lRKsrIXJXGjPs86kXhuqczIplJCthT1LpezMHWqVCpuK9rjmQ6HHdPyUygUy7//QPEsGM3IaFwkfCUq+442TyoYIiUE9Hvyc+b1FIfZyGGz7JuK8giNP2l32GlJTNL3EiqdTjveQ/SMBVNTU4NbQX1ENxh3Fb6JxIDZzNn13dGg80jO5c6cbAYNgshERwzuzZ+awELI93PQPBGXbTwThR6nA/FiO3pTzlowV2MlJlncbofObInlcKw5wcMffSp0EhjUlsViJj9YnD+jIfV8Z/KGvb8wj1CE0+H3O74wjpEV0wRwIwistmPf3lMKRqFQYJYHqE6rTeS+lDhOn4/2j6bjhJLmfi8tSeJTqYSGvc01freo2JDGoBNSDi/q+pBYRr/mCt9ZTJj395TykMlkJViLJ/XDCdkkKB7Z39RMSMHwabRUhSQrbqqsY00yjeZUyhYS6pOrd7tc742R93g4GHS7MA2Rsy9iThA42D8Q9dnJc5XjeoPg/dZ2PZFrbMyPr14xseS+ghw3BQKEfCcfjA3HTSJjomP0eTG3qmcVDOaTYNBsIb+AMPLAex8mIQgSctj/UmGy6HJhSk94pUpM7ivII6RsEQD8748Nk1ujMOHw+3DHDIBzemWch4dAsyGSmQxZrNy31a1EtjnQ9mUyOgCAcOkGm0IxXpee1qsQZw0qxFm6K1JTugAACRExvCdPoi/gsgkFH/5tGPQafT6ygDdM+NGZ5SPgnAppzEUUoKQFE2b2HDkGKhfLQj7/khSBWJ4mHK4bHQ+pPzIFghxPSEu6H1lQmM6iUPLPXXP4/d33HztlfqNftyJkASMMHYbdL6xYTChz2OrzefYODZAFvGGERaFg6pCzFgrmuAwRlxPzdgFzja+6ewTfaXWExpP8PFcS0vagmMsZPXr1FaYnpCWLWRTKjPomNoVS+M9Lli/5/MqyjiwmMy4HwW3Ml1jYFAoh6+X9sWHYh5LurHAiotExFfZZBYPpfKzIzyVzYMIMCgC8+f2PCGX3/iQ3m8OmwEEpAAmbNX7y2gpkeTI/6yKHUtelp5X857JVplDliyRVBIoap0HfGzWQ2iXMFLDYmPfzlIJRq9VqrMVlmRlk9mgEaBrUi77u7g3ZQqDCcNKOZaUjwZzzx9IFDhaFEvC2qkyYnDu5lQpJwAhxU2a6fkWyIIXINd4fG3YOetxkAW+YWcThYnZxnFIwKpWqEWvxpoULyEbfEeLlI02Ezr+vIDcnk8kIqARBykvq/2muJGifzTbZAomQTiM0sTJcQAD49q1aihJJ/HQhiPcFbR9ZWxdmIAC8S7g8zEj0WQtmUsHM6MCWI+ALioUphAa7k2DzrqaN3zNhJOKLYVTl51y0a97kl79/1dLJbUUoDwv69ZnxMWvvDkn2mIjJuNj2blY+HhsBDoTsnRZuFnG4LiaMrfenXn377bdHAQBHsA74kWxRhMWbn7j9ftqdb71NQVA05LyYzUX5dAYMzxpavjtfMlwmTM4J9T3KUwSER8eGAeSxRcWEQspeBPH+a1hHRkUjQIVAiKe1Nd+rnYaGhpNYR1xdiFmmRBIGvtMOpp42DIe8BUlnMpJvFWfOagXdLs4O9fJTcKjUmCejrUlN0cv4SYTKAg6ZjR6Dx0PmvYQf5BKeAFNxa7XaE98rGJVKVYt10LXFhbyK/DyyZCBCPF33LaGIxt6VSwQpdBrmNvbSFMHwtRlphLYVJi/habiEYFFg+5uXrqCc0z0vaExer/fp/i6yJUMEuF6Y1l3C5mAqf5VK9d/vFcynn376DQBAh3Xg7h/eSIMAFNs7bY6iatGkGqzW/lDP51CpKbeLszGzgx8szvcRrYY/abLEtI3k9RkiYzabRWgEyoGJUcTm95NZ6WGGCcPjj+YU4n039v3793/8/Yeu0WiQ2traJ7COXJiWmrRx9XJSwUQABEXh+9/9kEokL6aqYGavsEVJXP0GcRahsa1+ALxfDI/GNNnyBxkiQvcdAoDv/dFhUrlEgJ9miM00GMbsBKhWq3doNBrneR/87bff/goAoB3rhN+vraAyKBSydWMEeL+1Pfuk3hBy17uVyYKMq0Wpnee+tmvlEgsNhglZH6/09Du1TldMZwSJmAxCTuYDY8PufreTzHsJMwUsdvPPMsWYY44AABPV1dVPASzzefv27S9gnZEj4NO/2PhzKIlBJzRQjASbvUebCfli/rpEyoKmUw0q0oT6ijQhZo+fQBlzezyPnmqNud9CxAhdwdj9Pu/uoQFyiFqYSafTtX8tWiSEAcBs9tXQ0LCvvr5+yhiZoWD279+/BwDQhXXimtwc+mPyK+MhbDnneLX5eLLT6w25X8zyZL54XXrq1CTIh4rzkQBmM8/KK70D/gmvN+ZP/jG3J+TtzZfGcf+410tGjsIL8tvcotEMOgNvToxrx44d28/+nxlfnkaj8SqVyg0AAMzw6dY15azbSqVk68YwY/d4mb/99AsnkVYMd+VK0BUC/uBN2ZmE0uk9COLZ3dMf8/D0JOMeT6g+GP97o4a4+BvmEJ77snK+Xc0TLMNZR2pra+9TqVTfp05gfgH19fXDMpnMKpPJfnDhGgWGoQ2LZfT/tmicI3Z7zJ9wc4nvtIPJ961eMZzEYIQ0QkPKT4LKhSmWTCaD0CTIv7R32d/W6eMipZ5BgQc3iLOCDrUfNE043xzRky0Zwsg1KanHH5LkX4ZnHavV6v1XXXXVU+e+hqvhGxoamq+77roCkUi05MK1yauX5YjRfx4/5fchCPmUCCNcOt26tiA/JAUDQxA9g8kgVAGvdTg9ioZjDB+KxkXkpdNmpynEme2pDEZmoOc4/X7/Yz3tsMXvI+/NMCFhsDpq8ktSORQK3r156pZbbvmpTqc7r0Aa9ybS6XS+6urqnwEAjmKtr8jKpP/nx7f7z0QCScLF/qZmLoqzPY0Ge3r6/U6/P25+mB4ESbv50FHEj6IBj21RjeidOreLtK7DBAOCh15cIEPT6HQ8JT8il8uvbmxsnBEJnfUpVV9fj1ZWVm4EAGC2Fri+pIj1P1deTrZ0CCODFivvk/bOmBSYWn0+177egbhRLmfptNlXbTjcpLd4fb2zHYcA4P1YPzKybzD+/oYExveb3MLRVBp9Ac46olKpHqivrx/DWryoGaxSqU7V1dX9CM/5+Mdrr+aszM5KiF6uiQLRVg6hUtPS7jW43HHZouPdIcPylPc+hQ4YRj/BSkq0+/zjN3773fDdJ06w/QSnDZD8Hzemig5cK0yb4SY5S11dnbKysvK/eOsBhzIPHz78h/Ly8sex1sYdDk/5rn1I5/gE6VQLA1QY9p341QM9MlEaoVyWYOiw2lzST+uY/vhvJekv4LDbViYLaAIaDfUgfqbJ66N9MTzK9kEoq0TE9SUxaTEtb5grlPEF6ueKpPkAAEyHv1ar/c/69esVGo0G96YJWMFIpVKKWq3+BgBwGdb6N339roo9r5AKJkxcV1zYd+Dun2YAAKLymT50osX5fGdvQj/5c5LZdnEyi1QuYQAGkE61eIUvg87IwzlkrLKycqFKpZo1Az3gSIFGo/HLZLIbAQCY7TWvzMtlvnTLDVYoDCM1SAD4tLM774h2EHNfG26GXW7na326hHaKQgAgoiQGmVQXBjgwZXTfoiXG2ZSLUqm86mLKBcwWpsZidHTUBQA4IZfLq7DWV4uzGYMWi6t5SJ/QN2u8gAJgvnnRAkJ9UALhgWOnXEeMpoS2XoQcuiOdx0zovyFeqMqStF+VnIqXTAdUKtUvN2/e/Gkg1wo612Hbtm2H1Wp1FVaLTTDl9F1HE/N5ZFFkGFCdVqeN2OwRneR43Gh2vjEwGFLeTTyRwWOS6RJhYDE3qe3HGWK8iBFQq9Uvbd269dVArxdSMlVpaek/1Gr1Pqy1NA6b9tLNN5AFkWHA4nYzH//iKy+eMg8HL3T1xr1X92JwGVQTn0Ujh9gTZ/y3uUUUGAA8P1ZdaWlptU6nC1iZh5ytuXHjxscmH4BYazctWsBRrpNbyCQ84uw72lzUOTZOaGg+Ht02u/NN7WCiVxujBakcCtHizvkOFYKMfy+R9eYyWcU4h4xUVlbeH+x1Q1YwjY2NRplMdiUAADNpo+YqOW/rmnIyP4YgCIpSnv32MBpuZe1FEO9tDU3A6U/sUg9REsPKZVATfosXY3yP5RYNrEzir8JZ1ymVynKVStUR7IUJ1ZtoNBqbUqnciHfz/3n9NdzlmZlxMVcnkXn9+MkMq9vTGc5rvjdk8J00WeLGKVrC5YCrRUJQnpIMWJTAb8v0JCZpuRDkB0LRgetmSaZTKpUPbtu2LSRfYFi+nLfeemtDZWXlv7Bm74za7e7yXfuQ7glj3NzMich9q1e2vfyjm/LClRez5quD7kPjxphuj9IYdPCEtAQoxFkgnfl/ovhRFNSNjIG9PQPg7cEh4MfxEglYNKs0k8ch+qCcz5TxBOrniqWT9xWm30WtVj+5fv36J3Q6zHbdFyVs2r+lpeVZmUz2MNZaXU+fY+2+V+Oi/D+R6X3kwd685OR8otc5oB+xXn/wu5huK9IZDHDoqstBIXf2vLg93f3g/uZTmGsrc5LHGVRYGCER5zwwBHS1shW+TAYTM99FrVa/U1paeiuR9wjb/ru5ublh48aNVwAAZgz5yksW0IRslumTji4a+bQJHQ6dbrm6sIBQI2+Hz++58dAR2BjDTm+FHDZy8Ko1IJ/DvugDbmWKAKTS6eCA4fxR3EIO3ZzOYxJqTTGfYcOUsV0LF4/ms9h4Ien+zZs3V2o0GkKFt2H7sTc2Nlrlcvl6AMAA1vovyy8V3LNyBVl5TYD9Tc1CP4IQyot5Uzvo77E7YlrSUSMt8eWwWQFbz5uL88GNmef30Ernkb4XIvw0I3tgIZu7GGfZrlQq16pUKi3R9wlrBKG/v9/L4/HU5eXld2Ipr/IcMfiwrcM15nDEZcVuvGP3eOlcOl17eW5OSijfHQqA7+6jx6FhtydmkaMl/CTnC8sXU2EICurhxqFQwZvaoan/5jGpFkkKe9L8Ia3hELgqWXjowZyCUghnXrlKpdq8efPmL8PxXhF5CrS0tOyTyWSY5QRjdodrwfYXwITTSRZGhgAVhr3jjz86yGPg1ongsr9nwLzx2MmIlx7MRp38MktFmhCzG/1s2H0+wHvnk6lw5TKxYIRNpxBqCzpfKWCxW/4pXVY0S7DgSwiC1oXr/SLyBNi4ceNvAACnsdZSOWzmS7fcQHbCCxEfgtD2HW0OOrN31O12P3JKE9NI3uXCZFcoygWcmWAJSvlJIJlNM5PKJTToEGRQ5hezZlEuw5WVlZvC+Z4RUTCNjY1jcrn86kmDBWv99iWlnN9UrBmNxHvPB/Y3NScDAAaDOqdX6zd6vTHdmj5QmEeoLEHEYID0JNLwDRHnc8XS7kIWpxBn3VNXV3d9KMl0sxGxPWx9ff2oSqV64MzWfyZ/um5d+k0LF5BJeCGgGRkV1p5qGQ3UCnT5/a5d3X0xzdjNY7Ndt4ozCclgQX2mZDadzKcKgZ9mZGtWJPEvx1tXqVS/Xbt2LWbpDxEi6iSrrKx8u66u7k9YaxAAYO+tN9G4dDo5YykENn/wcaEXQQKqUXqytdM54HDGNKnu2aWLPCwKJWQLyoMgTi8ddUMQtmOSBJ/F3KSGX2TnLpzlkPeVSuX2SLx3xL3w1dXVj2u12vew1tK5XGb9fXfDySwm2d4hSEbtjiTVKfVFLcBum93517aumDp2lwp47tvEWYSqnZstZhOLQU0Pn1Tzg2wGs+evRYty8TJ1tVrtdzKZ7A6NRhOR94+4gtFoNOjDDz98HwDAiLW+IiuTvW3dWkek5ZiL7G06ljypa2Y75qWuPr83xjOOflGQ6yd6r31mHEv4thIxwP2HghJ7EoWKN7jOt3///iqNRhOx319U9uUajcYOAPhcLpcrAJjZ8X1VdhZDa7ZMnNAbyHKCIOg3mjjrCgvacgR8zBvI7PW67jp6nOqK4XC8VDrds3fVUohJoYScOWzwuIeeHegW+AEgOyUGjuORnIJjawQpq3HWXbW1tRs2b958MJJCRO3Jtm3btmaVSvV7rDUKDMP/uO0W4Spxlila8swFUACgX374iQQFANMX82qf1mv0+mLqs3iqdKGLT6MR8v/s1PWbPShKPnyCoFKU2fbDtIw1eOtqtXr77bff/kGk5Yiq6bx169Y9arX6Fbz11zb8iCFgMsntUhAcH9KLvurumTEYz4eg7he7+mLaBLuYy3FvLMglFPXpdjoGvzaO4bZwJJlJAYut/nmmWDLLIV+sX78eM/gSbqKqYHQ6nb+6uvoeAEAD1rpUlMZ6/+d3eiGMwVok+Lz83bHJH/F5Dt/tHd3mLps9piHdu/IkHgpEbFvz3qgBRcmSgIBJptL69y1ckiSg0tJwDumWy+U36nS6qDSDi/oXV19fDyorK3Gdvlfk5vCV69aSoesgeK+1LatrfOL7MIDW4XQoNe2Eqq7DwQ2ZIkLZ2mafV//ZxGhImb/zFOcjuYVWBgzP6GgwjXv79u331NfXRy1qG5Mng0qlaqmrq7sZbxzt41dVJK/Jy4nKTKC5gMfvpz3yyWdZZyNKL3f3e51+JNb5It7FAj4hGf6h141b/X5SwQTIL7Jyv6wQpJTirdfV1d378MMPfxNNmWJmeq5du/ZgQ0PDH7DWIADAxz//cVJpuojM9A2QdzVtkhNDBrPZ67Xu7e2PtXIBGQyGHsaIGAbKoNs19O6oIWqjcxOdtQLhyZ9mZl+Ht67VanetXbv2n9GVKsZ728rKyifVavXzWGtJDAbj3Z/eQRMwySS8QHm6/lvq//v6sGXE7Yl5Or3Z56XgWaiB8C/DoMeHojFXlInAIg732O/yiyQAJ4yvVqvfvuyyyx6KvmRxMuoBRdHPAADXYK3tONgwsfXjT1OiL1WCAlNQULoYApTYDwuw/ej6fg6Vmhv0eX5/z00nj2Z5UISsbLwI2Qxm91ulK3gQAHhO3RNyuXxlfX19TLoXxIV3frpE3IC19qvLLhX8dPnSkehLlaAgfggYJ2ItxRQf60dCyb71/13b6yaVS0DYH8kp8MyiXGxbt26tipVyAfGiYFQqVVddXd16AMCM7RAFhuHXFT8SrcjKxIw6kWAwFh/+8Vf6tEErGK3LafhkfGRRZCSaW/y/9Mz21TwB3meF1NXVKXbs2NEcZbHOIy4UDDjj9D2pUqkew1t/TfEjehKDQQ5yCwSnAwCTKea1O58YRsS7u/uPB9pWAgHA84K2z0d2Irs4hSz26Z9l4CfTNTQ0/Hnt2rUHoivVTOLCB3MWqVQK1Gr1ewCAm7HW63v7jPK9r3LxnFkk50Cno0BaCgEo5l8x+urqZeqf50lww6fgzCwk10+OHm8foLgWAgASfZxtRBHS6H1vl66g0mFYjHPIEZlMdrlGo4n5jPjYewLPYXR0dHK79P7NN9+8js/nz/jw8pIFLBRFTfW9/WRdysXw+yHAZALAinlACfpAP5w06HRpCzhsu4jJOC+vxYeirs+GR+13Hz3hHwAuhEmjpMZO1ITA8UR+8XABi12Es94qk8nWTRcYx5y4UjDgjJLx8ni8Rrlcfj/WFq6iIJ/5RVf3qNZsmX1iFwkAPj8KhMLYmzAA0I4Zzckvdffx/juo7+y1O1yHxiag94aGJ+46epy+p2cgyYz6JnJS2HgZqCRnQH8lzvv8hlQRbhGjUqm87e23326Lrlj4xPzmw+Ott976YWVl5ZtY5rLZ5XKW797nbR0ZI7M8L8YiGQqY8T9DqFjEHUzjMrJjLUc8c3Vy6sk/FJTIAABYRaw+tVr9QGlp6b4YiIZL3Dh5L+T2229/V61W78Ba4zOZrFc3/Aglksg1bxiP/0ZNNApsSOUwyCmNs8Cj0lofzS0U4SgXoFar98ebcgHxrGAmWb9+/VOTnx3W2iXibP4rG344BgHIE33JEoiJcQj441sPF6VxbBAESL8aDkIaTb97QSmFQ6Fk4hxyfOPGjbgR2FgSdz6Yc7FYLF4AwEm5XH4P1vqyzAzuhNNl/k6ri7knM25BEAhAEAKSkuJym8RlUIfyhJygs33nE1skBe2reQK8Ma8jcrn80kOHDsVHduUFxLUFA850wjukVqs3Tu4xsdaVV1ewl2ZmjEdfsgRiZBgCnvg09NJ5ZER6Fvw/Ts+uvyFVtARnHVGpVPfV19fHpXIBiaBgJiktLd0/ucfEWktmsZgH77+HlZHEtURfsgRh0ooxTsSdLwaGIKuIyyAd9Tgs5/JPbBLnXgFwZkir1eq3KisrMSd2xAsJoWDAmXG0k3vME1hrXDqdvfuHN05aOGQnPDzGxgBA40vHZPAYVgiCCI0zmauk0ei9v88vSp/lN9q5bdu2h6MsVtAkjIJpbGycmB5Hi1n4eMuihSl/vf4aXfQlSxA8bgiMj8VVFj45BhYbCIDxvxYvMmfQGXiZuma5XL5WpVIFNHgvliSMggFn2m1OqFSq+/FqW359xeX5isWy+Kj0i0f0QwD4Y549PkUal9HJolPw5vXMZ5CHcwoGilmcZXgHqFSqzfX19UHNJo8VCaVgwJnWDu/W1dVtw1vf88ObWEI2m3T6YuHzwWDCGHMrBgLAUZjGIX0vGFzGT/78R2kZeE7dSf5WWVn5RhRFIkTCKRhwZhztk1qt9j9YawIWk/PNfXdTRRxOXNRixB3jsffFpPOYRhiCyDGwF7CEy2v7c9GiS/HSR7Ra7ScymezX0ZcsdBJSwWg0GrSysvJuAMAhrHWpKI3/5h0b3DAEOaMvXZzjdMBgbDSWVowrW8AknS8XkMNkdTxZUMKHAcCbBtFcWVn5Y41GE99ZkxeQkAoGnHH6WuVy+XWTih1rfW1Bfsq/br9tONBeJPOKoUE0Vtm92QLWAINKEcbkzeMUBgwPvVhSiqbS6HiZusNyuXxdY2NjwjVdi+tM3ovR39/v5fF46vLy8juwlGVpukgwZLHom4f0SbGRME5BURjQaH7A4UT1AUODIfOC9CQmDEFkWcD/4X08r6i/lJskw1lHVCrVT5599tmTUZYrLCSsBXOWhx9++LO6uroteOsv3nxDyiJR2lB0pUoAxsaiXjqQlsR0UGCItF7O4Za0jAPXpKQtxVuvq6v7XWVl5fvRlSp8JLyCAWfabb6o1Wpfx1qjUyjMT+/+CSuHz0848zKiuJwwMEY1ouRJ5zHIToTncBk/ueV/cgrW4a1rtdq3qqurn4muVOFlTigYcKby+pcAAMxEOwmfn7zvtpvJcbQXotOi0YooZfCYfSyyW933UADU/0hOweTWHa9Qd3j9+vUPaDSaKEsWXhLaB3Muo6OjbgDAh3K5fAMAYIbPpTAlhc+mUTu+6OrhzaW/mxAIAgMGEwEsVkS3SxQYsi5KT6LBMER2IZy8OSnU0d0LFxtzmKxinENGlErlVW+//TZmACORmFM/tOmq0iG5XH4b1vr/Z+/cY5vIrj9+Zvy2Y8exYycmHhIT5+UbFtj9/bZh2WLz0MarLoiXYyo1iFKkPuSqgnYl1G5F/uhDLaWvVdltRaS2Yllqt6W7qLTsrpSkXZEAKktK7PAOyZgCedIEEtuZeCoTR03ZGW8S7LEzMx8JCelYo+PJ9XfOPXPuOWtKlxp7Rh70dd69JzY3mmGKioOxMKORbJFOOWzUKMS6lyR7lxBXXAVG1rxLIBD4is/n+4BbrzIDrwQmwc2bN4P19fVqs9m8hsm+mrBK3u68/Ggslv3xqjlBLIaBVhsHuSJTIjNlN+VFZBJcjF4en5DWdR8os9tTjHn9eWNj46HR0dHcOpm6QHKyCVE6oGn6NAC8zGT7Q1fo5o7j/nLuvcpRlEoKqh3STIw4MeUprlWY88Qh9tP0n0Crxgilim3tvY9h2Esc+5RReJPkfZKGhgZfYrvEZNte67B9e73zstjTN0kkIoXR0bS/UcIx7FGpQS2eOQIAOY4Pv1G1/E4KcbmXHKHMK3i3RZohFAqNAMCZZLvNJxslY+uW2You3b13/erAoPhmAx7PUYqDwZDWB45Zqxw0aRVs1amC4vMW6xW30bSKxRxtampyHjlypJtjtzIObwUGppO+AwihMYQQ41bpxdKl2DvdV4ZHJiLiUzYWA8jXx0EmS5fIxO0mzbhcigu+odRqnb79G6Xl1ThgjP1BA4HAqz6fL6c70y0U3uZgZkiOow0AwA4m++2RBz3VP3ldG6WmxEgmT0tBRSXjWIz5YtDIr1YXaavSca3FjE2p6j6GVhGJu8vykT8ihLYv9noXNnibg5kh8YdDCDWSJNnOZC8r0Nt+tXXzsJiPAYCHY1J49PCpczEYBuNlBrHfiwSw/tfKKqRs4pJYkwihz/FVXEAIAgPTIhNpbm7+AlvP3l2rVlTufm7V37j3LAcZfPpBbYV5igdKGS703Ev0cIWju1qTx1ZMN5lYk6FQiNctRXidg5lNW1vboMPhuIgQ2spUg7DFUV18jgz33BgaFvZhvGgUwGCkQSJZ8Pa5vFAzppBKBH2CvcFs6dxmLl7NYp7w+/3bfD4fY1TNJwQRwczg9Xr/HAwGD7OYVW9ueUUlxfFF0es0Y8TjONy9s+Btkl4lu6ZVygTda9ehzjv/NcLGWvsTDAZ/5PV6T3PrVXbgfZL3SaxWq5okyQ4AYJyUd/Ffd7vXH/216d+RqJCTvnGodgCoVPN6AGEAkZVW/ZBKLhHsEHuLXHH7aM0zUr1UxjYRoJMgiBfC4fA4x65lBcFskWZIjqO96HK59jLZLVqtCQP86gc3bwk5h4ABhk2BLn9eAmPUyPuL85WCFRcAmPxxheNOikOMdFNT0+ZTp071cuxX1hCcwMB0PuaOx+PpMZvNm5i2iWvKlub3jIyc67x7f2l2PMwBYlEaCk044HPXmGWFmlGlTCLUt0cT+5YuO+/SG59nsU/6/f5dPp/vDMd+ZRVB5WBmU1tb+9tAIHCAyYYBqH+zY2tdw3L0Efee5QgUJYG+3jkPtDZq5LfyVTLBRn1fKikN7TAVf5rNHggEXvV6vce59Sr7CC4HM5tkEd67ALCJyT4Wjd6xHfrZyND4eC333uUI1TUUqNSfVHwX+VSZYViCY4JM7j6rzW99vRKtBgC2Sf6/Rwh5+FzvwoZgIxj4bxHeTpIkzzPZtQpFyd+/uEdi0WqFO5J2Dr17i7SKIaGKS7lKff2wvcbBJi4kSZ5FCDUKUVxA6AID0yIz3tzcvJetkrfGVFjz/fqNfdx7liMMD9EQT/3WukinFOo6enjQVknJcdzMYp8ppotw7FfOIMgk75O0tbX1OxyOywihLQwnr2GlpbgoRlHvfdjbZxOcKNM0DvF4FHT5jNukArWst0SvsgjtvmAAo98trwo+q81nOyE94ff7t/p8vg6OXcspBLUoUuH1ek8Gg8Gfspjl36vfWP9Shf1Djt3KDQb6ZRCLMUV4k3bT42M2gntQ7bJYb7j0xjo2ezAY/KHX6/0Lt17lHqLAzMLtdn8nEdCwmPFjDdsqd65Y3gIAc367whNwGPr4GSVTnqJfJsFLs+NS9ngmT9uyq7gk1fc+43a7f8ChSzmLKDCzCIfDD10u18sAcJvJbtKol7zt3e56bd3a9xObB+49zCKDgx8bcVKky1gf35zFrtK890bV8pVKnHX87TWXy7U5HA7z+hDjXBFcaPtJ9Pb2Ujqdris5jpbp/mDry222/ytZcqmjLxx7EImwDSvnF/G4BFRqCpTTCd18pZQkCtRmAa2hh26D+Z1v2uw1GgnrUYjI/v37t584cYLxASVEBF0Hk4qWlpYvu1yuI6k+Q8Xjg9vf8l96t/vKekFEgzrdJJTapCCVxp8j9L0KmWRZtl3iiN4DpeUnNxUWfTWVoLa2tu5ct27d77h1LbcRytNn3ly4cOEfZrM5ghDawCbEOIapP7ui1vqZqoqgWi4fuDE0NDQxSRl5K9zRKIBMRhnMhv5inZL3uRcFjl/0mCwt3yqzTzyv07NFtI9pb28/tHbtWraXBIKFnz+ENNLS0rLb5XIdnaMYT5y+ev3sW5f+SR/vvFwFAAQHLnKLQkE5NrwwoOffsQAaAEgACK43FJ6zKTQTe5aUvAIArOX/s2hFCG0MhUJiV8QnEAVmDvj9/i0ej+eXAMBWUMXEwOV79+/fGB7Jo6amaP4khbF4gaXwI4kE70827lrka+jxMChMplLhLyrViegzEZlVppgZ/T+QJHnC7XbvDoVC0cz7uvhY5IuDO5xOp6G1tfWvAPD/2fYly0zO6gg4lfxHpziHw2eOIYR2i5ELO/xPTKaJtra2YYIgXIFA4OsAcC/b/uQIiW2jPCkucQCgkjVCU8n/85WRQCCwB8OwRlFcRNKOx+Mx0DT9Jk3TFC08YvP4bCR5j6IZ9Idr/uR0OguyvQZFBMC+ffscZ8+e/QVN0wPZXvUcMh+Bmc2M2FBPcY1s8aivr+/4wYMHN1itVjGtIMItTqcT9/v9m2iaPknT9ES2fw0ZJl3iMCM0kTRdLxOQXV1dB5xOp+CnUy4UUY3TTF1dnYogiOq6ujoHQRAEAFgAgE/VvlMZqJ+iEtd0OBwShBDBcX1W4vuMB4PBR8l55j0kSd7q6Ojoam9v7w6Hw089iE7I/CcAAP//LazR1LfsgEMAAAAASUVORK5CYII=
+      mediatype: image/png
+  labels:
+    alm-owner-kubevirt: kubevirt-hyperconverged
+    operated-by: kubevirt-hyperconverged
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-hyperconverged
+      operated-by: kubevirt-hyperconverged
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: true
+    - type: AllNamespaces
+      supported: true
+  install:
+    strategy: deployment
+    spec:
+
+      permissions:
+        - serviceAccountName: cluster-network-addons-operator
+          rules:
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - patch
+              - update
+              - delete
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - replicasets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - patch
+              - update
+              - delete
+
+
+      clusterPermissions:
+        - serviceAccountName: hyperconverged-cluster-operator
+          rules:
+            - apiGroups:
+              - hco.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - networkaddonsoperator.network.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              - pods
+              - serviceaccounts
+              - services
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - delete
+            - apiGroups:
+              - batch
+              resources:
+              - jobs
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - daemonsets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - rbac.authorization.k8s.io
+              resources:
+              - clusterroles
+              - clusterrolebindings
+              - roles
+              - rolebindings
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+              - update
+            - apiGroups:
+              - security.openshift.io
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - privileged
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - patch
+              - update
+            - apiGroups:
+              - machineremediation.kubevirt.io
+              resources:
+              - machineremediationoperators
+              - machineremediationoperators/status
+              verbs:
+              - '*'
+
+
+        - serviceAccountName: kubevirt-operator
+          rules:
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - kubevirts
+              verbs:
+              - get
+              - list
+              - watch
+              - patch
+              - update
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - serviceaccounts
+              - services
+              - endpoints
+              - pods/exec
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - delete
+              - patch
+            - apiGroups:
+              - batch
+              resources:
+              - jobs
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - daemonsets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+            - apiGroups:
+              - rbac.authorization.k8s.io
+              resources:
+              - clusterroles
+              - clusterrolebindings
+              - roles
+              - rolebindings
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+              - update
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - patch
+            - apiGroups:
+              - security.openshift.io
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - create
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - privileged
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - patch
+              - update
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - kubevirt-handler
+              - kubevirt-controller
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+              - update
+              - delete
+            - apiGroups:
+              - admissionregistration.k8s.io
+              resources:
+              - validatingwebhookconfigurations
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - monitoring.coreos.com
+              resources:
+              - servicemonitors
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+              - update
+              - patch
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - virtualmachines/start
+              - virtualmachines/stop
+              - virtualmachines/restart
+              verbs:
+              - put
+            - apiGroups:
+              - admissionregistration.k8s.io
+              resources:
+              - validatingwebhookconfigurations
+              - mutatingwebhookconfigurations
+              verbs:
+              - get
+              - create
+              - update
+            - apiGroups:
+              - apiregistration.k8s.io
+              resources:
+              - apiservices
+              verbs:
+              - get
+              - create
+              - update
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachines
+              - virtualmachineinstances
+              - virtualmachineinstancemigrations
+              verbs:
+              - get
+              - list
+              - watch
+              - patch
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachineinstancepresets
+              verbs:
+              - watch
+              - list
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - limitranges
+              verbs:
+              - watch
+              - list
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - get
+              - list
+              - delete
+              - update
+              - create
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - policy
+              resources:
+              - poddisruptionbudgets
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - configmaps
+              - endpoints
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - update
+              - create
+            - apiGroups:
+              - ""
+              resources:
+              - events
+              verbs:
+              - update
+              - create
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - pods/finalizers
+              verbs:
+              - update
+            - apiGroups:
+              - ""
+              resources:
+              - nodes
+              verbs:
+              - get
+              - list
+              - watch
+              - update
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - persistentvolumeclaims
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - k8s.cni.cncf.io
+              resources:
+              - network-attachment-definitions
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - authorization.k8s.io
+              resources:
+              - subjectaccessreviews
+              verbs:
+              - create
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachineinstances
+              verbs:
+              - update
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              - persistentvolumeclaims
+              verbs:
+              - get
+            - apiGroups:
+              - ""
+              resources:
+              - nodes
+              verbs:
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - events
+              verbs:
+              - create
+              - patch
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - create
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - version
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - virtualmachineinstances/console
+              - virtualmachineinstances/vnc
+              verbs:
+              - get
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - virtualmachines/start
+              - virtualmachines/stop
+              - virtualmachines/restart
+              verbs:
+              - update
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachines
+              - virtualmachineinstances
+              - virtualmachineinstancepresets
+              - virtualmachineinstancereplicasets
+              - virtualmachineinstancemigrations
+              verbs:
+              - get
+              - delete
+              - create
+              - update
+              - patch
+              - list
+              - watch
+              - deletecollection
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - virtualmachineinstances/console
+              - virtualmachineinstances/vnc
+              verbs:
+              - get
+            - apiGroups:
+              - subresources.kubevirt.io
+              resources:
+              - virtualmachines/start
+              - virtualmachines/stop
+              - virtualmachines/restart
+              verbs:
+              - update
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachines
+              - virtualmachineinstances
+              - virtualmachineinstancepresets
+              - virtualmachineinstancereplicasets
+              - virtualmachineinstancemigrations
+              verbs:
+              - get
+              - delete
+              - create
+              - update
+              - patch
+              - list
+              - watch
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - virtualmachines
+              - virtualmachineinstances
+              - virtualmachineinstancepresets
+              - virtualmachineinstancereplicasets
+              - virtualmachineinstancemigrations
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - authentication.k8s.io
+              resources:
+              - tokenreviews
+              verbs:
+              - create
+            - apiGroups:
+              - authorization.k8s.io
+              resources:
+              - subjectaccessreviews
+              verbs:
+              - create
+
+        - serviceAccountName: cdi-operator
+          rules:
+            - apiGroups:
+              - rbac.authorization.k8s.io
+              resources:
+              - roles
+              - rolebindings
+              - clusterrolebindings
+              - clusterroles
+              verbs:
+              - '*'
+            - apiGroups:
+              - security.openshift.io
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+              - patch
+              - update
+            - apiGroups:
+              - ""
+              resources:
+              - serviceaccounts
+              - services
+              verbs:
+              - '*'
+            - apiGroups:
+              - ""
+              resources:
+              - nodes
+              verbs:
+              - get
+              - list
+              - watch
+              - update
+              - patch
+            - apiGroups:
+              - extensions
+              resources:
+              - deployments
+              verbs:
+              - '*'
+            - apiGroups:
+              - extensions
+              resources:
+              - ingresses
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - watch
+              - create
+              - delete
+              - get
+              - update
+              - patch
+              - list
+            - apiGroups:
+              - batch
+              resources:
+              - jobs
+              verbs:
+              - create
+              - delete
+              - get
+              - update
+              - patch
+              - list
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - create
+              - delete
+              - get
+              - update
+              - patch
+              - list
+              - watch
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - deployments/finalizers
+              - daemonstes
+              verbs:
+              - create
+              - get
+              - list
+              - delete
+              - watch
+              - update
+            - apiGroups:
+              - admissionregistration.k8s.io
+              resources:
+              - validatingwebhookconfigurations
+              - mutatingwebhookconfigurations
+              verbs:
+              - get
+              - create
+              - update
+            - apiGroups:
+              - apiregistration.k8s.io
+              resources:
+              - apiservices
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - storage.k8s.io
+              resources:
+              - storageclasses
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - ""
+              resources:
+              - events
+              verbs:
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - persistentvolumeclaims
+              - volumesnapshots
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - ""
+              resources:
+              - persistentvolumeclaims/finalizers
+              - pods/finalizers
+              - volumesnapshots/finalizers
+              verbs:
+              - update
+            - apiGroups:
+              - ""
+              resources:
+              - services
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - delete
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+            - apiGroups:
+              - ""
+              resources:
+              - namespaces
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - route.openshift.io
+              resources:
+              - routes
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - route.openshift.io
+              resources:
+              - routes/custom-host
+              verbs:
+              - create
+              - update
+            - apiGroups:
+              - snapshot.storage.k8s.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - '*'
+
+        - serviceAccountName: cluster-network-addons-operator
+          rules:
+            - apiGroups:
+              - security.openshift.io
+              resourceNames:
+              - privileged
+              resources:
+              - securitycontextconstraints
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - operator.openshift.io
+              resources:
+              - networks
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - networkaddonsoperator.network.kubevirt.io
+              resources:
+              - networkaddonsconfigs
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - '*'
+              resources:
+              - '*'
+              verbs:
+              - '*'
+
+        - serviceAccountName: machine-remediation-operator
+          rules:
+            - apiGroups:
+              - machineremediation.kubevirt.io
+              resources:
+              - machineremediationoperators
+              - machineremediationoperators/status
+              verbs:
+              - get
+              - list
+              - update
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - nodes
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - serviceaccounts
+              verbs:
+              - '*'
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              verbs:
+              - '*'
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - '*'
+            - apiGroups:
+              - rbac.authorization.k8s.io
+              resources:
+              - clusterroles
+              - clusterrolebindings
+              verbs:
+              - '*'
+            - apiGroups:
+              - config.openshift.io
+              resources:
+              - infrastructures
+              - infrastructures/status
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - machineremediation.kubevirt.io
+              resources:
+              - machinedisruptionbudgets
+              - machinehealthchecks
+              verbs:
+              - '*'
+
+        - serviceAccountName: kubevirt-ssp-operator
+          rules:
+          - apiGroups:
+            - kubevirt.io
+            - oauth.openshift.io
+            - template.openshift.io
+            resources:
+            - '*'
+            verbs:
+            - '*'
+          - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - prometheusrules
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - watch
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - clusterroles
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - patch
+            - update
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - clusterrolebindings
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - patch
+            - update
+          - apiGroups:
+            - extensions
+            - apps
+            resources:
+            - deployments
+            - replicasets
+            - daemonsets
+            - statefulsets
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - serviceaccounts
+            - configmaps
+            - nodes
+            - endpoints
+            - events
+            - secrets
+            verbs:
+            - create
+            - get
+            - patch
+            - update
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - services
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - admissionregistration.k8s.io
+            resources:
+            - validatingwebhookconfigurations
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - watch
+          - apiGroups:
+            - security.openshift.io
+            resources:
+            - securitycontextconstraints
+            verbs:
+            - '*'
+            resourceNames:
+            - privileged
+
+        - serviceAccountName: node-maintenance-operator
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - services
+            - endpoints
+            - events
+            - configmaps
+            - serviceaccounts
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - get
+            - list
+            - update
+            - patch
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - pods/eviction
+            verbs:
+            - create
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            - daemonsets
+            - replicasets
+            - statefulsets
+            verbs:
+            - '*'
+          - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - servicemonitors
+            verbs:
+            - get
+            - create
+          - apiGroups:
+            - kubevirt.io
+            resources:
+            - '*'
+            verbs:
+            - '*'
+          - apiGroups:
+            - oauth.openshift.io
+            resources:
+            - '*'
+            verbs:
+            - '*'
+
+      deployments:
+        - name: hco-operator-0-0-2
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: hyperconverged-cluster-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: hyperconverged-cluster-operator
+              spec:
+                containers:
+                - command:
+                  - hyperconverged-cluster-operator
+                  env:
+                  - name: OPERATOR_IMAGE
+                    value: quay.io/kubevirt/hyperconverged-cluster-operator:latest
+                  - name: OPERATOR_NAME
+                    value: hyperconverged-cluster-operator
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: WATCH_NAMESPACE
+                  - name: CONVERSION_CONTAINER
+                    value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0
+                  - name: VMWARE_CONTAINER
+                    value: quay.io/kubevirt/kubevirt-vmware:v2.0.0
+                  image: quay.io/kubevirt/hyperconverged-cluster-operator:latest
+                  imagePullPolicy: Always
+                  name: hyperconverged-cluster-operator
+                  readinessProbe:
+                    exec:
+                      command:
+                      - stat
+                      - /tmp/operator-sdk-ready
+                    failureThreshold: 1
+                    initialDelaySeconds: 5
+                    periodSeconds: 5
+                  resources: {}
+                serviceAccountName: hyperconverged-cluster-operator
+
+
+        - name: virt-operator-0-0-2
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                kubevirt.io: virt-operator
+            strategy:
+              type: RollingUpdate
+            template:
+              metadata:
+                annotations:
+                  scheduler.alpha.kubernetes.io/critical-pod: ""
+                  scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly","operator":"Exists"}]'
+                labels:
+                  kubevirt.io: virt-operator
+                  prometheus.kubevirt.io: ""
+                name: virt-operator
+              spec:
+                containers:
+                - command:
+                  - virt-operator
+                  - --port
+                  - "8443"
+                  - -v
+                  - "2"
+                  env:
+                  - name: OPERATOR_IMAGE
+                    value: kubevirt/virt-operator:v0.20.6
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.annotations['olm.targetNamespaces']
+                  image: kubevirt/virt-operator:v0.20.6
+                  imagePullPolicy: IfNotPresent
+                  name: virt-operator
+                  ports:
+                  - containerPort: 8443
+                    name: metrics
+                    protocol: TCP
+                  readinessProbe:
+                    httpGet:
+                      path: /metrics
+                      port: 8443
+                      scheme: HTTPS
+                    initialDelaySeconds: 5
+                    timeoutSeconds: 10
+                  resources: {}
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: kubevirt-operator
+
+        - name: cdi-operator-0-0-2
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: cdi-operator
+                operator.cdi.kubevirt.io: ""
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: cdi-operator
+                  operator.cdi.kubevirt.io: ""
+              spec:
+                containers:
+                - env:
+                  - name: DEPLOY_CLUSTER_RESOURCES
+                    value: "true"
+                  - name: DOCKER_REPO
+                    value: kubevirt
+                  - name: DOCKER_TAG
+                    value: v1.10.3
+                  - name: CONTROLLER_IMAGE
+                    value: cdi-controller
+                  - name: IMPORTER_IMAGE
+                    value: cdi-importer
+                  - name: CLONER_IMAGE
+                    value: cdi-cloner
+                  - name: APISERVER_IMAGE
+                    value: cdi-apiserver
+                  - name: UPLOAD_SERVER_IMAGE
+                    value: cdi-uploadserver
+                  - name: UPLOAD_PROXY_IMAGE
+                    value: cdi-uploadproxy
+                  - name: VERBOSITY
+                    value: "1"
+                  - name: PULL_POLICY
+                    value: IfNotPresent
+                  image: kubevirt/cdi-operator:v1.10.3
+                  imagePullPolicy: IfNotPresent
+                  name: cdi-operator
+                  ports:
+                  - containerPort: 60000
+                    name: metrics
+                    protocol: TCP
+                  resources: {}
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: cdi-operator
+
+        - name: cluster-network-addons-operator-0-0-2
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: cluster-network-addons-operator
+            strategy:
+              type: Recreate
+            template:
+              metadata:
+                labels:
+                  name: cluster-network-addons-operator
+              spec:
+                containers:
+                - env:
+                  - name: MULTUS_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
+                  - name: LINUX_BRIDGE_IMAGE
+                    value: quay.io/kubevirt/cni-default-plugins:v0.8.1
+                  - name: LINUX_BRIDGE_MARKER_IMAGE
+                    value: quay.io/kubevirt/bridge-marker:0.2.0
+                  - name: NMSTATE_HANDLER_IMAGE
+                    value: quay.io/nmstate/kubernetes-nmstate-handler:v0.8.0
+                  - name: OVS_CNI_IMAGE
+                    value: quay.io/kubevirt/ovs-cni-plugin:v0.7.0
+                  - name: OVS_MARKER_IMAGE
+                    value: quay.io/kubevirt/ovs-cni-marker:v0.7.0
+                  - name: KUBEMACPOOL_IMAGE
+                    value: quay.io/kubevirt/kubemacpool:v0.7.0
+                  - name: OPERATOR_IMAGE
+                    value: quay.io/kubevirt/cluster-network-addons-operator:0.17.0
+                  - name: OPERATOR_NAME
+                    value: cluster-network-addons-operator
+                  - name: OPERATOR_VERSION
+                    value: 0.17.0
+                  - name: OPERATOR_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: OPERAND_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: WATCH_NAMESPACE
+                  image: quay.io/kubevirt/cluster-network-addons-operator:0.17.0
+                  imagePullPolicy: IfNotPresent
+                  name: cluster-network-addons-operator
+                  resources: {}
+                serviceAccountName: cluster-network-addons-operator
+
+        - name: machine-remediation-operator-0-0-2
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                machineremediation.kubevirt.io: machine-remediation-operator
+                machineremediation.kubevirt.io/version: v0.3.12
+            strategy:
+              type: RollingUpdate
+            template:
+              metadata:
+                labels:
+                  machineremediation.kubevirt.io: machine-remediation-operator
+                  machineremediation.kubevirt.io/version: v0.3.12
+              spec:
+                affinity:
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchExpressions:
+                          - key: machineremediation.kubevirt.io
+                            operator: In
+                            values:
+                            - machine-remediation-operator
+                        topologyKey: kubernetes.io/hostname
+                      weight: 50
+                containers:
+                - args:
+                  - --logtostderr=true
+                  - --v=2
+                  - --namespace=kubevirt-hyperconverged
+                  command:
+                  - /usr/bin/machine-remediation-operator
+                  env:
+                  - name: OPERATOR_VERSION
+                    value: v0.3.12
+                  image: kubevirt/machine-remediation-operator:v0.3.12
+                  imagePullPolicy: IfNotPresent
+                  name: machine-remediation-operator
+                  resources:
+                    requests:
+                      cpu: 10m
+                      memory: 20Mi
+                nodeSelector:
+                  node-role.kubernetes.io/master: ""
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: machine-remediation-operator
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+                - key: CriticalAddonsOnly
+                  operator: Exists
+                - effect: NoExecute
+                  key: node.kubernetes.io/not-ready
+                  operator: Exists
+                  tolerationSeconds: 120
+                - effect: NoExecute
+                  key: node.kubernetes.io/unreachable
+                  operator: Exists
+                  tolerationSeconds: 120
+
+        - name: kubevirt-ssp-operator-0-0-2
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: kubevirt-ssp-operator
+            template:
+              metadata:
+                labels:
+                  name: kubevirt-ssp-operator
+              spec:
+                serviceAccountName: kubevirt-ssp-operator
+                containers:
+                  - name: kubevirt-ssp-operator
+                    image: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.10
+                    ports:
+                    - containerPort: 60000
+                      name: metrics
+                    imagePullPolicy: Always
+                    env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: WATCH_NAMESPACE
+                        value: ""
+                      - name: VIRT_LAUNCHER_TAG
+                        value: v0.20.6
+                      - name: OPERATOR_NAME
+                        value: "kubevirt-ssp-operator"
+
+        - name: node-maintenance-operator-0-0-2
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: node-maintenance-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: node-maintenance-operator
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: node-role.kubernetes.io/master
+                          operator: Exists
+                containers:
+                - env:
+                  - name: WATCH_NAMESPACE
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: OPERATOR_NAME
+                    value: node-maintenance-operator
+                  image: quay.io/kubevirt/node-maintenance-operator:v0.4.0
+                  imagePullPolicy: Always
+                  name: node-maintenance-operator
+                  resources: {}
+                serviceAccountName: node-maintenance-operator
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+
+  customresourcedefinitions:
+    owned:
+      - name: hyperconvergeds.hco.kubevirt.io
+        version: v1alpha1
+        kind: HyperConverged
+        displayName: KubeVirt HyperConverged Cluster Operator Deployment
+        description: Represents the deployment of a KubeVirt HyperConverged Cluster Operator
+
+      - name: kubevirts.kubevirt.io
+        version: v1alpha3
+        kind: KubeVirt
+        displayName: KubeVirt deployment
+        description: Represents a KubeVirt deployment.
+      - name: cdis.cdi.kubevirt.io
+        version: v1alpha1
+        kind: CDI
+        displayName: CDI Application
+        description: Represents an instance of a CDI application
+      - name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+        version: v1alpha1
+        kind: NetworkAddonsConfig
+        displayName: Cluster Network Addons
+        description: Cluster Network Addons
+      - name: machineremediationoperators.machineremediation.kubevirt.io
+        version: v1alpha1
+        kind: MachineRemediationOperator
+        displayName: Machine Remediation Operator deployment
+        description: Represents a Machine Remediation Operator deployment
+      - name: kubevirtcommontemplatesbundles.kubevirt.io
+        version: v1
+        kind: KubevirtCommonTemplatesBundle
+        displayName: KubeVirt Common Templates
+        description: KubeVirt Common Templates
+      - name: kubevirtnodelabellerbundles.kubevirt.io
+        version: v1
+        kind: KubevirtNodeLabellerBundle
+        displayName: KubeVirt Node Labeller Bundler
+        description: KubeVirt Node Labeller Bundler
+      - name: kubevirttemplatevalidators.kubevirt.io
+        version: v1
+        kind: KubevirtTemplateValidator
+        displayName: KubeVirt Template Validator
+        description: KubeVirt Template Validator
+      - name: kubevirtmetricsaggregations.kubevirt.io
+        version: v1
+        kind: KubevirtMetricsAggregation
+        displayName: KubeVirt Metrics Aggregation Rules
+        description: KubeVirt Metrics Aggregation Rules
+      - name: nodemaintenances.kubevirt.io
+        version: v1alpha1
+        kind: NodeMaintenance
+        displayName: Node Maintenance
+        description: Node Maintenance
+      - name: v2vvmwares.kubevirt.io
+        version: v1alpha1
+        kind: V2VVmware
+        displayName: V2V Vmware
+        description: V2V Vmware

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/kubevirt.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/kubevirt.crd.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    categories:
+    - all
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  scope: Namespaced
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/metrics-aggregation.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/metrics-aggregation.crd.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtmetricsaggregations.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtMetricsAggregation
+    listKind: KubevirtMetricsAggregationList
+    plural: kubevirtmetricsaggregations
+    singular: kubevirtmetricsaggregation
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  subresources:
+    status: {}

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/mro.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/mro.crd.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: machineremediationoperators.machineremediation.kubevirt.io
+spec:
+  group: machineremediation.kubevirt.io
+  names:
+    kind: MachineRemediationOperator
+    plural: machineremediationoperators
+    shortNames:
+      - mro
+      - mros
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of MachineRemediationOperator
+          properties:
+            imagePullPolicy:
+              description: The ImagePullPolicy to use.
+              type: string
+            imageRegistry:
+              description: The image registry to pull the container images from Defaults
+                to the same registry the operator's container image is pulled from.
+              type: string
+          type: object
+        status:
+          description: Most recently observed status of MachineRemediationOperator
+            resource
+          properties:
+            conditions:
+              description: type specifies the state of the operator's reconciliation
+                functionality, which reflects the state of the application
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: lastTransitionTime is the time of the last update
+                      to the current status object.
+                    format: date-time
+                    type: string
+                  message:
+                    description: message provides additional information about the
+                      current condition. This is only to be consumed by humans.
+                    type: string
+                  reason:
+                    description: reason is the reason for the condition's last transition.  Reasons
+                      are CamelCase
+                    type: string
+                  status:
+                    description: status of the condition, one either True or False.
+                    type: string
+                  type:
+                    description: type specifies the state of the operator's reconciliation
+                      functionality, which reflects the state of the application
+                    type: string
+                required:
+                  - type
+                  - status
+                  - lastTransitionTime
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/node-labeller-bundles.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/node-labeller-bundles.crd.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtnodelabellerbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtNodeLabellerBundle
+    listKind: KubevirtNodeLabellerBundleList
+    plural: kubevirtnodelabellerbundles
+    singular: kubevirtnodelabellerbundle
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  subresources:
+    status: {}

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/nodemaintenance.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/nodemaintenance.crd.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nodemaintenances.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: NodeMaintenance
+    listKind: NodeMaintenanceList
+    plural: nodemaintenances
+    singular: nodemaintenance
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            nodeName:
+              description: Node name to apply maintanance on/off
+              type: string
+            reason:
+              description: Reason for maintanance
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          properties:
+            evictionPods:
+              description: EvictionPods is the total number of pods up for eviction
+                from the start
+              format: int64
+              type: integer
+            lastError:
+              description: LastError represents the latest error if any in the latest
+                reconciliation
+              type: string
+            pendingPods:
+              description: PendingPods is a list of pending pods for eviction
+              items:
+                type: string
+              type: array
+            phase:
+              description: Phase is the represtation of the maintenanace progress
+                (Running,Succeeded)
+              type: string
+            totalpods:
+              description: TotalPods is the total number of all pods on the node from
+                the start
+              format: int64
+              type: integer
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/template-validator.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/template-validator.crd.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirttemplatevalidators.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtTemplateValidator
+    listKind: KubevirtTemplateValidatorList
+    plural: kubevirttemplatevalidators
+    singular: kubevirttemplatevalidator
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  subresources:
+    status: {}

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/v2vvmware.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/manifests/v2vvmware.crd.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: v2vvmwares.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: V2VVmware
+    listKind: V2VVmwareList
+    plural: v2vvmwares
+    singular: v2vvmware
+  scope: Namespaced
+  version: v1alpha1

--- a/community-operators/community-kubevirt-hyperconverged/0.0.2/metadata/annotations.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.2/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: 0.0.2
+  operators.operatorframework.io.bundle.channels.v1: 0.0.2
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: community-kubevirt-hyperconverged

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/cluster-network-addons00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/cluster-network-addons00.crd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/containerized-data-importer00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/containerized-data-importer00.crd.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.cdi.kubevirt.io: ""
+  name: cdis.cdi.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: cdi.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: CDI
+    listKind: CDIList
+    plural: cdis
+    shortNames:
+    - cdi
+    - cdis
+    singular: cdi
+  scope: Cluster
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/hco.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/hco.crd.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hyperconvergeds.hco.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: hco.kubevirt.io
+  names:
+    kind: HyperConverged
+    plural: hyperconvergeds
+    shortNames:
+    - hco
+    - hcos
+    singular: hyperconverged
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/kubevirt-hyperconverged-operator.v0.0.3.clusterserviceversion.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/kubevirt-hyperconverged-operator.v0.0.3.clusterserviceversion.yaml
@@ -1,0 +1,1673 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1alpha1","kind":"HyperConverged","metadata":{"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{"BareMetalPlatform":false}}]'
+    capabilities: Full Lifecycle
+    categories: OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:latest
+    createdAt: "2019-11-19 13:19:14"
+    description: |-
+      **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+      Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+      Containerized Data Importer (CDI), and Cluster Network Addons (CNA) operators.
+
+      **KubeVirt** is a virtual machine management add-on for Kubernetes.
+      The aim is to provide a common ground for virtualization solutions on top of
+      Kubernetes.
+
+      # Virtualization extension for Kubernetes
+
+      At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+      additional virtualization resource types (especially the `VirtualMachine` type) through
+      [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+      By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+      resources alongside all other resources Kubernetes provides.
+
+      The resources themselves are not enough to launch virtual machines.
+      For this to happen the _functionality and business logic_ needs to be added to
+      the cluster. The functionality is not added to Kubernetes itself, but rather
+      added to a Kubernetes cluster by _running_ additional controllers and agents
+      on an existing cluster.
+
+      The necessary controllers and agents are provided by KubeVirt.
+
+      As of today KubeVirt can be used to declaratively
+
+        * Create a predefined VM
+        * Schedule a VM on a Kubernetes cluster
+        * Launch a VM
+        * Migrate a VM
+        * Stop a VM
+        * Delete a VM
+
+      # Start using KubeVirt
+
+        * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+        * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+      # Start developing KubeVirt
+
+      To set up a development environment please read our
+      [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+      To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+      You can learn more about how KubeVirt is designed (and why it is that way),
+      and learn more about the major components by taking a look at our developer documentation:
+
+        * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+        * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+        * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+      # Community
+
+      If you got enough of code and want to speak to people, then you got a couple of options:
+
+        * Follow us on [Twitter](https://twitter.com/kubevirt)
+        * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+        * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+        * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+      # License
+
+      KubeVirt is distributed under the
+      [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    support: "false"
+  name: kubevirt-hyperconverged-operator.v0.0.3
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents the deployment of a KubeVirt HyperConverged Cluster
+        Operator
+      displayName: KubeVirt HyperConverged Cluster Operator Deployment
+      kind: HyperConverged
+      name: hyperconvergeds.hco.kubevirt.io
+      version: v1alpha1
+    - description: V2V Vmware
+      displayName: V2V Vmware
+      kind: V2VVmware
+      name: v2vvmwares.kubevirt.io
+      version: v1alpha1
+    - description: Cluster Network Addons
+      displayName: Cluster Network Addons
+      kind: NetworkAddonsConfig
+      name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+      version: v1alpha1
+    - description: Represents a KubeVirt deployment
+      displayName: KubeVirt deployment
+      kind: KubeVirt
+      name: kubevirts.kubevirt.io
+      specDescriptors:
+      - description: The ImagePullPolicy to use for the KubeVirt components.
+        displayName: ImagePullPolicy
+        path: imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:imagePullPolicy
+      - description: The ImageRegistry to use for the KubeVirt components.
+        displayName: ImageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The ImageTag to use for the KubeVirt components.
+        displayName: ImageTag
+        path: imageTag
+        x-descriptors:
+        - urn:alm:descriptor:text
+      statusDescriptors:
+      - description: The deployment phase.
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Explanation for the current status of the cluster.
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      - description: The observed version of the KubeVirt deployment.
+        displayName: Observed KubeVirt Version
+        path: observedKubeVirtVersion
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The targeted version of the KubeVirt deployment.
+        displayName: Target KubeVirt Version
+        path: targetKubeVirtVersion
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The observed registry of the KubeVirt deployment.
+        displayName: Observed KubeVirt registry
+        path: ObservedKubeVirtRegistry
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The targeted registry of the KubeVirt deployment.
+        displayName: Target KubeVirt registry
+        path: TargetKubeVirtRegistry
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The version of the KubeVirt Operator.
+        displayName: KubeVirt Operator Version
+        path: operatorVersion
+        x-descriptors:
+        - urn:alm:descriptor:text
+      version: v1alpha3
+    - description: Represents a deployment of the predefined VM templates
+      displayName: KubeVirt common templates
+      kind: KubevirtCommonTemplatesBundle
+      name: kubevirtcommontemplatesbundles.kubevirt.io
+      specDescriptors:
+      - description: The version of the KubeVirt Templates to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+    - description: Provide aggregation rules for core kubevirt metrics
+      displayName: KubeVirt Metric Aggregation
+      kind: KubevirtMetricsAggregation
+      name: kubevirtmetricsaggregations.kubevirt.io
+      specDescriptors:
+      - description: The version of the aggregation rules to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+    - description: Represents a deployment of Node labeller component
+      displayName: KubeVirt Node labeller
+      kind: KubevirtNodeLabellerBundle
+      name: kubevirtnodelabellerbundles.kubevirt.io
+      specDescriptors:
+      - description: The version of the node labeller to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+    - description: Represents a deployment of admission control webhook to validate
+        the KubeVirt templates
+      displayName: KubeVirt Template Validator admission webhook
+      kind: KubevirtTemplateValidator
+      name: kubevirttemplatevalidators.kubevirt.io
+      specDescriptors:
+      - description: The version of the KubeVirt Template Validator to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+    - description: Represents a CDI deployment
+      displayName: CDI deployment
+      kind: CDI
+      name: cdis.cdi.kubevirt.io
+      resources:
+      - kind: ConfigMap
+        name: cdi-operator-leader-election-helper
+        version: v1
+      specDescriptors:
+      - description: The ImageRegistry to use for the CDI components.
+        displayName: ImageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The ImageTag to use for the CDI components.
+        displayName: ImageTag
+        path: imageTag
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The ImagePullPolicy to use for the CDI components.
+        displayName: ImagePullPolicy
+        path: imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:imagePullPolicy
+      statusDescriptors:
+      - description: The deployment phase.
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Explanation for the current status of the CDI deployment.
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      - description: The observed version of the CDI deployment.
+        displayName: Observed CDI Version
+        path: observedVersion
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The targeted version of the CDI deployment.
+        displayName: Target CDI Version
+        path: targetVersion
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The version of the CDI Operator
+        displayName: CDI Operator Version
+        path: operatorVersion
+        x-descriptors:
+        - urn:alm:descriptor:text
+      version: v1alpha1
+    - description: Represents a deployment of node maintenance crd
+      displayName: KubeVirt node maintenance
+      kind: NodeMaintenance
+      name: nodemaintenances.kubevirt.io
+      specDescriptors:
+      - description: The version of the node maintenance to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.node-maintenance:version
+      version: v1alpha1
+  description: |-
+    **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+    Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+    Containerized Data Importer (CDI), and Cluster Network Addons (CNA) operators.
+
+    **KubeVirt** is a virtual machine management add-on for Kubernetes.
+    The aim is to provide a common ground for virtualization solutions on top of
+    Kubernetes.
+
+    # Virtualization extension for Kubernetes
+
+    At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+    additional virtualization resource types (especially the `VirtualMachine` type) through
+    [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+    By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+    resources alongside all other resources Kubernetes provides.
+
+    The resources themselves are not enough to launch virtual machines.
+    For this to happen the _functionality and business logic_ needs to be added to
+    the cluster. The functionality is not added to Kubernetes itself, but rather
+    added to a Kubernetes cluster by _running_ additional controllers and agents
+    on an existing cluster.
+
+    The necessary controllers and agents are provided by KubeVirt.
+
+    As of today KubeVirt can be used to declaratively
+
+      * Create a predefined VM
+      * Schedule a VM on a Kubernetes cluster
+      * Launch a VM
+      * Migrate a VM
+      * Stop a VM
+      * Delete a VM
+
+    # Start using KubeVirt
+
+      * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+      * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+    # Start developing KubeVirt
+
+    To set up a development environment please read our
+    [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+    To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+    You can learn more about how KubeVirt is designed (and why it is that way),
+    and learn more about the major components by taking a look at our developer documentation:
+
+      * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+      * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+      * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+    # Community
+
+    If you got enough of code and want to speak to people, then you got a couple of options:
+
+      * Follow us on [Twitter](https://twitter.com/kubevirt)
+      * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+      * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+      * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+    # License
+
+    KubeVirt is distributed under the
+    [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+  displayName: KubeVirt HyperConverged Cluster Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAARgAAAEYCAYAAACHjumMAABam0lEQVR4nOydB3gb9fn4v3faw5Js2fKSvO0kkrMTsCFgBQKEslqIzB+6AAcocVpIKD9aWrBSaKEtJKUQEjLKKO0PLFo2hG1DEpvEcZYl7ynZkqf2lu7+jx2HXxLfOZJO077P8+Qp1ffu9Fo6vfd+30kFJCTTKBQKLgBgoUKhKAEA5AIAssRicVp5efnk62wAADL9zzv5r6GhwarT6QYAAL0qleqEVqs92djY6I3130FCQhJHVFRUcFpaWl5CUdSPEmMMRdFdCoUiP9Z/EwkJSYxRKBRFhw8f3o6iqImgYrkQF4qiHz/33HO3SqVSONZ/JwkJSRSpqKjgTlss0aCttrZ2baz/ZhISkgijUChKDh8+/DcURc1RUi5nmdx6ff3cc88ppFIpJdafAwkJSRipqKjgtbS0vBxlpYJHV21t7bWx/kxIogMUawFIIkdZWZl4+/bt/1NeXn4XACAp0PMQAGxDTqel3Wpnj7s9DA+CuLwIgkyaIQgAKAwgiEWBqRwqlV3M5TiKkzhUOgxzgxANBQAc2r59++4dO3a8qdPp/KH9hSTxDqlg5iBSqZS1c+fOR+Ry+f8AADiBnudDENsjp1qtz3f2pKEABJzCQIEgz63ZmdpfLyhkXJIiEAcp7mGlUnn/tm3bWoI8jyQBIBXMHGLSYtm6dWuVQqHYCAAI+Ifeb3eYdnX3gZd7+hkmr48V6vtDAHivzxCNVhfloT/ITBcBAGgBnopqtdoP9u/fv2v//v2fkxbN3IFUMHMAqVTK2blz5//I5fJfTyfEBcSkxbL1pNr2QldfRrhlKuUl9e9ZtRSUC5Nzgzz1u2mL5mS4ZSKJPqSCSWDKyspypi2We4KxWHpsdtPunn6wu7ufafX5mBEU0XdNetrIpsJc9IfZmWkAAHqgJ2q12o+mLZpPdTqdL4IykkQQUsEkIFKplLtz587fyOXyrQCAgLc0XgSxPXi8xbarpz/sFsvFKOZytPtWLfVfmSbMC/LUY0ql8hfbtm1ripBoJBGEVDAJhEKhyFUoFBunLZasQM/rstlNL3f3o7u6+1h2vz+SFsvF8MvThCObCvMQhSRLCAAIWBatVvvptEXzsU6nI+udEgRSwSQACoUiqba29jEAwEPB/Ch9COLc1Hzasrd3ID2yEgZPDps1tH/VMte69NSCIE89qVQqN23btu1whEQjCSOkgoljtmzZkl9VVXWvTCa7CwCQGeh5Q06X/ZU+rXdfTz+tz+EMOEwdA5AfZmXoHyjMg67NSJu0aBiBnqjVar+ctmg+0Ol0nsiKSRIqpIKJQxQKBa+2tvZxAMAvg/nReRHE8df2bstTrZ3JTr8/4PPigbKU5MG9q5Y4Svm84iBPbVEqlZu3bdtWHyHRSAhAKpg4QqFQ8Lds2bKxvLz8EQBAwNuaQafL/o/eAe++3gHaQHxbLBcDvT5DpK8uygPXZ6anwMH5aOp37NixTaVSHdbpdO7IikkSKKSCiQMqKiqgnTt3/lImkz0TTFTIgyCOP7d1Wf7U2pniQpCAQ8CJwMpkwdDuFUtsq1L4JUGe2lZZWXm7SqU6FSHRSIKAVDAxRKFQJE9bLA8AAAJu0qR1OKcslv29AzSt05XIFstFuVqUOrS5KB+6KStdQIGgQJWvBwDw0fbt26cygzUaTYSlJMGDVDAxYNpieUgmk/0pmKiQy++3P9PWZX26rSvFM8cslouxhM/Tv7RisfXy1JTiIO/b71Qq1QOVlZXHIygeCQ6kgokiCoUiZcuWLfeVl5f/YrrnbUAMOJz2/T393v19Wvqg0xVwKcBc5MrUFP3monz0h9kZAhoMB/pZeAEAB7Zv3/7S/v37D5AWTfQgFUyEEYvFUFVVVVlVVdUmiURyezAFgF+PjBlf7OqD3xsycP0oSjZoP4dsFtN4T36OsypPwsjlsIVBnNrb0NCwa8eOHftUKpUxgiKSkAomstTU1OQolcpdAIAfBHPeSZNlYlPzKd/hcaMoctLNDagQ5Pz1gkLtE9KSNBaFkhzEqS61Wv276urqHfX19WgERZzXkAomzExbLJdNWyyVIPC+KugJk9m8u7sf2dc7wPejKNlaMggymAzT1pIC123ZmbQCLicYi2agoaFh944dO/aoVKrxCIo4LyEVTBipqanJUyqVuwEA1wVznsnjndjYdBL5z6A+NXLSzQ9gANx/X764p7oorzCY6m0AgEetVtdUV1f/pb6+HomgiPMKUsEQZNpiuaKqquoBiUSyIQiLBWk2mi27u/uQV/q0PB/pYwkruWzWyP2Fucimwjwqn0YLRnEPNjQ0vLxjx46XVSrVSARFnBeQCoYACoUivba29g0AwLpgzpvweMarjp5E3x0ykBZLhIEBcP1lyaLehxcU5QeTEgAA8KrV6icrKyv/qNFoSIsmREgFEwJbtmwpnbRYZDLZnQAAQYCnIUcnTJaXe/qRV/u0pI8lymSxmGO/KMj1bSrKg4V0ejDO89Mqlerl7du3/6uxsdEUQRHnJKSCCQKFQpFZW1v7DADgxwCAgBXEmNszds/RE9AH+uFgnI8kkcHzpGxh9++lxTnBNEQHAAzX1dX9rrq6+lWNRkP2DA4QUsEEwJYtW5ZMWyx3AAD4AZ6GfDdhtOzu6kde79fxEUBaLPGEiEEff6Awz/tAYR6UzmQE0y+nddqi+WdjY+NEBEWcE5AKZhYUCkVWbW3tXwAAd5zZzgfGsMs9es/RE/DHhhHSYol/fI8tKup8snSRGA5idtSkYVpXV/dEdXX1Xo1GQ/YMxoFUMBhs2bJl2bTF8v8AALwAT/M3jButu7v7kDf6dQIkCIVEEnuS6TTjpsI89y8KcoGYzQqmZ3HHtEXzemNj41gERUxISAVzDgqFQlxbW/vs5H8GY7Hona6Re5pOUg8YRlIiKyFJFEAeKi7oeHapNIMCQYE68CeZqKur+0N1dfUujUZDdtibhlQwZyyWFdMWy+3BjFhts9gsT7V2+P49MChASYtlTpFEpZo3FeY5tpQUMNOZjGBKELpVKtWe7du3v9rY2Djv82jmtYJRKBQ5tbW1zwEAbgvmsxh3e8yPnW517u0dEJGKZW7DoVAsNbIFhq0lBZkUCArGR2Ouq6t7qrq6+gWNRjNvO+zNSwWzZcuWVVVVVZtkMtnkVijgoe2tFqtlV3c/8s9+HdPk9cZy/AdJlMnjsIwb83Ncd+flMLJYzGC2wr0qlWrf9u3bX2lsbNRHUMS4ZF4pmIqKCtbOnTv/JJPJHgzmbx91u82/OdXqfKVPm47Os8+M5HyYMGz73aLioUcXFqXTYDjQlIVJrHV1dc9UV1fv0Gg0zgiKGFfMix+LQqHI37Jly6by8vIqAEDA+2n1pMXS1Ye8MaBjmr0RHbFKkmBIWCzjPfkSZ1V+DlPCZgVj0Qxs37796f3797+u0WgcERQxLpjTCqaiooK9c+fOZ2Qy2S+DOW/Y5TY9ekrjeq1flz7XPyMSYtAgyPHowiLd7xYVi5gUSjBRJ5NKpXqosrLytQiKF3Pm5I9HoVAUnmOxBGzGnjZbzbu6e9F/9Q+yLD5fQs0VIoktWUyG6a78HOfG/Bx6fnAd9jTTzclf0Wg09giKGBPmjIIRi8W0qqqqH0y3TQi4HwsCgOetgUHbru4++NuxiWCeQCQkM4AB8NyQlT6+uTAfuTYjLT2I9h3OhoaG13fs2LGroaHhpE6ni7Ck0WFOKJiamppypVL5EgBgWTDnfTY8Olx19ART53QF46wjIQmI5QJ+7+6VS6iXpAgkQZ76plKp/NW2bdtGIyRa1EhYBSMWi+lVVVU3TLemDLgfCwKA93/7dZMWC3Ro3EhaLCQRBQLAtz4jbXRTYT5yY1a6KIim7y6tVvuv6fnbxxLVoklIBVNTU7NGqVTuBAAsCeY8jcVquLfpJOPwuDGYzEwSkrAg5SX17125BFyWmhLwyJpp/jM9f9sQIdEiRsIomGmL5aZpi+WqQM+btFg+04/YX+ruQz/QD5OKhSTW+O+UZBt+UZgLX5EmTA3CovFotdp/T1s0RxLFokkIBVNTU1OhVCpfBACUBnPeabNFf2/TKeZ3E6TFQhJ/rE1L1f5j9VJfHocd8NjgaT5QKpWbtm3bFvdaJq4VzJYtW+RbtmypkUgk8kDPQQDwHNAPO3Z29aEfG0ZIxUIS7/g3iDMNDxTmQVeJUlODmITg1Wq1b+3YseOpHTt2tEdYxpCJSwWjUChKa2trdwIArgzmvOMms+H+plOMo0YTqVhIEo41qSm6fauWuhckcQuDOM0HAPhHZWXl71UqVdxFneJKwWzZskVWVVX1qEwmqwQABJTo5keB5xP9sP3Frl7o0+FRMipEkuggN2Wl6zcV5sHXZYhSoAB/BwCACbVa/a/9+/dPWjWHIixjwMSFgpFKpWDnzp33yeXyvwEAWIGe1zRhMtzffIrZbDSTioVkznFpSvLgnpVLHEsEvOIgTz1QWVl5l0qlGo6QaAETcwUjlUqFBw4c2C6RSH4WyPF+FPV8ODTs2NnVCz4fGSMVC8lcB12fkaavLsoHP8hMT4EDn+00qFKpfrd169Z/6nS6mM11iqmCqampKVEqlQcBAGkAAD0AIHO24xsnjIYHmk4xT5gtpGIhmXesEPCHdq1cbL8kJTlgi0atVu8sLS3dHFnJ8ImZgqmpqVmiVCr/AwAomn7JON2u8rzaDR+CuD/QDztf7OoDX5EWCwkJuEqUqt9cmIfenJ0hoEAQO4BTnpBIJE/pdDo0CuKdR0wUTE1NTb5SqTyF0U3OdO6kxA6rzaJoOIacIi0WEpIZLOYn6d8qW4ks4iVlz3LY5IM7Wa1W/7a0tPSZKIo3RdQVjFQqZR04cOBriURyKcbyBAAgxeByef7c1u3b29NPt/v95FB4EhIcqBDkvk2cOfr4ohKajJ+ENUDOON1kzadWq59Yv379M9G0ZKI+bXBkZOQ1Pp9/Pc4y47jR3Hd1fQP3s+FRlhdFyYbaJCSzgABAVVusvN3dfdQsFuvEymR++jkjd2zTiXu0yddEItHVEolEq1KpjkdLvqgqmOeee+628vLyJ/HW//T1N947PzwwYOJOmXwxj3CRkCQKKADUD/TDWV02u3Z9hgihwTALADA2uSM49ziZTLYGAPBpfX19VELYUf0Royh6anLriLX2dN233sc++5I2pZQXLuoBLHZRNGUjIZkr5HJY2kNr1ziyWcwFOIfoZTLZQo1GY4m0LFHbgrz11lv34SmXN0+1+B777Evq9zKNj0fd201CMlfotzslD7dqPFYf7sjszH379v0mGrJEZYsklUpZL7300gGAkSTk9vnA9a++gdg8nv+TxelAQHqGDUBQwDOLSEhIzgBBoI3HpwsbLSbWDUIRTIFmblQkEskqAMCe+vr6iE42iIoFU1VVddO54edz+WntOy6D1XZ+pAhF04B2oDcaspGQzDGQElFSH4BARpfTTtk12I+XxctSKpUvicXiiAoTFQWjUCh+gvX6p51dPlWLGjv1eXxsJXA4SCVDQhIESQzqKSGH/n0L2doRPfzB2DCektmgUCiC6lgQLBFXMBUVFZBEIsH8I145Nmu0jAbGRvwRE4yEZA6SKWCiF2bD/6W/G4x43Jh+zaqqqjsiKU/EFYxcLr8SazaRD0HQzzq7cb1QUxiNycDvH4+kfCQkcwUWjXJKyGHkXPg6AgD87ugwpoKRyWTXS6XSiEWTI65glErlLVivv6tpMxmdrtkrQxFECIwTxkjJRkIyh0DyUzl6CADMoW+fG8fwtkm5CoVihlIKF9HwwWAOQfv3ydOBRYjGRqnTXbtISEhw4DKoGgGLthZvfcjtonY47Ji/I6lUuiZSckVUwSgUikltKr3w9UlV+kl7Z2A9KpzOPGAyRS21mYQkEcnkM30X6+f7tXEccytUWVm5PlJyRVTBiMXipVivtw6PeF3BzH4e1AkBikY865CEJBFhUuFWIYc+W0X1FA1mI17Q5BqxWBwRXRBRBVNeXo45yvXU8HBw7+txFwCTcSRccpGQzCXyhBwtDEFpFzuu02mnO/yYOia9vLw8LxKyRdqCwZy8eHzIEHz4eXSULH4kIbkADp3SmsKhXxHo8W0OG6YfpqysLKi57oESEwtGPTwS6DS7/8NuywN2O+mLISE5hww+yxNMo/xupwOzv5JEIlkeVsGmiZiC2bBhAxsAsBBr7dig3hvCJSlA288CKOoiLh0JSeJDhSFDKoeO1WQKl3Z8CwbTX0qUiCkYmUx2BdZso0GLBQzbbIFOrzsfp3MhsFgGwyEfCUmik8pljFBgKCOYc7qdDszffMJZMAqF4lqs199vbSdWvTk2SrZyICEBwJnBYwY6wuR7epwO1I1gZoiIa2pqcsMi2TlE0oLBjK1/3dMXeHgaC4tZDNzuNkLXICFJcNK4jMNsOqUk2PN8KEo5YbXgJa5iJsUSISIKZjrBbob/BUFR8GlHVyj+l3NhgoF+L5ndSzJfgSFoNDeFHXJ6/3cWI2ZEVqlUhj3hLlIWzBKsa3eOT/gsbnfQZt0MbNbFwGYdIHwdEpIEJJVLN9CpcLDjZL/nsNmE93C+RiqVhlUnRMqCwQxPn9Qbwvcm4+MxG4dJQhJDPJk8ZmhBkmm0bifD5MPcSHBlMhlm5DdUIqJgpFIpZoLdiVAS7PCYGBcBv5+0YkjmFUIO/RCHQcVr5h0w7Q47pobBMw5CJSJDzWQyGaaQLcPD4Xw/Hhjo776u7FJRNos5rxpTddkcrm/GxjHL8ucDV4lSO+8vyL0w4oFavT672mKF39QO0vUudyAjVRMKCAITeULOrPPbA6XbaadeysPsYjv52/13ON4DRELBlJWVcQAApVhrh/q13rA2GjcZlxYAtPOl1csIa/REwuL1ORd9+vXAkNMVsT4e8UoKnTb2dvkqZjKdhrVNmIpQPr14kWtXd5/p6bZO5ojbQ8jnx6NSXVeJUr2rUwSubBaTQoWgqA8rPMvXlon+Vo8tLPkqp21WBKTP/C0qFIrycFz/LGFXMBKJpBTruh1j4/4Jp5O4g/d84NeajtGevewSD5tKIbQvTSR4NGrqC8tKG25raJp3CuauXIkxmU6b1cHJoMDMh0oKmOXC5LGyrw4yQp3/tVzAt3y05hI0k8XkAwCSQhY6PPg+VI+GzSrrdNjx8smWSaVSoNFowvI+YffBKBQKzJTjD9s6POF+r0kc4+PC3zSdmHe+mFvFmStXJQu6Yy1HlLH/ojAv4IfUpcLk1P+UrzJAZ1oQBcX/k2SNflFRRp9WLjHn84mxpgGXM+i8FzwMHjdlwovr6A05QnUhkXDyYvpfvuruiYxpiaL8F+u/NescTqL5NYkG/eGSgnmVC/RQcf7p4iSOJJhzbhVnZv4gQxRUL6EyocD0v2UrhSl0ergt7pDwA2D6c39XWMcpowBADWajG2tNKpWGzdEbCQtmRgTJ6/eDr3p6IxZWRs2mxfs0bbpIXT9eUUiyMhfzkzpiLUc0EDHoI0+VLgxpS3ibODi/6NOLFyHRnHp6MT4eG55wIkhQijUQmqxmTLcCXpAmFML6IVZUVEz+z4wtUuvomNvp9UXyaUDfe+SYHw3BFE5kKBDE27tqqfHMQ25uc09+jolDpWaFcm65MDlg63ZBEndEnpaaEsr7RIoPx8Iaff2ew+YJTLdFOEPVYVUwcrn8ksk93IWvnzZE5gM6l6GhoeTnWzu0kX6feOPSlORL1qendcZajkgCA2C5ryA3ZAdnHocd8P33k5zsmEWJsDhqMXW12G0RGb9o8/sZOpcT66EctwoGs4L62JAec68XVhBE+LvPvzLafPgTv+co0MMLCud0hfmjC4s0+Rx2yD8yGIICvs+XCHjOUN8nAnj+3N/NjOR2rcOJGU3KqqmpyQ/H9cOtYDCLpTTDo8QqqAPEYTAUvdbeNRyN94on1qWn5a8VCU/GWo5IkMVkDtdISwjd7L12R8BbSCGdHjfbzW9NE+N6jzuiw6M7HdjdU6RSaVgKH8OmYBQKBQsAUIa11jQ4GHkL5gzcvU3N9ii9VzzB/PelKydNe1usBQk3GwtyLAwKJaiubRdybMIUsP+vw2qLmwzg90YNwbeWDZIupx1TB4RrlEk4LZglWFm6PRNG37jDGbUv7WR3L/89XTirKhODDCajdGN+zpzKB6JB0MS9+TmE7x2VTh/wsYfGjXERKOhw2MYaLSbMXP7wvo8d7++Vl5WVEVZw4bRgMAscP2hrj+6e1udNrz7w2aAfRePG1I0Wm4vyoDMpDnODx6Ul7WI266Lzfmaj1+6wvDdkCFhJvd6nS3H6/TG3BHdoe31ohGoFz2XM66GMeDA3GDyJREK4BCdsCgZvyNrXPX1RT+Ef7O3L+0/vwLybo7RUwC+5Iyf7cKzlCAc5bJb+t4uKCWWuIgD47z5ynBaMxvWiCO3Frt6YJm2etFpMp2zWoHrtEuGw2Yj594ZjlEnYFAzWiJLJL/bTjq7oWxIoKtx/7HjMn0IxgPL66uUSBgwnvKP7voJcKxWCCFWMf2kYddePTQQ80uMsT7S0czqstgki702Ed8cMUQ2VH7WYMbdCEokkPhSMVCqlYFVQt46MuF0+X0ycZl9q2rhNRtO8GzdLhaGch4oLxmMtBxFYFHj0nvwcHtHr/L2rJ6TtogtB6Jd9dZD5wZAh6krG4HHb6ozBK0UiHLGYvH505kcVjoS7sOzxFArFCgDAjKKw04aRmCUt+d2uzF99/tXRw5W3riZ6rU8No8O/b2mLitl8qVDge3H5YkJjPKuL8uh/bu9yAADiJiISDE/KFnZnMhmYEclAaTaazR/qR0IuVBz3eNk3HzrKfrA437BNugDm02kiIvIEyku6Pp8HRSLuezkXB+KnaV1OJI/FvtDgiBsFg5lg1zyo90WqqVUgNJxWZ9dfuWa0IkN00bm9s3FZajK3126fvOk44ZMOm2ajCflVUYG1JIkTcnsACZtV9Li05OsnNR1rwytd5CnksAe3LCgk1LbRh6Dee5tOhiXE+3xnb8bznb2ghMsZz+GwUDoEz1pwyKTAyNuXreZDAATte+x2OlxfGscFlBjUfnQ47CCPNeN5JKypqVm8bdu206FeNyxbJJlMhjnuQDM6GtseLX5/1t5jxwlvk5KoVM4T0pKobLcQAOCdXb2E768/yBasyGYxe8MjVfS4vzDXDgNAKDz7vt7gbjaZw2q9ddjswi+Gx1I/NowIZ/v330FD2ueG0ZACDO+MGuBkKi0mhWWd2Bm9QC6XExplQljBlJWVTX6Rl2KtHdVFLcEOl/+ePEUfsDsIy7GpME8gZjGj4jh+tU/L1DtdZoKX4VcX5REbchdleFSq4a68HML9V57v6IlpJfSWEy1cp98fVHrGoNvl+s5spLqR2GRXdDmwJz7K5fLriVyX8BchkUhkAMMc1FutyLDNHlVnFRZOm13y24ONp4hehwrDrJ/kiqNS52Tx+ZgPnWghnD/0UHGBAALAGB6pIs8zSxb1pTGCm7V8IafNFvs3YxMx9T1prDbBX9u6rYEe7/Ij3q0dmkkTAnZgT12MOO1OG55mu0KhUIS8EyGsYPA62L2naYublP03G78TacwWE9Hr3JUnidqTsVanz2iaMBFSDiwKJXtzUV5C9MlZkMTVPVCYJyNyDZff734xDNvLcPBUa0fyM21deh+CuGY7bsztcd178uSYzuMS6rET3qKC2eejal2YzzTadJZ+SBD+wYjFYswmwf9Vt8VN2Tviduc+8+3hMaLXWZDE5T26oDBqw/cfPaUh3MHs0YVFAgYMx33pRI20xE607+0Lnb3+/b0DM9qFxAIvitJ+e7o1c8ln9Y5d3X2GHptjUtFPaRAvgpjrR8cntp5QG7M++Ix22mWNi2jf58YxTAudSCNwwjcwiqJNAICV577mRxDAfOIpjw9B4qYRN4PDGdD++sH0NAadUGW3F0GsvHc+obsQJCoV4l9VlBvWilIJZXVu7+j+8uGTmqvDJ1V4yWGz2vpvWCcBABCJ0vlzP/rCNeBwRjzSR4BxDpXitPv8GWejq6lcur5ElBSWUSREKeUm+V9esHiGYaBWq/9RWlpaFco1CVkwGzZsYAIApBe+fsow7Iwn5TKJ224XP1x/kHBjJhoMJ92dL4na9u8Xx06xXEE6DC9ka0nhimIuJ14jSt7XLlnuJqhcwHuDBlucK5dJhHafX3xWucAQ8OSmsOOi7+8krTYb5PTP3GESaaFJSMHIZLLLJrf6F76uHolxeBob+J/fHEpqt1oDdr7h8bNcSdiaL1+MDpud/6Z2aNZ9fAAkby7Kj8vSibVpwj55mhDTjxcMf+/qjZseuoGSymE4GFRKcqzlOIsfoHCn0461TSqtqKgI6TdN6EvBS7Br0g3FPDyNCeLP3dd0nHCdTpkwmVeRJoxaOv7zHT2TTzxCEay78iRp2Sxm3I052VyUT1gxfD0yNvHVyFis5xYFTTqPGXeV791OB1ZiLF0ul8tDuR5RCwYzCadtdCxuzL4L2d/UTA9DKwfKi8tLiVoVAXPCbEn6Z5+WkJOaR6NmvLC8NK62SekMuuNWcSahbvkIAJ6fHzkR8cZM4SaZTTckMalxY72cpd1hw3yQKZXKkBLuQlYwCoVCAABYjLV2RKeL2o8vWIxGU+bbXT2ErZhSPi/7ylRh1HJMtp7SJE14vIR8Pz/KzrxiVbIgPCP7wsCNmel0rByqYPhXn9apdToTynqBAPDmCePH93IuOBbMJCEl3BGxYDA72BmsVp/R6YqLsBsOtH1HjoVlC3dvQfQmt465PZxXegeIFlwyHi4piJsBdWVC4g/wF7v6wiJLNBFy6XYWjRLxbnWh0Omw+3FS/RYpFIrUYK9HxILBTL45NqiPmxsYj6/bO/hHx8YJWzG3ijPpAho1ah37Xuruo3kRhND7KSTZuYv5PMKZzeEglUEnVAj7zqB++IjRFPXRrhAA4Lr0NOcfZAssr65eZnt19TLHYwuLvfI0oY8KXdz/nxGHvpezeFGUMuB0YOoYsVgc9OD9kBUM3njJ08MjUYuwhIrf50v51cefE+54x6ZQOApxVtQUTI/dwflrexehjGQKBAR7Vy2dmLyXwidZaGD1IAmUSUV7z9ETUd8aLeXzbNobr5k4cGUZ63FpCe/neRLuz/Mk7D8uXkj7Wn4ZtWndlf58Dhv3D2PRKCYekxZ3vpdz6XBg78TLy8uDjvaFrGBkMhnmm53QG+JewUzS2NaWV6cbIpzhWpUfvW3SJH/QdAoH7E5CIedLUwRXrk8XqcMnVWgMOkN31e3pGfCYvNFtZnZLVvpwnfwyajaLiTv5camAR2lbvxa9Q5KFaQWk8xhx//vAq6wOpYVmSAqmoqKCgufgPTGkT5TBZ0n7mo4T9sVcKkxOWSNMiVr5gBtB6Lt7+oh+xvCvFxSESaLQaRwP2UeO7uzqjeo2Y2Uyf+zdyy9JFdBpF3XO0mEYfvWS5aCIyzlPycAQ8GQkMeOmhAaPLqcDU0aJRBKdLZJcLr8CADAjVd7m8SCd4xPxmGSHyTunWzgDdgfhPi/bl8noIIpzsff1DtBNHi8hua9OT1uwNk0Y0wbhHxtGgNET/E6tdmDQ2Wq1RdVJ+sSiEgdWUAOPSSXzweWrUfo5/anyhZwxGIbiolZqNjocuJXVxRs2bAjK5xWSglEqlZgJdp+0dxkRFE2YnASH05n6my/r+oleZ3WKIG2tSEi4WjtQRt0e9m9OtxLt9cJ6s2zl5EOCaN+ZkDF7fWBnV3CpOcMuN7j32Kmobo0KOGz1zdkZQXdFXMhLolwtSpv6sTKoFEs6j0moFUW0MPl8FLzKaplMdlUw1wrVB4OZdPNNX3+814LM4M0jTZnq8QnCldZ35Uqi2shjT0+/SG22ErJiREzGynsLcnrCJ1XwPNPWBVTaoYCOtXp94GdHjgNLdMeP+/auWurBKokJhPLpUHwGb8rgj/vt0VkazEa8hLugJj4GrWAUCkUSAGAF1tq7mta46QETKCiCpO5vPkk4EnRHjpjNplCi9vejAMB/7+oh3Ptkc+FUqn7MeqjY/X5Q2XgMPN3aMetx3TY7WPZ5PfhseDRqsk1ymTC55ypRatC+h7MUctgIBAFfOi8qxfdh44jVjJdCEFkFgzdgbcRu9+rMlrgOv+HxRvNxhsXrJZR9TIMh9o5lsqiOuXijf5DTZ3cQ2potEfBK75Bkfxk+qULjsZZ2sOyzevCUpgN8PjwKjhvNoGF8AvyzTwvuPnp8Srn02KPfAfQeglFCCIJATjJnmArDhMewRJNmi9nvxe6ul6NQKAKethl0ohPWgDUw1X93yEO05D5WjJotoj83HFH/8crLCXVUu68gN2ObpsM85HRFJfnL4ffTq4+fnvhoDWZL5EChvFG2ovC/g/pBN4IQGtNKlJNmy9S/eIEJw6N35+cQmkhh9HmN2QImoWvEAjeKUPpcTqSYzZlhhEil0kmLLqDIadgsmNaR0YTZX2Lxt/pvU4fsDqKtHGj35Emiut34WD+ScXBsnJDlBANQ+FBxQcJPgww3DxTmGWEACFnlWp+LQrTeKlZ04iTcBdMfJmgFU15ejtk+r2FAG/cJRLPhcLrStx9qJBxR+WVxPo0Jw1Ed+P/oqVYq0TD5IwsKRSl0Wty1c4gVFAiYtpQUELLIxz0eS4PVGPPG96Fy2m7FS7gLuIVmUAqmoqKCDQDAHIp1bFAfnz1gguCVpmaqB0E8RK4hYjCSHl5QGNVO/ofHjbwPh4YJlT4IGXTx35aWtoZPqsTm1wuK2iVsFqEt457BAZsXoPFc+DsrXU474YS7oBSMXC6/GivUZnQ6fQMmU0L6X85lwmbL+OOhRsLlub9dWMQR0mlR9UhuPn6aY/f5CL3nT/PE8qV8XsxLCGJNGp0+UrOohFCfmgGX0/rRxEjQ1cfxRLfT4feimIZxZk1NTUCp4EEpGLwEu/da241oAsX4Z+OPn34hGHO7CdX6cKhU/u2S7Kj2xOl3OJP+2a8jZH0BALgPlRREdXsXj/wkV2xiUSlZRK7xwdiwH01Q38tZ3AhCUdtteBMfAwpXB+uDwVQwh/oHEt56OYsfQUT7jzYTzsqtys+Jekn+C129NAQAQkrmxznZuQuSuCfCJRMEAFidLDBvEGf6FOJM5Lr0NFMyjRa3DckAAK77CnIIJa24/H7ngfG47EsdNI1mI6YJE+jEx4AVjEKhEAEASrDW3lG3zamn3r6m49QzuWyhsyKZL1wnShsIn1QXR2OxcfZ09xHqFUyD4bTdKxfrifYAnmSDOMs6fPO1xiPrruCryldRa8tXwQeuLBPob7oW2bFMNsKiUOLOb3dXnuTEQl5SLpFrvDE8aJ3weRPW93IujWbcZ+3VUqn0oruWgBUMXnhaZ7a4xh0OYaDXSQS6RkZEr51SE65R+uvSRUwoylmyj55uFQy73IQyiq9IFV7GplBCLp8Q0ukeVdlKs6p8JTuNwZgR5mVQYPZDxQWi5nVXuHLYrLiZdsCmUIx/Kl1EqF5ozONx/NswFPUmWJGiy2mHrNilGSyZTDZjZNGFBKxg8JrNHBsais0w3cgCb/3gY5rb7yf0hF0m4IuuSU+LWhHkJBavj7Wvt59QM6nn2rtHHH5/yMPe9q1aatsgyeJfrPZmIS+J/+7lqy1ErcVwUSnJGs1kMfKJXOPA+IjPjUZnKF80QAGAO512zIekQqG4aD4MYQvmtIFwY7i4ZMJuz/7fFg3hcPNdedEtgpzk5e4BmsvvD8mK0Tmcphp1e8gOzrvzJCM/zM4IuJXCcgE/6y9LFhEeiBcGkE2FeYSmbCAAeD8YH0mYbgKB0o3TH2byGXqxcwlbMKcMw4T6qsYze48cI5w8WCnJ4vJp1Ki2RNA6nZw/aDpCyrnf0zvgdiFISE77FDrNsXfVMm6wwYNHFhTlZzIZhCvaiXBtelrT6hQBoS5cH4wabDq3K2ET6/Bod0TYgtmwYcPkTbMAa+34UOIn2OFxuLcv+ave/sB6CeBAgSDW35ctjnrPlb+2d6d12+xBlT7YfT7Tvp7+kH8gm4vyvRQIhOLcpP0gUxSzbRIMgP1vy2R8Ii1k7X6/a8+Qds4pFzDlh7HhfS5LpVLprA/hgD5QmUxWgVVP4fB6ka7xiTnhLceBvvmDj70owTT8n+WJs3LZrKhm9/pQlPpSV3CtNX/f0m7Uu9whVf1CACCbi0J3X5SlJMesZcQt2RlDi3hJmA/QQPlyYsxv8nnjctYRUXocThQn4U6oUChKZzs3IAWDNyL2vdb2iURqohMKrYbh3AOd3UTHxFLvjkFezCt9WpbZ6w0ou7fDajP+vbNHHOp7Pb14kT6NQQ85esKlUWP249xUmEf0u0HeHTXM2d+BH6Bws8WC+QCQSqWzJtwFasFgXuRw/0BCTdQLlT1HjhG+xsYYOHuNXi/z9b7Asnt3dvX5EABCclDmsFiWRxcWiUI59yx+hMAMEwIs4SedWJeelkfkGodMRnu70z4nrZezfGcxYeqKyspKYgpGoVCk4SXY/belNW5yGCLJR23tSa1j44RaqWWzWan35EmimngHpiYf9tL8KDpr5qzB5Z54rV8bcjZ2ddGUBUAoetJiscYi3cGza8USmEg7BS+CeF/Q9c7ZQMdZGizYGb0AgMvKyspwfU+BWDCY0aNhm901ZLXOqQQ7PLx+P/PhTz4jnK38/PJSFgWCojrwrMNm5zzf2Tur/2fLCbXdHOKMIQYMe6qL8ghvD+pHie5Cg+cqUWr/ZakpmBNKA+Vb84RPOwcjRxcy4HJSTD7MW5cpkUhwG7UFYsFgKpgm3WDMnHKx4JPWdnHTkJ6Qo5ZLpabdmZMdVWfvJI+3tCUPOp2YeTHNRtP4m9rBkCuHd61YMsqhUgmN4mgcN441jBuj/rC6MyebsNX07uhwQvdBCoYOhx3z85otXH1RBSOVSjEVTMvISFxkX0YReM+RY4RvyJ/nigklc4WCw+9n7u3BHpz/fGdwY0PORcrjmu7OlxCqOgYA+O5pOhmLH6m3UpxF6Ltod9gsx6zmOe17OZcupx3v8wpdweC1xzs+NHe95ni8daqFNepwEmoauzY9jbcqmR/d1vhnxpzQbT7feT6zdqtt4i3tUMiO+s2FU2FpQsrhPzq9pdUS/a02l0o9mUSjhlzUiADge3agZ85l7c5G2C2YDRs2pE4+qLDWDvcPEO09knBYXC72z1XvOIm0p4QBoL92yXIEDkO1cjDoXW72nY3N7rOyexDEddvhJsiNICE5OFcI+Kb7CnMJ5UChAPgeb2mLSd3OAi7XSsS5++XEqFdjt81538u5tNhw8zZXbtiwAfNemFXByGSy1Vh5Lg6P1zdosc6rD/csn3V0JndPGAlVK0t5SWkrkvlEG4wHzUeGYUG71TYl+6GxCbvaYg25oXWNtMRFgSBCPU9OmSz2VqstJr2EDG4XIdnrTVGdUBMXjHg8wO7HfC4yZTIZpitlVgWjVCoVWK+/earFiKDonGioEyx+FKU/++1hopEg+DcLi6MaTZoEQQHl8Zb2yff1/+ZUa8jm/Y2Z6cabszNCrrY+y+9Ot8asEn/Q6Vpu9flCaslxymax1RnH590D1g9Q+BvTBF5dUiXW6xfzwWCOiD08oJ3L5QEX5dVjx9l2r5dQDtCPxJm8NAY96o9BlW4o5cETLYNHjKaQB4E9WEyoo8EUzUaz4SPDSCwH9bE/1o8EvU1FAfA/N9BDnW8RjrMcsZgwfa94ybi4CkahUOQAADAjBO9o2uZsgWMguHw+5q8//oyQgoEBYL6wvDQmU8b+3tkb8rhCKY9rX5eeRiiD24eg7o1NJ2MefXmhs3dShqB8id8Yx3xdTkfMZY8V31lMfhyzc+F0Uu554CoYvPB0v8lkm3A4UghJOQfY/d3RjAGzmVCV9O2S7JwiLiembQqCAQIA+WVRvjeUiaDn8v6QwXHcZA64Z0ykODQ+kf0HTcfsQ7HPwYMg3p26/qg65+MNs89HGXJjJ4ZLpdIZ0SRcBYPntDk+ZIh6Hke8svfIMaKfBXxXriRhErXuzBGbfpIrJux7+1tnT9zcQzXqdtlTrR1DF7NkOqw27+3NzSODHvecaXAfKh127HA1VkrLbBYMZgr1Sb1h3oWn8dh7tBlGCYab7y3MQYhOZYwWvyzKg7hUKiH/2+fDo4ZvxybiqWct9HhLe9aKz78xnTZbDBcu+hDEu7en31H29UH3MPDMe8sdnOkPg/lQxLJgcE1dvAS7U4bhOdNvlCjDNhvng9Z2882LFoT8gxExGGnVhXl9O7v7CFX0RprVyQLrpcJkQorB5fc7NzWfjsvoy3GTWbTks3p0VbJgNJ/D4jFgmGr3+32HxiYoI24PWyxgmSEIECqJmCt0OrA7gARswdTU1CQDAIqw1o4NDs2pESVE2XOU8DYJPLtUmkSDoHieFQQeLM73E+n4Nslb2iFXl80eT9bLhUBNRlOaSqdnvDEwSHln0MAYcXumHsLpvHnr151BhxN7GBsAYGFNTc15ShjvhrkGKwXc5HS5B0zmkMObc5ED7Z2cU4ZhQtEgJoUi/FmeOOptNQNlYRLXrJBkEf2F+Z7vTMzU+kw+c4RBheNZMUaVMa8XNngwA8nwhcMZMRWMUqnEzH95t7VtHCUYQZhr+FEUfujDA4QjCz/LlcSN4/NCdq9c4qTDMCEF8+bA4NhxkyXhthgUGHLnpbDnvWP3QhrMRsx7XqlUnpcPM+OmFounuiZeg3XyIQJNieYyX/f0pjQMaAml/l+ZJhSUC5OHwydVeFidzLdWpAkJZe2avV7HlpPqhFMuk6QnMV0QBJH3/QUcsZjwDI1rp3XIFDMUTHl5+eQqZn+Q/7Zo4tpPEEv2HGkiaoHQdiyVEapxigS3iTMJRw1f79N5DC53QiqYDB4jYdIIoskR/IS73GkdMgWWBYMZPRq0WOwTTiehsZpzGdVpDUNvsRJSEJcKkwvKU5LjKvGumMshFPVBAHDv7OpNSN8Ln0WzMmkU0ueIgQtBKP1OB6azVywWLz/731gWDGb+S5NuaL6WXwSE3eulPvb5l4QLGO8tiP70gdng02iEOhe+1NU70W6zJ+QWI4OMHM1KJ3aTxPOGNM5QMGVlZZgWTMvwSEIkg8WS146dELSPjhHaRt4mzmJwqZSARo1EA5cfCXnrN+xy2x873RazkgA6DPvWiVKN9+bnuB9ZUGjfmJ/jXytKdVGhi+962DSKNYVNI3O+ZqHTga1gysrKvrdgZjhqJBIJ3ojYedmeIRjQqezeY+izP8AMwgUEj0bl3ZqdOfp6vy4uKtZH3FOFJyFZIPt7B7xWny8mCuaGTJHxpRVL4Bw262zF9lllQemx2T0/OXIcNIwbce/p/DSOB4KgeTGWJ1Q6nQ5MTS2RSL43Us57Om3YsCEFAIA5n7d5UE8m2AXAGydOUeweD6HP6t78nLixFj8fDq27p9uPOF7u6Y+J7+Wl5YtNH665VJDDZmHmrhRwOfTDV62h/n5RMWYyRxKTauczafNiYgYROh02vPs0r6amZspfe56CkclkV2NZNS6fz9s1MUFq8wAYttnpz9QfJBR5WZMmTFsp4Ed9hhIW/xk0cE0eb9AzRWo07aYBhzPqvpd78iSWB4ryBAH0CoafLF3IuDtPMiNJMpPHjCs/WLxi8vngARfms/T7hLvzFIxSqcQcEfuOunWUaIn+fOLZbw9zBy0WIr4Y+PnlpXA8FEF6EIRxw8HvILvPF/Dfc3BswvyXti7CHe+CpSJN6HpCWhKU32T3yiWMBUnc731eTBrFnsKhJ2TUKxY0mLEHsp1NuPtewYjFYgoA4IdYB3/U3km604PA5fNRdhxsIJTde3lqivimzPSoTx/A4vC4MeWWQ0dd4+6Lbv2Q/+r0plsOHWGhBOuWQuHpxQv9uRx2UAqGDsOMTYW5Z5UnWpLORWAIIp27AfKVEde4vamsrIz+/U1QXl5eAABIxTryXU3rvBqyFg72Hm2mexGEkC/m7vz46RXz5ciY4PKvDvr+d2BwcNqffR52n99615HjttsamgQTHm/UAwKL+UmOcmFKSFuyNakpU99TMptu59KppCsgCNR2K+REMI2YJIlEsuD7bU9ZWRlm9Kh7fMJs93hntMIjmR2L201/4vOvxp++bl3IiWo3ZqZzizickS67ndBg+XDRbrMn3fldc9LTbZ2WUj6PlUqnu90IQu21O7x1I2NsL4rGbFbWxvyckJVxKZ83dW4Gj0H6XoIEBQDqctiQxVweVsrL8u8VDF54+oTBQO5HQ+SZ+oPCLZeXW0VcTkhPRRoMs/+4eOHw7Y3Hwi8cAU6brbzT5qnSq7P3Rky30EwY9m/MD3mG2uQ2icqmU6zJbHpCJgTGmi6nA17MnZnwPKlTvtc6eBbMiSEDWX9EgJePNBHa5lRKsrIXJXGjPs86kXhuqczIplJCthT1LpezMHWqVCpuK9rjmQ6HHdPyUygUy7//QPEsGM3IaFwkfCUq+442TyoYIiUE9Hvyc+b1FIfZyGGz7JuK8giNP2l32GlJTNL3EiqdTjveQ/SMBVNTU4NbQX1ENxh3Fb6JxIDZzNn13dGg80jO5c6cbAYNgshERwzuzZ+awELI93PQPBGXbTwThR6nA/FiO3pTzlowV2MlJlncbofObInlcKw5wcMffSp0EhjUlsViJj9YnD+jIfV8Z/KGvb8wj1CE0+H3O74wjpEV0wRwIwistmPf3lMKRqFQYJYHqE6rTeS+lDhOn4/2j6bjhJLmfi8tSeJTqYSGvc01freo2JDGoBNSDi/q+pBYRr/mCt9ZTJj395TykMlkJViLJ/XDCdkkKB7Z39RMSMHwabRUhSQrbqqsY00yjeZUyhYS6pOrd7tc742R93g4GHS7MA2Rsy9iThA42D8Q9dnJc5XjeoPg/dZ2PZFrbMyPr14xseS+ghw3BQKEfCcfjA3HTSJjomP0eTG3qmcVDOaTYNBsIb+AMPLAex8mIQgSctj/UmGy6HJhSk94pUpM7ivII6RsEQD8748Nk1ujMOHw+3DHDIBzemWch4dAsyGSmQxZrNy31a1EtjnQ9mUyOgCAcOkGm0IxXpee1qsQZw0qxFm6K1JTugAACRExvCdPoi/gsgkFH/5tGPQafT6ygDdM+NGZ5SPgnAppzEUUoKQFE2b2HDkGKhfLQj7/khSBWJ4mHK4bHQ+pPzIFghxPSEu6H1lQmM6iUPLPXXP4/d33HztlfqNftyJkASMMHYbdL6xYTChz2OrzefYODZAFvGGERaFg6pCzFgrmuAwRlxPzdgFzja+6ewTfaXWExpP8PFcS0vagmMsZPXr1FaYnpCWLWRTKjPomNoVS+M9Lli/5/MqyjiwmMy4HwW3Ml1jYFAoh6+X9sWHYh5LurHAiotExFfZZBYPpfKzIzyVzYMIMCgC8+f2PCGX3/iQ3m8OmwEEpAAmbNX7y2gpkeTI/6yKHUtelp5X857JVplDliyRVBIoap0HfGzWQ2iXMFLDYmPfzlIJRq9VqrMVlmRlk9mgEaBrUi77u7g3ZQqDCcNKOZaUjwZzzx9IFDhaFEvC2qkyYnDu5lQpJwAhxU2a6fkWyIIXINd4fG3YOetxkAW+YWcThYnZxnFIwKpWqEWvxpoULyEbfEeLlI02Ezr+vIDcnk8kIqARBykvq/2muJGifzTbZAomQTiM0sTJcQAD49q1aihJJ/HQhiPcFbR9ZWxdmIAC8S7g8zEj0WQtmUsHM6MCWI+ALioUphAa7k2DzrqaN3zNhJOKLYVTl51y0a97kl79/1dLJbUUoDwv69ZnxMWvvDkn2mIjJuNj2blY+HhsBDoTsnRZuFnG4LiaMrfenXn377bdHAQBHsA74kWxRhMWbn7j9ftqdb71NQVA05LyYzUX5dAYMzxpavjtfMlwmTM4J9T3KUwSER8eGAeSxRcWEQspeBPH+a1hHRkUjQIVAiKe1Nd+rnYaGhpNYR1xdiFmmRBIGvtMOpp42DIe8BUlnMpJvFWfOagXdLs4O9fJTcKjUmCejrUlN0cv4SYTKAg6ZjR6Dx0PmvYQf5BKeAFNxa7XaE98rGJVKVYt10LXFhbyK/DyyZCBCPF33LaGIxt6VSwQpdBrmNvbSFMHwtRlphLYVJi/habiEYFFg+5uXrqCc0z0vaExer/fp/i6yJUMEuF6Y1l3C5mAqf5VK9d/vFcynn376DQBAh3Xg7h/eSIMAFNs7bY6iatGkGqzW/lDP51CpKbeLszGzgx8szvcRrYY/abLEtI3k9RkiYzabRWgEyoGJUcTm95NZ6WGGCcPjj+YU4n039v3793/8/Yeu0WiQ2traJ7COXJiWmrRx9XJSwUQABEXh+9/9kEokL6aqYGavsEVJXP0GcRahsa1+ALxfDI/GNNnyBxkiQvcdAoDv/dFhUrlEgJ9miM00GMbsBKhWq3doNBrneR/87bff/goAoB3rhN+vraAyKBSydWMEeL+1Pfuk3hBy17uVyYKMq0Wpnee+tmvlEgsNhglZH6/09Du1TldMZwSJmAxCTuYDY8PufreTzHsJMwUsdvPPMsWYY44AABPV1dVPASzzefv27S9gnZEj4NO/2PhzKIlBJzRQjASbvUebCfli/rpEyoKmUw0q0oT6ijQhZo+fQBlzezyPnmqNud9CxAhdwdj9Pu/uoQFyiFqYSafTtX8tWiSEAcBs9tXQ0LCvvr5+yhiZoWD279+/BwDQhXXimtwc+mPyK+MhbDnneLX5eLLT6w25X8zyZL54XXrq1CTIh4rzkQBmM8/KK70D/gmvN+ZP/jG3J+TtzZfGcf+410tGjsIL8tvcotEMOgNvToxrx44d28/+nxlfnkaj8SqVyg0AAMzw6dY15azbSqVk68YwY/d4mb/99AsnkVYMd+VK0BUC/uBN2ZmE0uk9COLZ3dMf8/D0JOMeT6g+GP97o4a4+BvmEJ77snK+Xc0TLMNZR2pra+9TqVTfp05gfgH19fXDMpnMKpPJfnDhGgWGoQ2LZfT/tmicI3Z7zJ9wc4nvtIPJ961eMZzEYIQ0QkPKT4LKhSmWTCaD0CTIv7R32d/W6eMipZ5BgQc3iLOCDrUfNE043xzRky0Zwsg1KanHH5LkX4ZnHavV6v1XXXXVU+e+hqvhGxoamq+77roCkUi05MK1yauX5YjRfx4/5fchCPmUCCNcOt26tiA/JAUDQxA9g8kgVAGvdTg9ioZjDB+KxkXkpdNmpynEme2pDEZmoOc4/X7/Yz3tsMXvI+/NMCFhsDpq8ktSORQK3r156pZbbvmpTqc7r0Aa9ybS6XS+6urqnwEAjmKtr8jKpP/nx7f7z0QCScLF/qZmLoqzPY0Ge3r6/U6/P25+mB4ESbv50FHEj6IBj21RjeidOreLtK7DBAOCh15cIEPT6HQ8JT8il8uvbmxsnBEJnfUpVV9fj1ZWVm4EAGC2Fri+pIj1P1deTrZ0CCODFivvk/bOmBSYWn0+177egbhRLmfptNlXbTjcpLd4fb2zHYcA4P1YPzKybzD+/oYExveb3MLRVBp9Ac46olKpHqivrx/DWryoGaxSqU7V1dX9CM/5+Mdrr+aszM5KiF6uiQLRVg6hUtPS7jW43HHZouPdIcPylPc+hQ4YRj/BSkq0+/zjN3773fDdJ06w/QSnDZD8Hzemig5cK0yb4SY5S11dnbKysvK/eOsBhzIPHz78h/Ly8sex1sYdDk/5rn1I5/gE6VQLA1QY9p341QM9MlEaoVyWYOiw2lzST+uY/vhvJekv4LDbViYLaAIaDfUgfqbJ66N9MTzK9kEoq0TE9SUxaTEtb5grlPEF6ueKpPkAAEyHv1ar/c/69esVGo0G96YJWMFIpVKKWq3+BgBwGdb6N339roo9r5AKJkxcV1zYd+Dun2YAAKLymT50osX5fGdvQj/5c5LZdnEyi1QuYQAGkE61eIUvg87IwzlkrLKycqFKpZo1Az3gSIFGo/HLZLIbAQCY7TWvzMtlvnTLDVYoDCM1SAD4tLM774h2EHNfG26GXW7na326hHaKQgAgoiQGmVQXBjgwZXTfoiXG2ZSLUqm86mLKBcwWpsZidHTUBQA4IZfLq7DWV4uzGYMWi6t5SJ/QN2u8gAJgvnnRAkJ9UALhgWOnXEeMpoS2XoQcuiOdx0zovyFeqMqStF+VnIqXTAdUKtUvN2/e/Gkg1wo612Hbtm2H1Wp1FVaLTTDl9F1HE/N5ZFFkGFCdVqeN2OwRneR43Gh2vjEwGFLeTTyRwWOS6RJhYDE3qe3HGWK8iBFQq9Uvbd269dVArxdSMlVpaek/1Gr1Pqy1NA6b9tLNN5AFkWHA4nYzH//iKy+eMg8HL3T1xr1X92JwGVQTn0Ujh9gTZ/y3uUUUGAA8P1ZdaWlptU6nC1iZh5ytuXHjxscmH4BYazctWsBRrpNbyCQ84uw72lzUOTZOaGg+Ht02u/NN7WCiVxujBakcCtHizvkOFYKMfy+R9eYyWcU4h4xUVlbeH+x1Q1YwjY2NRplMdiUAADNpo+YqOW/rmnIyP4YgCIpSnv32MBpuZe1FEO9tDU3A6U/sUg9REsPKZVATfosXY3yP5RYNrEzir8JZ1ymVynKVStUR7IUJ1ZtoNBqbUqnciHfz/3n9NdzlmZlxMVcnkXn9+MkMq9vTGc5rvjdk8J00WeLGKVrC5YCrRUJQnpIMWJTAb8v0JCZpuRDkB0LRgetmSaZTKpUPbtu2LSRfYFi+nLfeemtDZWXlv7Bm74za7e7yXfuQ7glj3NzMich9q1e2vfyjm/LClRez5quD7kPjxphuj9IYdPCEtAQoxFkgnfl/ovhRFNSNjIG9PQPg7cEh4MfxEglYNKs0k8ch+qCcz5TxBOrniqWT9xWm30WtVj+5fv36J3Q6zHbdFyVs2r+lpeVZmUz2MNZaXU+fY+2+V+Oi/D+R6X3kwd685OR8otc5oB+xXn/wu5huK9IZDHDoqstBIXf2vLg93f3g/uZTmGsrc5LHGVRYGCER5zwwBHS1shW+TAYTM99FrVa/U1paeiuR9wjb/ru5ublh48aNVwAAZgz5yksW0IRslumTji4a+bQJHQ6dbrm6sIBQI2+Hz++58dAR2BjDTm+FHDZy8Ko1IJ/DvugDbmWKAKTS6eCA4fxR3EIO3ZzOYxJqTTGfYcOUsV0LF4/ms9h4Ien+zZs3V2o0GkKFt2H7sTc2Nlrlcvl6AMAA1vovyy8V3LNyBVl5TYD9Tc1CP4IQyot5Uzvo77E7YlrSUSMt8eWwWQFbz5uL88GNmef30Ernkb4XIvw0I3tgIZu7GGfZrlQq16pUKi3R9wlrBKG/v9/L4/HU5eXld2Ipr/IcMfiwrcM15nDEZcVuvGP3eOlcOl17eW5OSijfHQqA7+6jx6FhtydmkaMl/CTnC8sXU2EICurhxqFQwZvaoan/5jGpFkkKe9L8Ia3hELgqWXjowZyCUghnXrlKpdq8efPmL8PxXhF5CrS0tOyTyWSY5QRjdodrwfYXwITTSRZGhgAVhr3jjz86yGPg1ongsr9nwLzx2MmIlx7MRp38MktFmhCzG/1s2H0+wHvnk6lw5TKxYIRNpxBqCzpfKWCxW/4pXVY0S7DgSwiC1oXr/SLyBNi4ceNvAACnsdZSOWzmS7fcQHbCCxEfgtD2HW0OOrN31O12P3JKE9NI3uXCZFcoygWcmWAJSvlJIJlNM5PKJTToEGRQ5hezZlEuw5WVlZvC+Z4RUTCNjY1jcrn86kmDBWv99iWlnN9UrBmNxHvPB/Y3NScDAAaDOqdX6zd6vTHdmj5QmEeoLEHEYID0JNLwDRHnc8XS7kIWpxBn3VNXV3d9KMl0sxGxPWx9ff2oSqV64MzWfyZ/um5d+k0LF5BJeCGgGRkV1p5qGQ3UCnT5/a5d3X0xzdjNY7Ndt4ozCclgQX2mZDadzKcKgZ9mZGtWJPEvx1tXqVS/Xbt2LWbpDxEi6iSrrKx8u66u7k9YaxAAYO+tN9G4dDo5YykENn/wcaEXQQKqUXqytdM54HDGNKnu2aWLPCwKJWQLyoMgTi8ddUMQtmOSBJ/F3KSGX2TnLpzlkPeVSuX2SLx3xL3w1dXVj2u12vew1tK5XGb9fXfDySwm2d4hSEbtjiTVKfVFLcBum93517aumDp2lwp47tvEWYSqnZstZhOLQU0Pn1Tzg2wGs+evRYty8TJ1tVrtdzKZ7A6NRhOR94+4gtFoNOjDDz98HwDAiLW+IiuTvW3dWkek5ZiL7G06ljypa2Y75qWuPr83xjOOflGQ6yd6r31mHEv4thIxwP2HghJ7EoWKN7jOt3///iqNRhOx319U9uUajcYOAPhcLpcrAJjZ8X1VdhZDa7ZMnNAbyHKCIOg3mjjrCgvacgR8zBvI7PW67jp6nOqK4XC8VDrds3fVUohJoYScOWzwuIeeHegW+AEgOyUGjuORnIJjawQpq3HWXbW1tRs2b958MJJCRO3Jtm3btmaVSvV7rDUKDMP/uO0W4Spxlila8swFUACgX374iQQFANMX82qf1mv0+mLqs3iqdKGLT6MR8v/s1PWbPShKPnyCoFKU2fbDtIw1eOtqtXr77bff/kGk5Yiq6bx169Y9arX6Fbz11zb8iCFgMsntUhAcH9KLvurumTEYz4eg7he7+mLaBLuYy3FvLMglFPXpdjoGvzaO4bZwJJlJAYut/nmmWDLLIV+sX78eM/gSbqKqYHQ6nb+6uvoeAEAD1rpUlMZ6/+d3eiGMwVok+Lz83bHJH/F5Dt/tHd3mLps9piHdu/IkHgpEbFvz3qgBRcmSgIBJptL69y1ckiSg0tJwDumWy+U36nS6qDSDi/oXV19fDyorK3Gdvlfk5vCV69aSoesgeK+1LatrfOL7MIDW4XQoNe2Eqq7DwQ2ZIkLZ2mafV//ZxGhImb/zFOcjuYVWBgzP6GgwjXv79u331NfXRy1qG5Mng0qlaqmrq7sZbxzt41dVJK/Jy4nKTKC5gMfvpz3yyWdZZyNKL3f3e51+JNb5It7FAj4hGf6h141b/X5SwQTIL7Jyv6wQpJTirdfV1d378MMPfxNNmWJmeq5du/ZgQ0PDH7DWIADAxz//cVJpuojM9A2QdzVtkhNDBrPZ67Xu7e2PtXIBGQyGHsaIGAbKoNs19O6oIWqjcxOdtQLhyZ9mZl+Ht67VanetXbv2n9GVKsZ728rKyifVavXzWGtJDAbj3Z/eQRMwySS8QHm6/lvq//v6sGXE7Yl5Or3Z56XgWaiB8C/DoMeHojFXlInAIg732O/yiyQAJ4yvVqvfvuyyyx6KvmRxMuoBRdHPAADXYK3tONgwsfXjT1OiL1WCAlNQULoYApTYDwuw/ej6fg6Vmhv0eX5/z00nj2Z5UISsbLwI2Qxm91ulK3gQAHhO3RNyuXxlfX19TLoXxIV3frpE3IC19qvLLhX8dPnSkehLlaAgfggYJ2ItxRQf60dCyb71/13b6yaVS0DYH8kp8MyiXGxbt26tipVyAfGiYFQqVVddXd16AMCM7RAFhuHXFT8SrcjKxIw6kWAwFh/+8Vf6tEErGK3LafhkfGRRZCSaW/y/9Mz21TwB3meF1NXVKXbs2NEcZbHOIy4UDDjj9D2pUqkew1t/TfEjehKDQQ5yCwSnAwCTKea1O58YRsS7u/uPB9pWAgHA84K2z0d2Irs4hSz26Z9l4CfTNTQ0/Hnt2rUHoivVTOLCB3MWqVQK1Gr1ewCAm7HW63v7jPK9r3LxnFkk50Cno0BaCgEo5l8x+urqZeqf50lww6fgzCwk10+OHm8foLgWAgASfZxtRBHS6H1vl66g0mFYjHPIEZlMdrlGo4n5jPjYewLPYXR0dHK79P7NN9+8js/nz/jw8pIFLBRFTfW9/WRdysXw+yHAZALAinlACfpAP5w06HRpCzhsu4jJOC+vxYeirs+GR+13Hz3hHwAuhEmjpMZO1ITA8UR+8XABi12Es94qk8nWTRcYx5y4UjDgjJLx8ni8Rrlcfj/WFq6iIJ/5RVf3qNZsmX1iFwkAPj8KhMLYmzAA0I4Zzckvdffx/juo7+y1O1yHxiag94aGJ+46epy+p2cgyYz6JnJS2HgZqCRnQH8lzvv8hlQRbhGjUqm87e23326Lrlj4xPzmw+Ott976YWVl5ZtY5rLZ5XKW797nbR0ZI7M8L8YiGQqY8T9DqFjEHUzjMrJjLUc8c3Vy6sk/FJTIAABYRaw+tVr9QGlp6b4YiIZL3Dh5L+T2229/V61W78Ba4zOZrFc3/Aglksg1bxiP/0ZNNApsSOUwyCmNs8Cj0lofzS0U4SgXoFar98ebcgHxrGAmWb9+/VOTnx3W2iXibP4rG344BgHIE33JEoiJcQj441sPF6VxbBAESL8aDkIaTb97QSmFQ6Fk4hxyfOPGjbgR2FgSdz6Yc7FYLF4AwEm5XH4P1vqyzAzuhNNl/k6ri7knM25BEAhAEAKSkuJym8RlUIfyhJygs33nE1skBe2reQK8Ma8jcrn80kOHDsVHduUFxLUFA850wjukVqs3Tu4xsdaVV1ewl2ZmjEdfsgRiZBgCnvg09NJ5ZER6Fvw/Ts+uvyFVtARnHVGpVPfV19fHpXIBiaBgJiktLd0/ucfEWktmsZgH77+HlZHEtURfsgRh0ooxTsSdLwaGIKuIyyAd9Tgs5/JPbBLnXgFwZkir1eq3KisrMSd2xAsJoWDAmXG0k3vME1hrXDqdvfuHN05aOGQnPDzGxgBA40vHZPAYVgiCCI0zmauk0ei9v88vSp/lN9q5bdu2h6MsVtAkjIJpbGycmB5Hi1n4eMuihSl/vf4aXfQlSxA8bgiMj8VVFj45BhYbCIDxvxYvMmfQGXiZuma5XL5WpVIFNHgvliSMggFn2m1OqFSq+/FqW359xeX5isWy+Kj0i0f0QwD4Y549PkUal9HJolPw5vXMZ5CHcwoGilmcZXgHqFSqzfX19UHNJo8VCaVgwJnWDu/W1dVtw1vf88ObWEI2m3T6YuHzwWDCGHMrBgLAUZjGIX0vGFzGT/78R2kZeE7dSf5WWVn5RhRFIkTCKRhwZhztk1qt9j9YawIWk/PNfXdTRRxOXNRixB3jsffFpPOYRhiCyDGwF7CEy2v7c9GiS/HSR7Ra7ScymezX0ZcsdBJSwWg0GrSysvJuAMAhrHWpKI3/5h0b3DAEOaMvXZzjdMBgbDSWVowrW8AknS8XkMNkdTxZUMKHAcCbBtFcWVn5Y41GE99ZkxeQkAoGnHH6WuVy+XWTih1rfW1Bfsq/br9tONBeJPOKoUE0Vtm92QLWAINKEcbkzeMUBgwPvVhSiqbS6HiZusNyuXxdY2NjwjVdi+tM3ovR39/v5fF46vLy8juwlGVpukgwZLHom4f0SbGRME5BURjQaH7A4UT1AUODIfOC9CQmDEFkWcD/4X08r6i/lJskw1lHVCrVT5599tmTUZYrLCSsBXOWhx9++LO6uroteOsv3nxDyiJR2lB0pUoAxsaiXjqQlsR0UGCItF7O4Za0jAPXpKQtxVuvq6v7XWVl5fvRlSp8JLyCAWfabb6o1Wpfx1qjUyjMT+/+CSuHz0848zKiuJwwMEY1ouRJ5zHIToTncBk/ueV/cgrW4a1rtdq3qqurn4muVOFlTigYcKby+pcAAMxEOwmfn7zvtpvJcbQXotOi0YooZfCYfSyyW933UADU/0hOweTWHa9Qd3j9+vUPaDSaKEsWXhLaB3Muo6OjbgDAh3K5fAMAYIbPpTAlhc+mUTu+6OrhzaW/mxAIAgMGEwEsVkS3SxQYsi5KT6LBMER2IZy8OSnU0d0LFxtzmKxinENGlErlVW+//TZmACORmFM/tOmq0iG5XH4b1vr/Z+/cY5vIrj9+Zvy2Y8exYycmHhIT5+UbFtj9/bZh2WLz0MarLoiXYyo1iFKkPuSqgnYl1G5F/uhDLaWvVdltRaS2Yllqt6W7qLTsrpSkXZEAKktK7PAOyZgCedIEEtuZeCoTR03ZGW8S7LEzMx8JCelYo+PJ9XfOPXPuOWtKlxp7Rh70dd69JzY3mmGKioOxMKORbJFOOWzUKMS6lyR7lxBXXAVG1rxLIBD4is/n+4BbrzIDrwQmwc2bN4P19fVqs9m8hsm+mrBK3u68/Ggslv3xqjlBLIaBVhsHuSJTIjNlN+VFZBJcjF4en5DWdR8os9tTjHn9eWNj46HR0dHcOpm6QHKyCVE6oGn6NAC8zGT7Q1fo5o7j/nLuvcpRlEoKqh3STIw4MeUprlWY88Qh9tP0n0Crxgilim3tvY9h2Esc+5RReJPkfZKGhgZfYrvEZNte67B9e73zstjTN0kkIoXR0bS/UcIx7FGpQS2eOQIAOY4Pv1G1/E4KcbmXHKHMK3i3RZohFAqNAMCZZLvNJxslY+uW2You3b13/erAoPhmAx7PUYqDwZDWB45Zqxw0aRVs1amC4vMW6xW30bSKxRxtampyHjlypJtjtzIObwUGppO+AwihMYQQ41bpxdKl2DvdV4ZHJiLiUzYWA8jXx0EmS5fIxO0mzbhcigu+odRqnb79G6Xl1ThgjP1BA4HAqz6fL6c70y0U3uZgZkiOow0AwA4m++2RBz3VP3ldG6WmxEgmT0tBRSXjWIz5YtDIr1YXaavSca3FjE2p6j6GVhGJu8vykT8ihLYv9noXNnibg5kh8YdDCDWSJNnOZC8r0Nt+tXXzsJiPAYCHY1J49PCpczEYBuNlBrHfiwSw/tfKKqRs4pJYkwihz/FVXEAIAgPTIhNpbm7+AlvP3l2rVlTufm7V37j3LAcZfPpBbYV5igdKGS703Ev0cIWju1qTx1ZMN5lYk6FQiNctRXidg5lNW1vboMPhuIgQ2spUg7DFUV18jgz33BgaFvZhvGgUwGCkQSJZ8Pa5vFAzppBKBH2CvcFs6dxmLl7NYp7w+/3bfD4fY1TNJwQRwczg9Xr/HAwGD7OYVW9ueUUlxfFF0es0Y8TjONy9s+Btkl4lu6ZVygTda9ehzjv/NcLGWvsTDAZ/5PV6T3PrVXbgfZL3SaxWq5okyQ4AYJyUd/Ffd7vXH/216d+RqJCTvnGodgCoVPN6AGEAkZVW/ZBKLhHsEHuLXHH7aM0zUr1UxjYRoJMgiBfC4fA4x65lBcFskWZIjqO96HK59jLZLVqtCQP86gc3bwk5h4ABhk2BLn9eAmPUyPuL85WCFRcAmPxxheNOikOMdFNT0+ZTp071cuxX1hCcwMB0PuaOx+PpMZvNm5i2iWvKlub3jIyc67x7f2l2PMwBYlEaCk044HPXmGWFmlGlTCLUt0cT+5YuO+/SG59nsU/6/f5dPp/vDMd+ZRVB5WBmU1tb+9tAIHCAyYYBqH+zY2tdw3L0Efee5QgUJYG+3jkPtDZq5LfyVTLBRn1fKikN7TAVf5rNHggEXvV6vce59Sr7CC4HM5tkEd67ALCJyT4Wjd6xHfrZyND4eC333uUI1TUUqNSfVHwX+VSZYViCY4JM7j6rzW99vRKtBgC2Sf6/Rwh5+FzvwoZgIxj4bxHeTpIkzzPZtQpFyd+/uEdi0WqFO5J2Dr17i7SKIaGKS7lKff2wvcbBJi4kSZ5FCDUKUVxA6AID0yIz3tzcvJetkrfGVFjz/fqNfdx7liMMD9EQT/3WukinFOo6enjQVknJcdzMYp8ppotw7FfOIMgk75O0tbX1OxyOywihLQwnr2GlpbgoRlHvfdjbZxOcKNM0DvF4FHT5jNukArWst0SvsgjtvmAAo98trwo+q81nOyE94ff7t/p8vg6OXcspBLUoUuH1ek8Gg8Gfspjl36vfWP9Shf1Djt3KDQb6ZRCLMUV4k3bT42M2gntQ7bJYb7j0xjo2ezAY/KHX6/0Lt17lHqLAzMLtdn8nEdCwmPFjDdsqd65Y3gIAc367whNwGPr4GSVTnqJfJsFLs+NS9ngmT9uyq7gk1fc+43a7f8ChSzmLKDCzCIfDD10u18sAcJvJbtKol7zt3e56bd3a9xObB+49zCKDgx8bcVKky1gf35zFrtK890bV8pVKnHX87TWXy7U5HA7z+hDjXBFcaPtJ9Pb2Ujqdris5jpbp/mDry222/ytZcqmjLxx7EImwDSvnF/G4BFRqCpTTCd18pZQkCtRmAa2hh26D+Z1v2uw1GgnrUYjI/v37t584cYLxASVEBF0Hk4qWlpYvu1yuI6k+Q8Xjg9vf8l96t/vKekFEgzrdJJTapCCVxp8j9L0KmWRZtl3iiN4DpeUnNxUWfTWVoLa2tu5ct27d77h1LbcRytNn3ly4cOEfZrM5ghDawCbEOIapP7ui1vqZqoqgWi4fuDE0NDQxSRl5K9zRKIBMRhnMhv5inZL3uRcFjl/0mCwt3yqzTzyv07NFtI9pb28/tHbtWraXBIKFnz+ENNLS0rLb5XIdnaMYT5y+ev3sW5f+SR/vvFwFAAQHLnKLQkE5NrwwoOffsQAaAEgACK43FJ6zKTQTe5aUvAIArOX/s2hFCG0MhUJiV8QnEAVmDvj9/i0ej+eXAMBWUMXEwOV79+/fGB7Jo6amaP4khbF4gaXwI4kE70827lrka+jxMChMplLhLyrViegzEZlVppgZ/T+QJHnC7XbvDoVC0cz7uvhY5IuDO5xOp6G1tfWvAPD/2fYly0zO6gg4lfxHpziHw2eOIYR2i5ELO/xPTKaJtra2YYIgXIFA4OsAcC/b/uQIiW2jPCkucQCgkjVCU8n/85WRQCCwB8OwRlFcRNKOx+Mx0DT9Jk3TFC08YvP4bCR5j6IZ9Idr/uR0OguyvQZFBMC+ffscZ8+e/QVN0wPZXvUcMh+Bmc2M2FBPcY1s8aivr+/4wYMHN1itVjGtIMItTqcT9/v9m2iaPknT9ES2fw0ZJl3iMCM0kTRdLxOQXV1dB5xOp+CnUy4UUY3TTF1dnYogiOq6ujoHQRAEAFgAgE/VvlMZqJ+iEtd0OBwShBDBcX1W4vuMB4PBR8l55j0kSd7q6Ojoam9v7w6Hw089iE7I/CcAAP//LazR1LfsgEMAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - hco.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - machineremediation.kubevirt.io
+          resources:
+          - machineremediationoperators
+          - machineremediationoperators/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - daemonsets
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        serviceAccountName: hyperconverged-cluster-operator
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - networkaddonsconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          - endpoints
+          - pods/exec
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - kubevirt-handler
+          - kubevirt-controller
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - put
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancepresets
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - limitranges
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - delete
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - update
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstances
+          verbs:
+          - update
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - version
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - kubevirt.io
+          - template.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - watch
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - daemonsets
+          verbs:
+          - create
+          - update
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - services
+          verbs:
+          - create
+          - get
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: kubevirt-ssp-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - extensions
+          resources:
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - watch
+          - create
+          - delete
+          - get
+          - update
+          - patch
+          - list
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+          - patch
+          - list
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - daemonstes
+          verbs:
+          - create
+          - get
+          - list
+          - delete
+          - watch
+          - update
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - cdi.kubevirt.io
+          - upload.cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - persistentvolumeclaims
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims/finalizers
+          - pods/finalizers
+          - volumesnapshots/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+          - update
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - events
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: node-maintenance-operator
+      deployments:
+      - name: hco-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-operator
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                  - name: KVM_EMULATION
+                  - name: OPERATOR_IMAGE
+                    value: quay.io/kubevirt/hyperconverged-cluster-operator:latest
+                  - name: OPERATOR_NAME
+                    value: hyperconverged-cluster-operator
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: WATCH_NAMESPACE
+                  - name: CONVERSION_CONTAINER
+                    value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0
+                  - name: VMWARE_CONTAINER
+                    value: quay.io/kubevirt/kubevirt-vmware:v2.0.0
+                image: quay.io/kubevirt/hyperconverged-cluster-operator:latest
+                imagePullPolicy: IfNotPresent
+                name: hyperconverged-cluster-operator
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: cluster-network-addons-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cluster-network-addons-operator
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                name: cluster-network-addons-operator
+            spec:
+              containers:
+              - env:
+                - name: MULTUS_IMAGE
+                  value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
+                - name: LINUX_BRIDGE_IMAGE
+                  value: quay.io/kubevirt/cni-default-plugins:v0.8.1
+                - name: LINUX_BRIDGE_MARKER_IMAGE
+                  value: quay.io/kubevirt/bridge-marker:0.2.0
+                - name: NMSTATE_HANDLER_IMAGE
+                  value: quay.io/nmstate/kubernetes-nmstate-handler:v0.8.0
+                - name: OVS_CNI_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-plugin:v0.7.0
+                - name: OVS_MARKER_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-marker:v0.7.0
+                - name: KUBEMACPOOL_IMAGE
+                  value: quay.io/kubevirt/kubemacpool:v0.7.0
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/cluster-network-addons-operator:latest
+                - name: OPERATOR_NAME
+                  value: cluster-network-addons-operator
+                - name: OPERATOR_VERSION
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERAND_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/cluster-network-addons-operator:latest
+                imagePullPolicy: IfNotPresent
+                name: cluster-network-addons-operator
+                resources: {}
+              serviceAccountName: cluster-network-addons-operator
+      - name: virt-operator
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              kubevirt.io: virt-operator
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              annotations:
+                scheduler.alpha.kubernetes.io/critical-pod: ""
+                scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly","operator":"Exists"}]'
+              labels:
+                kubevirt.io: virt-operator
+                prometheus.kubevirt.io: ""
+              name: virt-operator
+            spec:
+              containers:
+              - command:
+                - virt-operator
+                - --port
+                - "8443"
+                - -v
+                - "2"
+                env:
+                - name: OPERATOR_IMAGE
+                  value: kubevirt/virt-operator:v0.20.8
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: kubevirt/virt-operator:v0.20.8
+                imagePullPolicy: IfNotPresent
+                name: virt-operator
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /metrics
+                    port: 8443
+                    scheme: HTTPS
+                  initialDelaySeconds: 5
+                  timeoutSeconds: 10
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: kubevirt-operator
+      - name: kubevirt-ssp-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kubevirt-ssp-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: kubevirt-ssp-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                - name: KVM_INFO_TAG
+                - name: VALIDATOR_TAG
+                - name: VIRT_LAUNCHER_TAG
+                - name: NODE_LABELLER_TAG
+                - name: CPU_PLUGIN_TAG
+                - name: IMAGE_NAME_PREFIX
+                - name: OPERATOR_NAME
+                  value: kubevirt-ssp-operator
+                image: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.16
+                imagePullPolicy: Always
+                name: kubevirt-ssp-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              serviceAccountName: kubevirt-ssp-operator
+      - name: cdi-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cdi-operator
+              operator.cdi.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: cdi-operator
+                operator.cdi.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                - name: CONTROLLER_IMAGE
+                  value: docker.io/kubevirt/cdi-controller:v1.11.0
+                - name: IMPORTER_IMAGE
+                  value: docker.io/kubevirt/cdi-importer:v1.11.0
+                - name: CLONER_IMAGE
+                  value: docker.io/kubevirt/cdi-cloner:v1.11.0
+                - name: APISERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-apiserver:v1.11.0
+                - name: UPLOAD_SERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadserver:v1.11.0
+                - name: UPLOAD_PROXY_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadproxy:v1.11.0
+                - name: VERBOSITY
+                  value: "1"
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: docker.io/kubevirt/cdi-operator:v1.11.0
+                imagePullPolicy: IfNotPresent
+                name: cdi-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                  protocol: TCP
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cdi-operator
+      - name: node-maintenance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: node-maintenance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: node-maintenance-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: node-maintenance-operator
+                image: quay.io/kubevirt/node-maintenance-operator:v0.4.0
+                imagePullPolicy: Always
+                name: node-maintenance-operator
+                resources: {}
+              serviceAccountName: node-maintenance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        serviceAccountName: cluster-network-addons-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  labels:
+    alm-owner-kubevirt: kubevirt-hyperconverged
+    operated-by: kubevirt-hyperconverged
+  links:
+  - name: KubeVirt project
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/hyperconverged-cluster-operator
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  replaces: kubevirt-hyperconverged-operator.v0.0.2
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-hyperconverged
+      operated-by: kubevirt-hyperconverged
+  version: 0.0.3

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/kubevirt00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/kubevirt00.crd.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    categories:
+    - all
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  scope: Namespaced
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/node-maintenance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/node-maintenance00.crd.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nodemaintenances.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: NodeMaintenance
+    listKind: NodeMaintenanceList
+    plural: nodemaintenances
+    singular: nodemaintenance
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            nodeName:
+              description: Node name to apply maintanance on/off
+              type: string
+            reason:
+              description: Reason for maintanance
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          properties:
+            evictionPods:
+              description: EvictionPods is the total number of pods up for eviction
+                from the start
+              format: int64
+              type: integer
+            lastError:
+              description: LastError represents the latest error if any in the latest
+                reconciliation
+              type: string
+            pendingPods:
+              description: PendingPods is a list of pending pods for eviction
+              items:
+                type: string
+              type: array
+            phase:
+              description: Phase is the represtation of the maintenanace progress
+                (Running,Succeeded)
+              type: string
+            totalpods:
+              description: TotalPods is the total number of all pods on the node from
+                the start
+              format: int64
+              type: integer
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/scheduling-scale-performance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/scheduling-scale-performance00.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtcommontemplatesbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtCommonTemplatesBundle
+    listKind: KubevirtCommonTemplatesBundleList
+    plural: kubevirtcommontemplatesbundles
+    singular: kubevirtcommontemplatesbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/scheduling-scale-performance01.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/scheduling-scale-performance01.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtmetricsaggregations.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtMetricsAggregation
+    listKind: KubevirtMetricsAggregationList
+    plural: kubevirtmetricsaggregations
+    singular: kubevirtmetricsaggregation
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/scheduling-scale-performance02.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/scheduling-scale-performance02.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtnodelabellerbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtNodeLabellerBundle
+    listKind: KubevirtNodeLabellerBundleList
+    plural: kubevirtnodelabellerbundles
+    singular: kubevirtnodelabellerbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/scheduling-scale-performance03.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/scheduling-scale-performance03.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirttemplatevalidators.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtTemplateValidator
+    listKind: KubevirtTemplateValidatorList
+    plural: kubevirttemplatevalidators
+    singular: kubevirttemplatevalidator
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/v2vvmware.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/manifests/v2vvmware.crd.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: v2vvmwares.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: V2VVmware
+    listKind: V2VVmwareList
+    plural: v2vvmwares
+    singular: v2vvmware
+  scope: Namespaced
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/0.0.3/metadata/annotations.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/0.0.3/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: 0.0.3
+  operators.operatorframework.io.bundle.channels.v1: 0.0.3
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: community-kubevirt-hyperconverged

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/cluster-network-addons00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/cluster-network-addons00.crd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/containerized-data-importer00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/containerized-data-importer00.crd.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.cdi.kubevirt.io: ""
+  name: cdis.cdi.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: cdi.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: CDI
+    listKind: CDIList
+    plural: cdis
+    shortNames:
+    - cdi
+    - cdis
+    singular: cdi
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            imagePullPolicy:
+              enum:
+              - Always
+              - IfNotPresent
+              - Never
+              type: string
+            uninstallStrategy:
+              enum:
+              - RemoveWorkloads
+              - BlockUninstallIfWorkloadsExist
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/hco00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/hco00.crd.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hyperconvergeds.hco.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: hco.kubevirt.io
+  names:
+    kind: HyperConverged
+    plural: hyperconvergeds
+    shortNames:
+    - hco
+    - hcos
+    singular: hyperconverged
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        metadata:
+          properties:
+            name:
+              pattern: kubevirt-hyperconverged
+              type: string
+            namespace:
+              pattern: kubevirt-hyperconverged
+              type: string
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/hco01.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/hco01.crd.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: v2vvmwares.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: V2VVmware
+    listKind: V2VVmwareList
+    plural: v2vvmwares
+    singular: v2vvmware
+  scope: Namespaced
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/hostpath-provisioner00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/hostpath-provisioner00.crd.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.hostpathprovisioner.kubevirt.io: ""
+  name: hostpathprovisioners.hostpathprovisioner.kubevirt.io
+spec:
+  group: hostpathprovisioner.kubevirt.io
+  names:
+    kind: HostPathProvisioner
+    listKind: HostPathProvisionerList
+    plural: hostpathprovisioners
+    shortNames:
+    - hpp
+    - hpps
+    singular: hostpathprovisioner
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            imagePullPolicy:
+              enum:
+              - Always
+              - IfNotPresent
+              - Never
+              type: string
+            imageRegistry:
+              type: string
+            imageTag:
+              type: string
+            pathConfig:
+              properties:
+                path:
+                  type: string
+                useNamingPrefix:
+                  enum:
+                  - "true"
+                  - "false"
+                  type: string
+              type: object
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/kubevirt-hyperconverged-operator.v1.0.0.clusterserviceversion.yaml
@@ -1,0 +1,1625 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1alpha1","kind":"HyperConverged","metadata":{"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{"BareMetalPlatform":false}},{"apiVersion":"networkaddonsoperator.network.kubevirt.io/v1alpha1","kind":"NetworkAddonsConfig","metadata":{"name":"cluster"},"spec":{"imagePullPolicy":"IfNotPresent","kubeMacPool":{"rangeEnd":"FD:FF:FF:FF:FF:FF","rangeStart":"02:00:00:00:00:00"},"linuxBridge":{},"multus":{},"nmstate":{},"ovs":{}}},{"apiVersion":"kubevirt.io/v1alpha3","kind":"KubeVirt","metadata":{"name":"kubevirt","namespace":"kubevirt"},"spec":{"imagePullPolicy":"Always"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"templateValidatorReplicas":2,"version":"v0.6.2"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.7.0"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.1.1"}},{"apiVersion":"cdi.kubevirt.io/v1alpha1","kind":"CDI","metadata":{"name":"cdi","namespace":"cdi"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"kubevirt.io/v1alpha1","kind":"NodeMaintenance","metadata":{"name":"nodemaintenance-xyz"},"spec":{"nodeName":"node02","reason":"Test
+      node maintenance"}}]'
+    capabilities: Full Lifecycle
+    categories: OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.0.0
+    createdAt: "2020-03-09 14:34:54"
+    description: |-
+      **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+      Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+      Containerized Data Importer (CDI), and Cluster Network Addons (CNA) operators.
+
+      **KubeVirt** is a virtual machine management add-on for Kubernetes.
+      The aim is to provide a common ground for virtualization solutions on top of
+      Kubernetes.
+
+      # Virtualization extension for Kubernetes
+
+      At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+      additional virtualization resource types (especially the `VirtualMachine` type) through
+      [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+      By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+      resources alongside all other resources Kubernetes provides.
+
+      The resources themselves are not enough to launch virtual machines.
+      For this to happen the _functionality and business logic_ needs to be added to
+      the cluster. The functionality is not added to Kubernetes itself, but rather
+      added to a Kubernetes cluster by _running_ additional controllers and agents
+      on an existing cluster.
+
+      The necessary controllers and agents are provided by KubeVirt.
+
+      As of today KubeVirt can be used to declaratively
+
+        * Create a predefined VM
+        * Schedule a VM on a Kubernetes cluster
+        * Launch a VM
+        * Migrate a VM
+        * Stop a VM
+        * Delete a VM
+
+      # Start using KubeVirt
+
+        * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+        * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+      # Start developing KubeVirt
+
+      To set up a development environment please read our
+      [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+      To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+      You can learn more about how KubeVirt is designed (and why it is that way),
+      and learn more about the major components by taking a look at our developer documentation:
+
+        * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+        * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+        * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+      # Community
+
+      If you got enough of code and want to speak to people, then you got a couple of options:
+
+        * Follow us on [Twitter](https://twitter.com/kubevirt)
+        * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+        * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+        * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+      # License
+
+      KubeVirt is distributed under the
+      [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+    operatorframework.io/suggested-namespace: kubevirt-hyperconverged
+    operators.operatorframework.io/internal-objects: '["v2vvmwares.kubevirt.io","networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","kubevirtcommontemplatesbundles.kubevirt.io","kubevirtmetricsaggregations.kubevirt.io","kubevirtnodelabellerbundles.kubevirt.io","kubevirttemplatevalidators.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.kubevirt.io"]'
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    support: "false"
+  name: kubevirt-hyperconverged-operator.v1.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents the deployment of HyperConverged Cluster Operator
+      displayName: HyperConverged Cluster Operator Deployment
+      kind: HyperConverged
+      name: hyperconvergeds.hco.kubevirt.io
+      version: v1alpha1
+    - description: V2V Vmware
+      displayName: V2V Vmware
+      kind: V2VVmware
+      name: v2vvmwares.kubevirt.io
+      version: v1alpha1
+    - description: Cluster Network Addons
+      displayName: Cluster Network Addons
+      kind: NetworkAddonsConfig
+      name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+      version: v1alpha1
+    - description: Represents a KubeVirt deployment
+      displayName: KubeVirt deployment
+      kind: KubeVirt
+      name: kubevirts.kubevirt.io
+      version: v1alpha3
+    - description: Represents a deployment of the predefined VM templates
+      displayName: KubeVirt common templates
+      kind: KubevirtCommonTemplatesBundle
+      name: kubevirtcommontemplatesbundles.kubevirt.io
+      version: v1
+    - description: Provide aggregation rules for core kubevirt metrics
+      displayName: KubeVirt Metric Aggregation
+      kind: KubevirtMetricsAggregation
+      name: kubevirtmetricsaggregations.kubevirt.io
+      version: v1
+    - description: Represents a deployment of Node labeller component
+      displayName: KubeVirt Node labeller
+      kind: KubevirtNodeLabellerBundle
+      name: kubevirtnodelabellerbundles.kubevirt.io
+      version: v1
+    - description: Represents a deployment of admission control webhook to validate
+        the KubeVirt templates
+      displayName: KubeVirt Template Validator admission webhook
+      kind: KubevirtTemplateValidator
+      name: kubevirttemplatevalidators.kubevirt.io
+      version: v1
+    - description: Represents a CDI deployment
+      displayName: CDI deployment
+      kind: CDI
+      name: cdis.cdi.kubevirt.io
+      version: v1alpha1
+    - description: Represents a deployment of node maintenance crd
+      displayName: KubeVirt node maintenance
+      kind: NodeMaintenance
+      name: nodemaintenances.kubevirt.io
+      version: v1alpha1
+  description: |-
+    **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+    Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+    Containerized Data Importer (CDI), and Cluster Network Addons (CNA) operators.
+
+    **KubeVirt** is a virtual machine management add-on for Kubernetes.
+    The aim is to provide a common ground for virtualization solutions on top of
+    Kubernetes.
+
+    # Virtualization extension for Kubernetes
+
+    At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+    additional virtualization resource types (especially the `VirtualMachine` type) through
+    [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+    By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+    resources alongside all other resources Kubernetes provides.
+
+    The resources themselves are not enough to launch virtual machines.
+    For this to happen the _functionality and business logic_ needs to be added to
+    the cluster. The functionality is not added to Kubernetes itself, but rather
+    added to a Kubernetes cluster by _running_ additional controllers and agents
+    on an existing cluster.
+
+    The necessary controllers and agents are provided by KubeVirt.
+
+    As of today KubeVirt can be used to declaratively
+
+      * Create a predefined VM
+      * Schedule a VM on a Kubernetes cluster
+      * Launch a VM
+      * Migrate a VM
+      * Stop a VM
+      * Delete a VM
+
+    # Start using KubeVirt
+
+      * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+      * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+    # Start developing KubeVirt
+
+    To set up a development environment please read our
+    [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+    To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+    You can learn more about how KubeVirt is designed (and why it is that way),
+    and learn more about the major components by taking a look at our developer documentation:
+
+      * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+      * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+      * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+    # Community
+
+    If you got enough of code and want to speak to people, then you got a couple of options:
+
+      * Follow us on [Twitter](https://twitter.com/kubevirt)
+      * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+      * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+      * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+    # License
+
+    KubeVirt is distributed under the
+    [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+  displayName: KubeVirt HyperConverged Cluster Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAARgAAAEYCAYAAACHjumMAABam0lEQVR4nOydB3gb9fn4v3faw5Js2fKSvO0kkrMTsCFgBQKEslqIzB+6AAcocVpIKD9aWrBSaKEtJKUQEjLKKO0PLFo2hG1DEpvEcZYl7ynZkqf2lu7+jx2HXxLfOZJO077P8+Qp1ffu9Fo6vfd+30kFJCTTKBQKLgBgoUKhKAEA5AIAssRicVp5efnk62wAADL9zzv5r6GhwarT6QYAAL0qleqEVqs92djY6I3130FCQhJHVFRUcFpaWl5CUdSPEmMMRdFdCoUiP9Z/EwkJSYxRKBRFhw8f3o6iqImgYrkQF4qiHz/33HO3SqVSONZ/JwkJSRSpqKjgTlss0aCttrZ2baz/ZhISkgijUChKDh8+/DcURc1RUi5nmdx6ff3cc88ppFIpJdafAwkJSRipqKjgtbS0vBxlpYJHV21t7bWx/kxIogMUawFIIkdZWZl4+/bt/1NeXn4XACAp0PMQAGxDTqel3Wpnj7s9DA+CuLwIgkyaIQgAKAwgiEWBqRwqlV3M5TiKkzhUOgxzgxANBQAc2r59++4dO3a8qdPp/KH9hSTxDqlg5iBSqZS1c+fOR+Ry+f8AADiBnudDENsjp1qtz3f2pKEABJzCQIEgz63ZmdpfLyhkXJIiEAcp7mGlUnn/tm3bWoI8jyQBIBXMHGLSYtm6dWuVQqHYCAAI+Ifeb3eYdnX3gZd7+hkmr48V6vtDAHivzxCNVhfloT/ITBcBAGgBnopqtdoP9u/fv2v//v2fkxbN3IFUMHMAqVTK2blz5//I5fJfTyfEBcSkxbL1pNr2QldfRrhlKuUl9e9ZtRSUC5Nzgzz1u2mL5mS4ZSKJPqSCSWDKyspypi2We4KxWHpsdtPunn6wu7ufafX5mBEU0XdNetrIpsJc9IfZmWkAAHqgJ2q12o+mLZpPdTqdL4IykkQQUsEkIFKplLtz587fyOXyrQCAgLc0XgSxPXi8xbarpz/sFsvFKOZytPtWLfVfmSbMC/LUY0ql8hfbtm1ripBoJBGEVDAJhEKhyFUoFBunLZasQM/rstlNL3f3o7u6+1h2vz+SFsvF8MvThCObCvMQhSRLCAAIWBatVvvptEXzsU6nI+udEgRSwSQACoUiqba29jEAwEPB/Ch9COLc1Hzasrd3ID2yEgZPDps1tH/VMte69NSCIE89qVQqN23btu1whEQjCSOkgoljtmzZkl9VVXWvTCa7CwCQGeh5Q06X/ZU+rXdfTz+tz+EMOEwdA5AfZmXoHyjMg67NSJu0aBiBnqjVar+ctmg+0Ol0nsiKSRIqpIKJQxQKBa+2tvZxAMAvg/nReRHE8df2bstTrZ3JTr8/4PPigbKU5MG9q5Y4Svm84iBPbVEqlZu3bdtWHyHRSAhAKpg4QqFQ8Lds2bKxvLz8EQBAwNuaQafL/o/eAe++3gHaQHxbLBcDvT5DpK8uygPXZ6anwMH5aOp37NixTaVSHdbpdO7IikkSKKSCiQMqKiqgnTt3/lImkz0TTFTIgyCOP7d1Wf7U2pniQpCAQ8CJwMpkwdDuFUtsq1L4JUGe2lZZWXm7SqU6FSHRSIKAVDAxRKFQJE9bLA8AAAJu0qR1OKcslv29AzSt05XIFstFuVqUOrS5KB+6KStdQIGgQJWvBwDw0fbt26cygzUaTYSlJMGDVDAxYNpieUgmk/0pmKiQy++3P9PWZX26rSvFM8cslouxhM/Tv7RisfXy1JTiIO/b71Qq1QOVlZXHIygeCQ6kgokiCoUiZcuWLfeVl5f/YrrnbUAMOJz2/T393v19Wvqg0xVwKcBc5MrUFP3monz0h9kZAhoMB/pZeAEAB7Zv3/7S/v37D5AWTfQgFUyEEYvFUFVVVVlVVdUmiURyezAFgF+PjBlf7OqD3xsycP0oSjZoP4dsFtN4T36OsypPwsjlsIVBnNrb0NCwa8eOHftUKpUxgiKSkAomstTU1OQolcpdAIAfBHPeSZNlYlPzKd/hcaMoctLNDagQ5Pz1gkLtE9KSNBaFkhzEqS61Wv276urqHfX19WgERZzXkAomzExbLJdNWyyVIPC+KugJk9m8u7sf2dc7wPejKNlaMggymAzT1pIC123ZmbQCLicYi2agoaFh944dO/aoVKrxCIo4LyEVTBipqanJUyqVuwEA1wVznsnjndjYdBL5z6A+NXLSzQ9gANx/X764p7oorzCY6m0AgEetVtdUV1f/pb6+HomgiPMKUsEQZNpiuaKqquoBiUSyIQiLBWk2mi27u/uQV/q0PB/pYwkruWzWyP2Fucimwjwqn0YLRnEPNjQ0vLxjx46XVSrVSARFnBeQCoYACoUivba29g0AwLpgzpvweMarjp5E3x0ykBZLhIEBcP1lyaLehxcU5QeTEgAA8KrV6icrKyv/qNFoSIsmREgFEwJbtmwpnbRYZDLZnQAAQYCnIUcnTJaXe/qRV/u0pI8lymSxmGO/KMj1bSrKg4V0ejDO89Mqlerl7du3/6uxsdEUQRHnJKSCCQKFQpFZW1v7DADgxwCAgBXEmNszds/RE9AH+uFgnI8kkcHzpGxh9++lxTnBNEQHAAzX1dX9rrq6+lWNRkP2DA4QUsEEwJYtW5ZMWyx3AAD4AZ6GfDdhtOzu6kde79fxEUBaLPGEiEEff6Awz/tAYR6UzmQE0y+nddqi+WdjY+NEBEWcE5AKZhYUCkVWbW3tXwAAd5zZzgfGsMs9es/RE/DHhhHSYol/fI8tKup8snSRGA5idtSkYVpXV/dEdXX1Xo1GQ/YMxoFUMBhs2bJl2bTF8v8AALwAT/M3jButu7v7kDf6dQIkCIVEEnuS6TTjpsI89y8KcoGYzQqmZ3HHtEXzemNj41gERUxISAVzDgqFQlxbW/vs5H8GY7Hona6Re5pOUg8YRlIiKyFJFEAeKi7oeHapNIMCQYE68CeZqKur+0N1dfUujUZDdtibhlQwZyyWFdMWy+3BjFhts9gsT7V2+P49MChASYtlTpFEpZo3FeY5tpQUMNOZjGBKELpVKtWe7du3v9rY2Djv82jmtYJRKBQ5tbW1zwEAbgvmsxh3e8yPnW517u0dEJGKZW7DoVAsNbIFhq0lBZkUCArGR2Ouq6t7qrq6+gWNRjNvO+zNSwWzZcuWVVVVVZtkMtnkVijgoe2tFqtlV3c/8s9+HdPk9cZy/AdJlMnjsIwb83Ncd+flMLJYzGC2wr0qlWrf9u3bX2lsbNRHUMS4ZF4pmIqKCtbOnTv/JJPJHgzmbx91u82/OdXqfKVPm47Os8+M5HyYMGz73aLioUcXFqXTYDjQlIVJrHV1dc9UV1fv0Gg0zgiKGFfMix+LQqHI37Jly6by8vIqAEDA+2n1pMXS1Ye8MaBjmr0RHbFKkmBIWCzjPfkSZ1V+DlPCZgVj0Qxs37796f3797+u0WgcERQxLpjTCqaiooK9c+fOZ2Qy2S+DOW/Y5TY9ekrjeq1flz7XPyMSYtAgyPHowiLd7xYVi5gUSjBRJ5NKpXqosrLytQiKF3Pm5I9HoVAUnmOxBGzGnjZbzbu6e9F/9Q+yLD5fQs0VIoktWUyG6a78HOfG/Bx6fnAd9jTTzclf0Wg09giKGBPmjIIRi8W0qqqqH0y3TQi4HwsCgOetgUHbru4++NuxiWCeQCQkM4AB8NyQlT6+uTAfuTYjLT2I9h3OhoaG13fs2LGroaHhpE6ni7Ck0WFOKJiamppypVL5EgBgWTDnfTY8Olx19ART53QF46wjIQmI5QJ+7+6VS6iXpAgkQZ76plKp/NW2bdtGIyRa1EhYBSMWi+lVVVU3TLemDLgfCwKA93/7dZMWC3Ro3EhaLCQRBQLAtz4jbXRTYT5yY1a6KIim7y6tVvuv6fnbxxLVoklIBVNTU7NGqVTuBAAsCeY8jcVquLfpJOPwuDGYzEwSkrAg5SX17125BFyWmhLwyJpp/jM9f9sQIdEiRsIomGmL5aZpi+WqQM+btFg+04/YX+ruQz/QD5OKhSTW+O+UZBt+UZgLX5EmTA3CovFotdp/T1s0RxLFokkIBVNTU1OhVCpfBACUBnPeabNFf2/TKeZ3E6TFQhJ/rE1L1f5j9VJfHocd8NjgaT5QKpWbtm3bFvdaJq4VzJYtW+RbtmypkUgk8kDPQQDwHNAPO3Z29aEfG0ZIxUIS7/g3iDMNDxTmQVeJUlODmITg1Wq1b+3YseOpHTt2tEdYxpCJSwWjUChKa2trdwIArgzmvOMms+H+plOMo0YTqVhIEo41qSm6fauWuhckcQuDOM0HAPhHZWXl71UqVdxFneJKwWzZskVWVVX1qEwmqwQABJTo5keB5xP9sP3Frl7o0+FRMipEkuggN2Wl6zcV5sHXZYhSoAB/BwCACbVa/a/9+/dPWjWHIixjwMSFgpFKpWDnzp33yeXyvwEAWIGe1zRhMtzffIrZbDSTioVkznFpSvLgnpVLHEsEvOIgTz1QWVl5l0qlGo6QaAETcwUjlUqFBw4c2C6RSH4WyPF+FPV8ODTs2NnVCz4fGSMVC8lcB12fkaavLsoHP8hMT4EDn+00qFKpfrd169Z/6nS6mM11iqmCqampKVEqlQcBAGkAAD0AIHO24xsnjIYHmk4xT5gtpGIhmXesEPCHdq1cbL8kJTlgi0atVu8sLS3dHFnJ8ImZgqmpqVmiVCr/AwAomn7JON2u8rzaDR+CuD/QDztf7OoDX5EWCwkJuEqUqt9cmIfenJ0hoEAQO4BTnpBIJE/pdDo0CuKdR0wUTE1NTb5SqTyF0U3OdO6kxA6rzaJoOIacIi0WEpIZLOYn6d8qW4ks4iVlz3LY5IM7Wa1W/7a0tPSZKIo3RdQVjFQqZR04cOBriURyKcbyBAAgxeByef7c1u3b29NPt/v95FB4EhIcqBDkvk2cOfr4ohKajJ+ENUDOON1kzadWq59Yv379M9G0ZKI+bXBkZOQ1Pp9/Pc4y47jR3Hd1fQP3s+FRlhdFyYbaJCSzgABAVVusvN3dfdQsFuvEymR++jkjd2zTiXu0yddEItHVEolEq1KpjkdLvqgqmOeee+628vLyJ/HW//T1N947PzwwYOJOmXwxj3CRkCQKKADUD/TDWV02u3Z9hgihwTALADA2uSM49ziZTLYGAPBpfX19VELYUf0Royh6anLriLX2dN233sc++5I2pZQXLuoBLHZRNGUjIZkr5HJY2kNr1ziyWcwFOIfoZTLZQo1GY4m0LFHbgrz11lv34SmXN0+1+B777Evq9zKNj0fd201CMlfotzslD7dqPFYf7sjszH379v0mGrJEZYsklUpZL7300gGAkSTk9vnA9a++gdg8nv+TxelAQHqGDUBQwDOLSEhIzgBBoI3HpwsbLSbWDUIRTIFmblQkEskqAMCe+vr6iE42iIoFU1VVddO54edz+WntOy6D1XZ+pAhF04B2oDcaspGQzDGQElFSH4BARpfTTtk12I+XxctSKpUvicXiiAoTFQWjUCh+gvX6p51dPlWLGjv1eXxsJXA4SCVDQhIESQzqKSGH/n0L2doRPfzB2DCektmgUCiC6lgQLBFXMBUVFZBEIsH8I145Nmu0jAbGRvwRE4yEZA6SKWCiF2bD/6W/G4x43Jh+zaqqqjsiKU/EFYxcLr8SazaRD0HQzzq7cb1QUxiNycDvH4+kfCQkcwUWjXJKyGHkXPg6AgD87ugwpoKRyWTXS6XSiEWTI65glErlLVivv6tpMxmdrtkrQxFECIwTxkjJRkIyh0DyUzl6CADMoW+fG8fwtkm5CoVihlIKF9HwwWAOQfv3ydOBRYjGRqnTXbtISEhw4DKoGgGLthZvfcjtonY47Ji/I6lUuiZSckVUwSgUikltKr3w9UlV+kl7Z2A9KpzOPGAyRS21mYQkEcnkM30X6+f7tXEccytUWVm5PlJyRVTBiMXipVivtw6PeF3BzH4e1AkBikY865CEJBFhUuFWIYc+W0X1FA1mI17Q5BqxWBwRXRBRBVNeXo45yvXU8HBw7+txFwCTcSRccpGQzCXyhBwtDEFpFzuu02mnO/yYOia9vLw8LxKyRdqCwZy8eHzIEHz4eXSULH4kIbkADp3SmsKhXxHo8W0OG6YfpqysLKi57oESEwtGPTwS6DS7/8NuywN2O+mLISE5hww+yxNMo/xupwOzv5JEIlkeVsGmiZiC2bBhAxsAsBBr7dig3hvCJSlA288CKOoiLh0JSeJDhSFDKoeO1WQKl3Z8CwbTX0qUiCkYmUx2BdZso0GLBQzbbIFOrzsfp3MhsFgGwyEfCUmik8pljFBgKCOYc7qdDszffMJZMAqF4lqs199vbSdWvTk2SrZyICEBwJnBYwY6wuR7epwO1I1gZoiIa2pqcsMi2TlE0oLBjK1/3dMXeHgaC4tZDNzuNkLXICFJcNK4jMNsOqUk2PN8KEo5YbXgJa5iJsUSISIKZjrBbob/BUFR8GlHVyj+l3NhgoF+L5ndSzJfgSFoNDeFHXJ6/3cWI2ZEVqlUhj3hLlIWzBKsa3eOT/gsbnfQZt0MbNbFwGYdIHwdEpIEJJVLN9CpcLDjZL/nsNmE93C+RiqVhlUnRMqCwQxPn9Qbwvcm4+MxG4dJQhJDPJk8ZmhBkmm0bifD5MPcSHBlMhlm5DdUIqJgpFIpZoLdiVAS7PCYGBcBv5+0YkjmFUIO/RCHQcVr5h0w7Q47pobBMw5CJSJDzWQyGaaQLcPD4Xw/Hhjo776u7FJRNos5rxpTddkcrm/GxjHL8ucDV4lSO+8vyL0w4oFavT672mKF39QO0vUudyAjVRMKCAITeULOrPPbA6XbaadeysPsYjv52/13ON4DRELBlJWVcQAApVhrh/q13rA2GjcZlxYAtPOl1csIa/REwuL1ORd9+vXAkNMVsT4e8UoKnTb2dvkqZjKdhrVNmIpQPr14kWtXd5/p6bZO5ojbQ8jnx6NSXVeJUr2rUwSubBaTQoWgqA8rPMvXlon+Vo8tLPkqp21WBKTP/C0qFIrycFz/LGFXMBKJpBTruh1j4/4Jp5O4g/d84NeajtGevewSD5tKIbQvTSR4NGrqC8tKG25raJp3CuauXIkxmU6b1cHJoMDMh0oKmOXC5LGyrw4yQp3/tVzAt3y05hI0k8XkAwCSQhY6PPg+VI+GzSrrdNjx8smWSaVSoNFowvI+YffBKBQKzJTjD9s6POF+r0kc4+PC3zSdmHe+mFvFmStXJQu6Yy1HlLH/ojAv4IfUpcLk1P+UrzJAZ1oQBcX/k2SNflFRRp9WLjHn84mxpgGXM+i8FzwMHjdlwovr6A05QnUhkXDyYvpfvuruiYxpiaL8F+u/NescTqL5NYkG/eGSgnmVC/RQcf7p4iSOJJhzbhVnZv4gQxRUL6EyocD0v2UrhSl0ergt7pDwA2D6c39XWMcpowBADWajG2tNKpWGzdEbCQtmRgTJ6/eDr3p6IxZWRs2mxfs0bbpIXT9eUUiyMhfzkzpiLUc0EDHoI0+VLgxpS3ibODi/6NOLFyHRnHp6MT4eG55wIkhQijUQmqxmTLcCXpAmFML6IVZUVEz+z4wtUuvomNvp9UXyaUDfe+SYHw3BFE5kKBDE27tqqfHMQ25uc09+jolDpWaFcm65MDlg63ZBEndEnpaaEsr7RIoPx8Iaff2ew+YJTLdFOEPVYVUwcrn8ksk93IWvnzZE5gM6l6GhoeTnWzu0kX6feOPSlORL1qendcZajkgCA2C5ryA3ZAdnHocd8P33k5zsmEWJsDhqMXW12G0RGb9o8/sZOpcT66EctwoGs4L62JAec68XVhBE+LvPvzLafPgTv+co0MMLCud0hfmjC4s0+Rx2yD8yGIICvs+XCHjOUN8nAnj+3N/NjOR2rcOJGU3KqqmpyQ/H9cOtYDCLpTTDo8QqqAPEYTAUvdbeNRyN94on1qWn5a8VCU/GWo5IkMVkDtdISwjd7L12R8BbSCGdHjfbzW9NE+N6jzuiw6M7HdjdU6RSaVgKH8OmYBQKBQsAUIa11jQ4GHkL5gzcvU3N9ii9VzzB/PelKydNe1usBQk3GwtyLAwKJaiubRdybMIUsP+vw2qLmwzg90YNwbeWDZIupx1TB4RrlEk4LZglWFm6PRNG37jDGbUv7WR3L/89XTirKhODDCajdGN+zpzKB6JB0MS9+TmE7x2VTh/wsYfGjXERKOhw2MYaLSbMXP7wvo8d7++Vl5WVEVZw4bRgMAscP2hrj+6e1udNrz7w2aAfRePG1I0Wm4vyoDMpDnODx6Ul7WI266Lzfmaj1+6wvDdkCFhJvd6nS3H6/TG3BHdoe31ohGoFz2XM66GMeDA3GDyJREK4BCdsCgZvyNrXPX1RT+Ef7O3L+0/vwLybo7RUwC+5Iyf7cKzlCAc5bJb+t4uKCWWuIgD47z5ynBaMxvWiCO3Frt6YJm2etFpMp2zWoHrtEuGw2Yj594ZjlEnYFAzWiJLJL/bTjq7oWxIoKtx/7HjMn0IxgPL66uUSBgwnvKP7voJcKxWCCFWMf2kYddePTQQ80uMsT7S0czqstgki702Ed8cMUQ2VH7WYMbdCEokkPhSMVCqlYFVQt46MuF0+X0ycZl9q2rhNRtO8GzdLhaGch4oLxmMtBxFYFHj0nvwcHtHr/L2rJ6TtogtB6Jd9dZD5wZAh6krG4HHb6ozBK0UiHLGYvH505kcVjoS7sOzxFArFCgDAjKKw04aRmCUt+d2uzF99/tXRw5W3riZ6rU8No8O/b2mLitl8qVDge3H5YkJjPKuL8uh/bu9yAADiJiISDE/KFnZnMhmYEclAaTaazR/qR0IuVBz3eNk3HzrKfrA437BNugDm02kiIvIEyku6Pp8HRSLuezkXB+KnaV1OJI/FvtDgiBsFg5lg1zyo90WqqVUgNJxWZ9dfuWa0IkN00bm9s3FZajK3126fvOk44ZMOm2ajCflVUYG1JIkTcnsACZtV9Li05OsnNR1rwytd5CnksAe3LCgk1LbRh6Dee5tOhiXE+3xnb8bznb2ghMsZz+GwUDoEz1pwyKTAyNuXreZDAATte+x2OlxfGscFlBjUfnQ47CCPNeN5JKypqVm8bdu206FeNyxbJJlMhjnuQDM6GtseLX5/1t5jxwlvk5KoVM4T0pKobLcQAOCdXb2E768/yBasyGYxe8MjVfS4vzDXDgNAKDz7vt7gbjaZw2q9ddjswi+Gx1I/NowIZ/v330FD2ueG0ZACDO+MGuBkKi0mhWWd2Bm9QC6XExplQljBlJWVTX6Rl2KtHdVFLcEOl/+ePEUfsDsIy7GpME8gZjGj4jh+tU/L1DtdZoKX4VcX5REbchdleFSq4a68HML9V57v6IlpJfSWEy1cp98fVHrGoNvl+s5spLqR2GRXdDmwJz7K5fLriVyX8BchkUhkAMMc1FutyLDNHlVnFRZOm13y24ONp4hehwrDrJ/kiqNS52Tx+ZgPnWghnD/0UHGBAALAGB6pIs8zSxb1pTGCm7V8IafNFvs3YxMx9T1prDbBX9u6rYEe7/Ij3q0dmkkTAnZgT12MOO1OG55mu0KhUIS8EyGsYPA62L2naYublP03G78TacwWE9Hr3JUnidqTsVanz2iaMBFSDiwKJXtzUV5C9MlZkMTVPVCYJyNyDZff734xDNvLcPBUa0fyM21deh+CuGY7bsztcd178uSYzuMS6rET3qKC2eejal2YzzTadJZ+SBD+wYjFYswmwf9Vt8VN2Tviduc+8+3hMaLXWZDE5T26oDBqw/cfPaUh3MHs0YVFAgYMx33pRI20xE607+0Lnb3+/b0DM9qFxAIvitJ+e7o1c8ln9Y5d3X2GHptjUtFPaRAvgpjrR8cntp5QG7M++Ix22mWNi2jf58YxTAudSCNwwjcwiqJNAICV577mRxDAfOIpjw9B4qYRN4PDGdD++sH0NAadUGW3F0GsvHc+obsQJCoV4l9VlBvWilIJZXVu7+j+8uGTmqvDJ1V4yWGz2vpvWCcBABCJ0vlzP/rCNeBwRjzSR4BxDpXitPv8GWejq6lcur5ElBSWUSREKeUm+V9esHiGYaBWq/9RWlpaFco1CVkwGzZsYAIApBe+fsow7Iwn5TKJ224XP1x/kHBjJhoMJ92dL4na9u8Xx06xXEE6DC9ka0nhimIuJ14jSt7XLlnuJqhcwHuDBlucK5dJhHafX3xWucAQ8OSmsOOi7+8krTYb5PTP3GESaaFJSMHIZLLLJrf6F76uHolxeBob+J/fHEpqt1oDdr7h8bNcSdiaL1+MDpud/6Z2aNZ9fAAkby7Kj8vSibVpwj55mhDTjxcMf+/qjZseuoGSymE4GFRKcqzlOIsfoHCn0461TSqtqKgI6TdN6EvBS7Br0g3FPDyNCeLP3dd0nHCdTpkwmVeRJoxaOv7zHT2TTzxCEay78iRp2Sxm3I052VyUT1gxfD0yNvHVyFis5xYFTTqPGXeV791OB1ZiLF0ul8tDuR5RCwYzCadtdCxuzL4L2d/UTA9DKwfKi8tLiVoVAXPCbEn6Z5+WkJOaR6NmvLC8NK62SekMuuNWcSahbvkIAJ6fHzkR8cZM4SaZTTckMalxY72cpd1hw3yQKZXKkBLuQlYwCoVCAABYjLV2RKeL2o8vWIxGU+bbXT2ErZhSPi/7ylRh1HJMtp7SJE14vIR8Pz/KzrxiVbIgPCP7wsCNmel0rByqYPhXn9apdToTynqBAPDmCePH93IuOBbMJCEl3BGxYDA72BmsVp/R6YqLsBsOtH1HjoVlC3dvQfQmt465PZxXegeIFlwyHi4piJsBdWVC4g/wF7v6wiJLNBFy6XYWjRLxbnWh0Omw+3FS/RYpFIrUYK9HxILBTL45NqiPmxsYj6/bO/hHx8YJWzG3ijPpAho1ah37Xuruo3kRhND7KSTZuYv5PMKZzeEglUEnVAj7zqB++IjRFPXRrhAA4Lr0NOcfZAssr65eZnt19TLHYwuLvfI0oY8KXdz/nxGHvpezeFGUMuB0YOoYsVgc9OD9kBUM3njJ08MjUYuwhIrf50v51cefE+54x6ZQOApxVtQUTI/dwflrexehjGQKBAR7Vy2dmLyXwidZaGD1IAmUSUV7z9ETUd8aLeXzbNobr5k4cGUZ63FpCe/neRLuz/Mk7D8uXkj7Wn4ZtWndlf58Dhv3D2PRKCYekxZ3vpdz6XBg78TLy8uDjvaFrGBkMhnmm53QG+JewUzS2NaWV6cbIpzhWpUfvW3SJH/QdAoH7E5CIedLUwRXrk8XqcMnVWgMOkN31e3pGfCYvNFtZnZLVvpwnfwyajaLiTv5camAR2lbvxa9Q5KFaQWk8xhx//vAq6wOpYVmSAqmoqKCgufgPTGkT5TBZ0n7mo4T9sVcKkxOWSNMiVr5gBtB6Lt7+oh+xvCvFxSESaLQaRwP2UeO7uzqjeo2Y2Uyf+zdyy9JFdBpF3XO0mEYfvWS5aCIyzlPycAQ8GQkMeOmhAaPLqcDU0aJRBKdLZJcLr8CADAjVd7m8SCd4xPxmGSHyTunWzgDdgfhPi/bl8noIIpzsff1DtBNHi8hua9OT1uwNk0Y0wbhHxtGgNET/E6tdmDQ2Wq1RdVJ+sSiEgdWUAOPSSXzweWrUfo5/anyhZwxGIbiolZqNjocuJXVxRs2bAjK5xWSglEqlZgJdp+0dxkRFE2YnASH05n6my/r+oleZ3WKIG2tSEi4WjtQRt0e9m9OtxLt9cJ6s2zl5EOCaN+ZkDF7fWBnV3CpOcMuN7j32Kmobo0KOGz1zdkZQXdFXMhLolwtSpv6sTKoFEs6j0moFUW0MPl8FLzKaplMdlUw1wrVB4OZdPNNX3+814LM4M0jTZnq8QnCldZ35Uqi2shjT0+/SG22ErJiREzGynsLcnrCJ1XwPNPWBVTaoYCOtXp94GdHjgNLdMeP+/auWurBKokJhPLpUHwGb8rgj/vt0VkazEa8hLugJj4GrWAUCkUSAGAF1tq7mta46QETKCiCpO5vPkk4EnRHjpjNplCi9vejAMB/7+oh3Ptkc+FUqn7MeqjY/X5Q2XgMPN3aMetx3TY7WPZ5PfhseDRqsk1ymTC55ypRatC+h7MUctgIBAFfOi8qxfdh44jVjJdCEFkFgzdgbcRu9+rMlrgOv+HxRvNxhsXrJZR9TIMh9o5lsqiOuXijf5DTZ3cQ2potEfBK75Bkfxk+qULjsZZ2sOyzevCUpgN8PjwKjhvNoGF8AvyzTwvuPnp8Srn02KPfAfQeglFCCIJATjJnmArDhMewRJNmi9nvxe6ul6NQKAKethl0ohPWgDUw1X93yEO05D5WjJotoj83HFH/8crLCXVUu68gN2ObpsM85HRFJfnL4ffTq4+fnvhoDWZL5EChvFG2ovC/g/pBN4IQGtNKlJNmy9S/eIEJw6N35+cQmkhh9HmN2QImoWvEAjeKUPpcTqSYzZlhhEil0kmLLqDIadgsmNaR0YTZX2Lxt/pvU4fsDqKtHGj35Emiut34WD+ScXBsnJDlBANQ+FBxQcJPgww3DxTmGWEACFnlWp+LQrTeKlZ04iTcBdMfJmgFU15ejtk+r2FAG/cJRLPhcLrStx9qJBxR+WVxPo0Jw1Ed+P/oqVYq0TD5IwsKRSl0Wty1c4gVFAiYtpQUELLIxz0eS4PVGPPG96Fy2m7FS7gLuIVmUAqmoqKCDQDAHIp1bFAfnz1gguCVpmaqB0E8RK4hYjCSHl5QGNVO/ofHjbwPh4YJlT4IGXTx35aWtoZPqsTm1wuK2iVsFqEt457BAZsXoPFc+DsrXU474YS7oBSMXC6/GivUZnQ6fQMmU0L6X85lwmbL+OOhRsLlub9dWMQR0mlR9UhuPn6aY/f5CL3nT/PE8qV8XsxLCGJNGp0+UrOohFCfmgGX0/rRxEjQ1cfxRLfT4feimIZxZk1NTUCp4EEpGLwEu/da241oAsX4Z+OPn34hGHO7CdX6cKhU/u2S7Kj2xOl3OJP+2a8jZH0BALgPlRREdXsXj/wkV2xiUSlZRK7xwdiwH01Q38tZ3AhCUdtteBMfAwpXB+uDwVQwh/oHEt56OYsfQUT7jzYTzsqtys+Jekn+C129NAQAQkrmxznZuQuSuCfCJRMEAFidLDBvEGf6FOJM5Lr0NFMyjRa3DckAAK77CnIIJa24/H7ngfG47EsdNI1mI6YJE+jEx4AVjEKhEAEASrDW3lG3zamn3r6m49QzuWyhsyKZL1wnShsIn1QXR2OxcfZ09xHqFUyD4bTdKxfrifYAnmSDOMs6fPO1xiPrruCryldRa8tXwQeuLBPob7oW2bFMNsKiUOLOb3dXnuTEQl5SLpFrvDE8aJ3weRPW93IujWbcZ+3VUqn0oruWgBUMXnhaZ7a4xh0OYaDXSQS6RkZEr51SE65R+uvSRUwoylmyj55uFQy73IQyiq9IFV7GplBCLp8Q0ukeVdlKs6p8JTuNwZgR5mVQYPZDxQWi5nVXuHLYrLiZdsCmUIx/Kl1EqF5ozONx/NswFPUmWJGiy2mHrNilGSyZTDZjZNGFBKxg8JrNHBsais0w3cgCb/3gY5rb7yf0hF0m4IuuSU+LWhHkJBavj7Wvt59QM6nn2rtHHH5/yMPe9q1aatsgyeJfrPZmIS+J/+7lqy1ErcVwUSnJGs1kMfKJXOPA+IjPjUZnKF80QAGAO512zIekQqG4aD4MYQvmtIFwY7i4ZMJuz/7fFg3hcPNdedEtgpzk5e4BmsvvD8mK0Tmcphp1e8gOzrvzJCM/zM4IuJXCcgE/6y9LFhEeiBcGkE2FeYSmbCAAeD8YH0mYbgKB0o3TH2byGXqxcwlbMKcMw4T6qsYze48cI5w8WCnJ4vJp1Ki2RNA6nZw/aDpCyrnf0zvgdiFISE77FDrNsXfVMm6wwYNHFhTlZzIZhCvaiXBtelrT6hQBoS5cH4wabDq3K2ET6/Bod0TYgtmwYcPkTbMAa+34UOIn2OFxuLcv+ave/sB6CeBAgSDW35ctjnrPlb+2d6d12+xBlT7YfT7Tvp7+kH8gm4vyvRQIhOLcpP0gUxSzbRIMgP1vy2R8Ii1k7X6/a8+Qds4pFzDlh7HhfS5LpVLprA/hgD5QmUxWgVVP4fB6ka7xiTnhLceBvvmDj70owTT8n+WJs3LZrKhm9/pQlPpSV3CtNX/f0m7Uu9whVf1CACCbi0J3X5SlJMesZcQt2RlDi3hJmA/QQPlyYsxv8nnjctYRUXocThQn4U6oUChKZzs3IAWDNyL2vdb2iURqohMKrYbh3AOd3UTHxFLvjkFezCt9WpbZ6w0ou7fDajP+vbNHHOp7Pb14kT6NQQ85esKlUWP249xUmEf0u0HeHTXM2d+BH6Bws8WC+QCQSqWzJtwFasFgXuRw/0BCTdQLlT1HjhG+xsYYOHuNXi/z9b7Asnt3dvX5EABCclDmsFiWRxcWiUI59yx+hMAMEwIs4SedWJeelkfkGodMRnu70z4nrZezfGcxYeqKyspKYgpGoVCk4SXY/belNW5yGCLJR23tSa1j44RaqWWzWan35EmimngHpiYf9tL8KDpr5qzB5Z54rV8bcjZ2ddGUBUAoetJiscYi3cGza8USmEg7BS+CeF/Q9c7ZQMdZGizYGb0AgMvKyspwfU+BWDCY0aNhm901ZLXOqQQ7PLx+P/PhTz4jnK38/PJSFgWCojrwrMNm5zzf2Tur/2fLCbXdHOKMIQYMe6qL8ghvD+pHie5Cg+cqUWr/ZakpmBNKA+Vb84RPOwcjRxcy4HJSTD7MW5cpkUhwG7UFYsFgKpgm3WDMnHKx4JPWdnHTkJ6Qo5ZLpabdmZMdVWfvJI+3tCUPOp2YeTHNRtP4m9rBkCuHd61YMsqhUgmN4mgcN441jBuj/rC6MyebsNX07uhwQvdBCoYOhx3z85otXH1RBSOVSjEVTMvISFxkX0YReM+RY4RvyJ/nigklc4WCw+9n7u3BHpz/fGdwY0PORcrjmu7OlxCqOgYA+O5pOhmLH6m3UpxF6Ltod9gsx6zmOe17OZcupx3v8wpdweC1xzs+NHe95ni8daqFNepwEmoauzY9jbcqmR/d1vhnxpzQbT7feT6zdqtt4i3tUMiO+s2FU2FpQsrhPzq9pdUS/a02l0o9mUSjhlzUiADge3agZ85l7c5G2C2YDRs2pE4+qLDWDvcPEO09knBYXC72z1XvOIm0p4QBoL92yXIEDkO1cjDoXW72nY3N7rOyexDEddvhJsiNICE5OFcI+Kb7CnMJ5UChAPgeb2mLSd3OAi7XSsS5++XEqFdjt81538u5tNhw8zZXbtiwAfNemFXByGSy1Vh5Lg6P1zdosc6rD/csn3V0JndPGAlVK0t5SWkrkvlEG4wHzUeGYUG71TYl+6GxCbvaYg25oXWNtMRFgSBCPU9OmSz2VqstJr2EDG4XIdnrTVGdUBMXjHg8wO7HfC4yZTIZpitlVgWjVCoVWK+/earFiKDonGioEyx+FKU/++1hopEg+DcLi6MaTZoEQQHl8Zb2yff1/+ZUa8jm/Y2Z6cabszNCrrY+y+9Ot8asEn/Q6Vpu9flCaslxymax1RnH590D1g9Q+BvTBF5dUiXW6xfzwWCOiD08oJ3L5QEX5dVjx9l2r5dQDtCPxJm8NAY96o9BlW4o5cETLYNHjKaQB4E9WEyoo8EUzUaz4SPDSCwH9bE/1o8EvU1FAfA/N9BDnW8RjrMcsZgwfa94ybi4CkahUOQAADAjBO9o2uZsgWMguHw+5q8//oyQgoEBYL6wvDQmU8b+3tkb8rhCKY9rX5eeRiiD24eg7o1NJ2MefXmhs3dShqB8id8Yx3xdTkfMZY8V31lMfhyzc+F0Uu554CoYvPB0v8lkm3A4UghJOQfY/d3RjAGzmVCV9O2S7JwiLiembQqCAQIA+WVRvjeUiaDn8v6QwXHcZA64Z0ykODQ+kf0HTcfsQ7HPwYMg3p26/qg65+MNs89HGXJjJ4ZLpdIZ0SRcBYPntDk+ZIh6Hke8svfIMaKfBXxXriRhErXuzBGbfpIrJux7+1tnT9zcQzXqdtlTrR1DF7NkOqw27+3NzSODHvecaXAfKh127HA1VkrLbBYMZgr1Sb1h3oWn8dh7tBlGCYab7y3MQYhOZYwWvyzKg7hUKiH/2+fDo4ZvxybiqWct9HhLe9aKz78xnTZbDBcu+hDEu7en31H29UH3MPDMe8sdnOkPg/lQxLJgcE1dvAS7U4bhOdNvlCjDNhvng9Z2882LFoT8gxExGGnVhXl9O7v7CFX0RprVyQLrpcJkQorB5fc7NzWfjsvoy3GTWbTks3p0VbJgNJ/D4jFgmGr3+32HxiYoI24PWyxgmSEIECqJmCt0OrA7gARswdTU1CQDAIqw1o4NDs2pESVE2XOU8DYJPLtUmkSDoHieFQQeLM73E+n4Nslb2iFXl80eT9bLhUBNRlOaSqdnvDEwSHln0MAYcXumHsLpvHnr151BhxN7GBsAYGFNTc15ShjvhrkGKwXc5HS5B0zmkMObc5ED7Z2cU4ZhQtEgJoUi/FmeOOptNQNlYRLXrJBkEf2F+Z7vTMzU+kw+c4RBheNZMUaVMa8XNngwA8nwhcMZMRWMUqnEzH95t7VtHCUYQZhr+FEUfujDA4QjCz/LlcSN4/NCdq9c4qTDMCEF8+bA4NhxkyXhthgUGHLnpbDnvWP3QhrMRsx7XqlUnpcPM+OmFounuiZeg3XyIQJNieYyX/f0pjQMaAml/l+ZJhSUC5OHwydVeFidzLdWpAkJZe2avV7HlpPqhFMuk6QnMV0QBJH3/QUcsZjwDI1rp3XIFDMUTHl5+eQqZn+Q/7Zo4tpPEEv2HGkiaoHQdiyVEapxigS3iTMJRw1f79N5DC53QiqYDB4jYdIIoskR/IS73GkdMgWWBYMZPRq0WOwTTiehsZpzGdVpDUNvsRJSEJcKkwvKU5LjKvGumMshFPVBAHDv7OpNSN8Ln0WzMmkU0ueIgQtBKP1OB6azVywWLz/731gWDGb+S5NuaL6WXwSE3eulPvb5l4QLGO8tiP70gdng02iEOhe+1NU70W6zJ+QWI4OMHM1KJ3aTxPOGNM5QMGVlZZgWTMvwSEIkg8WS146dELSPjhHaRt4mzmJwqZSARo1EA5cfCXnrN+xy2x873RazkgA6DPvWiVKN9+bnuB9ZUGjfmJ/jXytKdVGhi+962DSKNYVNI3O+ZqHTga1gysrKvrdgZjhqJBIJ3ojYedmeIRjQqezeY+izP8AMwgUEj0bl3ZqdOfp6vy4uKtZH3FOFJyFZIPt7B7xWny8mCuaGTJHxpRVL4Bw262zF9lllQemx2T0/OXIcNIwbce/p/DSOB4KgeTGWJ1Q6nQ5MTS2RSL43Us57Om3YsCEFAIA5n7d5UE8m2AXAGydOUeweD6HP6t78nLixFj8fDq27p9uPOF7u6Y+J7+Wl5YtNH665VJDDZmHmrhRwOfTDV62h/n5RMWYyRxKTauczafNiYgYROh02vPs0r6amZspfe56CkclkV2NZNS6fz9s1MUFq8wAYttnpz9QfJBR5WZMmTFsp4Ed9hhIW/xk0cE0eb9AzRWo07aYBhzPqvpd78iSWB4ryBAH0CoafLF3IuDtPMiNJMpPHjCs/WLxi8vngARfms/T7hLvzFIxSqcQcEfuOunWUaIn+fOLZbw9zBy0WIr4Y+PnlpXA8FEF6EIRxw8HvILvPF/Dfc3BswvyXti7CHe+CpSJN6HpCWhKU32T3yiWMBUnc731eTBrFnsKhJ2TUKxY0mLEHsp1NuPtewYjFYgoA4IdYB3/U3km604PA5fNRdhxsIJTde3lqivimzPSoTx/A4vC4MeWWQ0dd4+6Lbv2Q/+r0plsOHWGhBOuWQuHpxQv9uRx2UAqGDsOMTYW5Z5UnWpLORWAIIp27AfKVEde4vamsrIz+/U1QXl5eAABIxTryXU3rvBqyFg72Hm2mexGEkC/m7vz46RXz5ciY4PKvDvr+d2BwcNqffR52n99615HjttsamgQTHm/UAwKL+UmOcmFKSFuyNakpU99TMptu59KppCsgCNR2K+REMI2YJIlEsuD7bU9ZWRlm9Kh7fMJs93hntMIjmR2L201/4vOvxp++bl3IiWo3ZqZzizickS67ndBg+XDRbrMn3fldc9LTbZ2WUj6PlUqnu90IQu21O7x1I2NsL4rGbFbWxvyckJVxKZ83dW4Gj0H6XoIEBQDqctiQxVweVsrL8u8VDF54+oTBQO5HQ+SZ+oPCLZeXW0VcTkhPRRoMs/+4eOHw7Y3Hwi8cAU6brbzT5qnSq7P3Rky30EwY9m/MD3mG2uQ2icqmU6zJbHpCJgTGmi6nA17MnZnwPKlTvtc6eBbMiSEDWX9EgJePNBHa5lRKsrIXJXGjPs86kXhuqczIplJCthT1LpezMHWqVCpuK9rjmQ6HHdPyUygUy7//QPEsGM3IaFwkfCUq+442TyoYIiUE9Hvyc+b1FIfZyGGz7JuK8giNP2l32GlJTNL3EiqdTjveQ/SMBVNTU4NbQX1ENxh3Fb6JxIDZzNn13dGg80jO5c6cbAYNgshERwzuzZ+awELI93PQPBGXbTwThR6nA/FiO3pTzlowV2MlJlncbofObInlcKw5wcMffSp0EhjUlsViJj9YnD+jIfV8Z/KGvb8wj1CE0+H3O74wjpEV0wRwIwistmPf3lMKRqFQYJYHqE6rTeS+lDhOn4/2j6bjhJLmfi8tSeJTqYSGvc01freo2JDGoBNSDi/q+pBYRr/mCt9ZTJj395TykMlkJViLJ/XDCdkkKB7Z39RMSMHwabRUhSQrbqqsY00yjeZUyhYS6pOrd7tc742R93g4GHS7MA2Rsy9iThA42D8Q9dnJc5XjeoPg/dZ2PZFrbMyPr14xseS+ghw3BQKEfCcfjA3HTSJjomP0eTG3qmcVDOaTYNBsIb+AMPLAex8mIQgSctj/UmGy6HJhSk94pUpM7ivII6RsEQD8748Nk1ujMOHw+3DHDIBzemWch4dAsyGSmQxZrNy31a1EtjnQ9mUyOgCAcOkGm0IxXpee1qsQZw0qxFm6K1JTugAACRExvCdPoi/gsgkFH/5tGPQafT6ygDdM+NGZ5SPgnAppzEUUoKQFE2b2HDkGKhfLQj7/khSBWJ4mHK4bHQ+pPzIFghxPSEu6H1lQmM6iUPLPXXP4/d33HztlfqNftyJkASMMHYbdL6xYTChz2OrzefYODZAFvGGERaFg6pCzFgrmuAwRlxPzdgFzja+6ewTfaXWExpP8PFcS0vagmMsZPXr1FaYnpCWLWRTKjPomNoVS+M9Lli/5/MqyjiwmMy4HwW3Ml1jYFAoh6+X9sWHYh5LurHAiotExFfZZBYPpfKzIzyVzYMIMCgC8+f2PCGX3/iQ3m8OmwEEpAAmbNX7y2gpkeTI/6yKHUtelp5X857JVplDliyRVBIoap0HfGzWQ2iXMFLDYmPfzlIJRq9VqrMVlmRlk9mgEaBrUi77u7g3ZQqDCcNKOZaUjwZzzx9IFDhaFEvC2qkyYnDu5lQpJwAhxU2a6fkWyIIXINd4fG3YOetxkAW+YWcThYnZxnFIwKpWqEWvxpoULyEbfEeLlI02Ezr+vIDcnk8kIqARBykvq/2muJGifzTbZAomQTiM0sTJcQAD49q1aihJJ/HQhiPcFbR9ZWxdmIAC8S7g8zEj0WQtmUsHM6MCWI+ALioUphAa7k2DzrqaN3zNhJOKLYVTl51y0a97kl79/1dLJbUUoDwv69ZnxMWvvDkn2mIjJuNj2blY+HhsBDoTsnRZuFnG4LiaMrfenXn377bdHAQBHsA74kWxRhMWbn7j9ftqdb71NQVA05LyYzUX5dAYMzxpavjtfMlwmTM4J9T3KUwSER8eGAeSxRcWEQspeBPH+a1hHRkUjQIVAiKe1Nd+rnYaGhpNYR1xdiFmmRBIGvtMOpp42DIe8BUlnMpJvFWfOagXdLs4O9fJTcKjUmCejrUlN0cv4SYTKAg6ZjR6Dx0PmvYQf5BKeAFNxa7XaE98rGJVKVYt10LXFhbyK/DyyZCBCPF33LaGIxt6VSwQpdBrmNvbSFMHwtRlphLYVJi/habiEYFFg+5uXrqCc0z0vaExer/fp/i6yJUMEuF6Y1l3C5mAqf5VK9d/vFcynn376DQBAh3Xg7h/eSIMAFNs7bY6iatGkGqzW/lDP51CpKbeLszGzgx8szvcRrYY/abLEtI3k9RkiYzabRWgEyoGJUcTm95NZ6WGGCcPjj+YU4n039v3793/8/Yeu0WiQ2traJ7COXJiWmrRx9XJSwUQABEXh+9/9kEokL6aqYGavsEVJXP0GcRahsa1+ALxfDI/GNNnyBxkiQvcdAoDv/dFhUrlEgJ9miM00GMbsBKhWq3doNBrneR/87bff/goAoB3rhN+vraAyKBSydWMEeL+1Pfuk3hBy17uVyYKMq0Wpnee+tmvlEgsNhglZH6/09Du1TldMZwSJmAxCTuYDY8PufreTzHsJMwUsdvPPMsWYY44AABPV1dVPASzzefv27S9gnZEj4NO/2PhzKIlBJzRQjASbvUebCfli/rpEyoKmUw0q0oT6ijQhZo+fQBlzezyPnmqNud9CxAhdwdj9Pu/uoQFyiFqYSafTtX8tWiSEAcBs9tXQ0LCvvr5+yhiZoWD279+/BwDQhXXimtwc+mPyK+MhbDnneLX5eLLT6w25X8zyZL54XXrq1CTIh4rzkQBmM8/KK70D/gmvN+ZP/jG3J+TtzZfGcf+410tGjsIL8tvcotEMOgNvToxrx44d28/+nxlfnkaj8SqVyg0AAMzw6dY15azbSqVk68YwY/d4mb/99AsnkVYMd+VK0BUC/uBN2ZmE0uk9COLZ3dMf8/D0JOMeT6g+GP97o4a4+BvmEJ77snK+Xc0TLMNZR2pra+9TqVTfp05gfgH19fXDMpnMKpPJfnDhGgWGoQ2LZfT/tmicI3Z7zJ9wc4nvtIPJ961eMZzEYIQ0QkPKT4LKhSmWTCaD0CTIv7R32d/W6eMipZ5BgQc3iLOCDrUfNE043xzRky0Zwsg1KanHH5LkX4ZnHavV6v1XXXXVU+e+hqvhGxoamq+77roCkUi05MK1yauX5YjRfx4/5fchCPmUCCNcOt26tiA/JAUDQxA9g8kgVAGvdTg9ioZjDB+KxkXkpdNmpynEme2pDEZmoOc4/X7/Yz3tsMXvI+/NMCFhsDpq8ktSORQK3r156pZbbvmpTqc7r0Aa9ybS6XS+6urqnwEAjmKtr8jKpP/nx7f7z0QCScLF/qZmLoqzPY0Ge3r6/U6/P25+mB4ESbv50FHEj6IBj21RjeidOreLtK7DBAOCh15cIEPT6HQ8JT8il8uvbmxsnBEJnfUpVV9fj1ZWVm4EAGC2Fri+pIj1P1deTrZ0CCODFivvk/bOmBSYWn0+177egbhRLmfptNlXbTjcpLd4fb2zHYcA4P1YPzKybzD+/oYExveb3MLRVBp9Ac46olKpHqivrx/DWryoGaxSqU7V1dX9CM/5+Mdrr+aszM5KiF6uiQLRVg6hUtPS7jW43HHZouPdIcPylPc+hQ4YRj/BSkq0+/zjN3773fDdJ06w/QSnDZD8Hzemig5cK0yb4SY5S11dnbKysvK/eOsBhzIPHz78h/Ly8sex1sYdDk/5rn1I5/gE6VQLA1QY9p341QM9MlEaoVyWYOiw2lzST+uY/vhvJekv4LDbViYLaAIaDfUgfqbJ66N9MTzK9kEoq0TE9SUxaTEtb5grlPEF6ueKpPkAAEyHv1ar/c/69esVGo0G96YJWMFIpVKKWq3+BgBwGdb6N339roo9r5AKJkxcV1zYd+Dun2YAAKLymT50osX5fGdvQj/5c5LZdnEyi1QuYQAGkE61eIUvg87IwzlkrLKycqFKpZo1Az3gSIFGo/HLZLIbAQCY7TWvzMtlvnTLDVYoDCM1SAD4tLM774h2EHNfG26GXW7na326hHaKQgAgoiQGmVQXBjgwZXTfoiXG2ZSLUqm86mLKBcwWpsZidHTUBQA4IZfLq7DWV4uzGYMWi6t5SJ/QN2u8gAJgvnnRAkJ9UALhgWOnXEeMpoS2XoQcuiOdx0zovyFeqMqStF+VnIqXTAdUKtUvN2/e/Gkg1wo612Hbtm2H1Wp1FVaLTTDl9F1HE/N5ZFFkGFCdVqeN2OwRneR43Gh2vjEwGFLeTTyRwWOS6RJhYDE3qe3HGWK8iBFQq9Uvbd269dVArxdSMlVpaek/1Gr1Pqy1NA6b9tLNN5AFkWHA4nYzH//iKy+eMg8HL3T1xr1X92JwGVQTn0Ujh9gTZ/y3uUUUGAA8P1ZdaWlptU6nC1iZh5ytuXHjxscmH4BYazctWsBRrpNbyCQ84uw72lzUOTZOaGg+Ht02u/NN7WCiVxujBakcCtHizvkOFYKMfy+R9eYyWcU4h4xUVlbeH+x1Q1YwjY2NRplMdiUAADNpo+YqOW/rmnIyP4YgCIpSnv32MBpuZe1FEO9tDU3A6U/sUg9REsPKZVATfosXY3yP5RYNrEzir8JZ1ymVynKVStUR7IUJ1ZtoNBqbUqnciHfz/3n9NdzlmZlxMVcnkXn9+MkMq9vTGc5rvjdk8J00WeLGKVrC5YCrRUJQnpIMWJTAb8v0JCZpuRDkB0LRgetmSaZTKpUPbtu2LSRfYFi+nLfeemtDZWXlv7Bm74za7e7yXfuQ7glj3NzMich9q1e2vfyjm/LClRez5quD7kPjxphuj9IYdPCEtAQoxFkgnfl/ovhRFNSNjIG9PQPg7cEh4MfxEglYNKs0k8ch+qCcz5TxBOrniqWT9xWm30WtVj+5fv36J3Q6zHbdFyVs2r+lpeVZmUz2MNZaXU+fY+2+V+Oi/D+R6X3kwd685OR8otc5oB+xXn/wu5huK9IZDHDoqstBIXf2vLg93f3g/uZTmGsrc5LHGVRYGCER5zwwBHS1shW+TAYTM99FrVa/U1paeiuR9wjb/ru5ublh48aNVwAAZgz5yksW0IRslumTji4a+bQJHQ6dbrm6sIBQI2+Hz++58dAR2BjDTm+FHDZy8Ko1IJ/DvugDbmWKAKTS6eCA4fxR3EIO3ZzOYxJqTTGfYcOUsV0LF4/ms9h4Ien+zZs3V2o0GkKFt2H7sTc2Nlrlcvl6AMAA1vovyy8V3LNyBVl5TYD9Tc1CP4IQyot5Uzvo77E7YlrSUSMt8eWwWQFbz5uL88GNmef30Ernkb4XIvw0I3tgIZu7GGfZrlQq16pUKi3R9wlrBKG/v9/L4/HU5eXld2Ipr/IcMfiwrcM15nDEZcVuvGP3eOlcOl17eW5OSijfHQqA7+6jx6FhtydmkaMl/CTnC8sXU2EICurhxqFQwZvaoan/5jGpFkkKe9L8Ia3hELgqWXjowZyCUghnXrlKpdq8efPmL8PxXhF5CrS0tOyTyWSY5QRjdodrwfYXwITTSRZGhgAVhr3jjz86yGPg1ongsr9nwLzx2MmIlx7MRp38MktFmhCzG/1s2H0+wHvnk6lw5TKxYIRNpxBqCzpfKWCxW/4pXVY0S7DgSwiC1oXr/SLyBNi4ceNvAACnsdZSOWzmS7fcQHbCCxEfgtD2HW0OOrN31O12P3JKE9NI3uXCZFcoygWcmWAJSvlJIJlNM5PKJTToEGRQ5hezZlEuw5WVlZvC+Z4RUTCNjY1jcrn86kmDBWv99iWlnN9UrBmNxHvPB/Y3NScDAAaDOqdX6zd6vTHdmj5QmEeoLEHEYID0JNLwDRHnc8XS7kIWpxBn3VNXV3d9KMl0sxGxPWx9ff2oSqV64MzWfyZ/um5d+k0LF5BJeCGgGRkV1p5qGQ3UCnT5/a5d3X0xzdjNY7Ndt4ozCclgQX2mZDadzKcKgZ9mZGtWJPEvx1tXqVS/Xbt2LWbpDxEi6iSrrKx8u66u7k9YaxAAYO+tN9G4dDo5YykENn/wcaEXQQKqUXqytdM54HDGNKnu2aWLPCwKJWQLyoMgTi8ddUMQtmOSBJ/F3KSGX2TnLpzlkPeVSuX2SLx3xL3w1dXVj2u12vew1tK5XGb9fXfDySwm2d4hSEbtjiTVKfVFLcBum93517aumDp2lwp47tvEWYSqnZstZhOLQU0Pn1Tzg2wGs+evRYty8TJ1tVrtdzKZ7A6NRhOR94+4gtFoNOjDDz98HwDAiLW+IiuTvW3dWkek5ZiL7G06ljypa2Y75qWuPr83xjOOflGQ6yd6r31mHEv4thIxwP2HghJ7EoWKN7jOt3///iqNRhOx319U9uUajcYOAPhcLpcrAJjZ8X1VdhZDa7ZMnNAbyHKCIOg3mjjrCgvacgR8zBvI7PW67jp6nOqK4XC8VDrds3fVUohJoYScOWzwuIeeHegW+AEgOyUGjuORnIJjawQpq3HWXbW1tRs2b958MJJCRO3Jtm3btmaVSvV7rDUKDMP/uO0W4Spxlila8swFUACgX374iQQFANMX82qf1mv0+mLqs3iqdKGLT6MR8v/s1PWbPShKPnyCoFKU2fbDtIw1eOtqtXr77bff/kGk5Yiq6bx169Y9arX6Fbz11zb8iCFgMsntUhAcH9KLvurumTEYz4eg7he7+mLaBLuYy3FvLMglFPXpdjoGvzaO4bZwJJlJAYut/nmmWDLLIV+sX78eM/gSbqKqYHQ6nb+6uvoeAEAD1rpUlMZ6/+d3eiGMwVok+Lz83bHJH/F5Dt/tHd3mLps9piHdu/IkHgpEbFvz3qgBRcmSgIBJptL69y1ckiSg0tJwDumWy+U36nS6qDSDi/oXV19fDyorK3Gdvlfk5vCV69aSoesgeK+1LatrfOL7MIDW4XQoNe2Eqq7DwQ2ZIkLZ2mafV//ZxGhImb/zFOcjuYVWBgzP6GgwjXv79u331NfXRy1qG5Mng0qlaqmrq7sZbxzt41dVJK/Jy4nKTKC5gMfvpz3yyWdZZyNKL3f3e51+JNb5It7FAj4hGf6h141b/X5SwQTIL7Jyv6wQpJTirdfV1d378MMPfxNNmWJmeq5du/ZgQ0PDH7DWIADAxz//cVJpuojM9A2QdzVtkhNDBrPZ67Xu7e2PtXIBGQyGHsaIGAbKoNs19O6oIWqjcxOdtQLhyZ9mZl+Ht67VanetXbv2n9GVKsZ728rKyifVavXzWGtJDAbj3Z/eQRMwySS8QHm6/lvq//v6sGXE7Yl5Or3Z56XgWaiB8C/DoMeHojFXlInAIg732O/yiyQAJ4yvVqvfvuyyyx6KvmRxMuoBRdHPAADXYK3tONgwsfXjT1OiL1WCAlNQULoYApTYDwuw/ej6fg6Vmhv0eX5/z00nj2Z5UISsbLwI2Qxm91ulK3gQAHhO3RNyuXxlfX19TLoXxIV3frpE3IC19qvLLhX8dPnSkehLlaAgfggYJ2ItxRQf60dCyb71/13b6yaVS0DYH8kp8MyiXGxbt26tipVyAfGiYFQqVVddXd16AMCM7RAFhuHXFT8SrcjKxIw6kWAwFh/+8Vf6tEErGK3LafhkfGRRZCSaW/y/9Mz21TwB3meF1NXVKXbs2NEcZbHOIy4UDDjj9D2pUqkew1t/TfEjehKDQQ5yCwSnAwCTKea1O58YRsS7u/uPB9pWAgHA84K2z0d2Irs4hSz26Z9l4CfTNTQ0/Hnt2rUHoivVTOLCB3MWqVQK1Gr1ewCAm7HW63v7jPK9r3LxnFkk50Cno0BaCgEo5l8x+urqZeqf50lww6fgzCwk10+OHm8foLgWAgASfZxtRBHS6H1vl66g0mFYjHPIEZlMdrlGo4n5jPjYewLPYXR0dHK79P7NN9+8js/nz/jw8pIFLBRFTfW9/WRdysXw+yHAZALAinlACfpAP5w06HRpCzhsu4jJOC+vxYeirs+GR+13Hz3hHwAuhEmjpMZO1ITA8UR+8XABi12Es94qk8nWTRcYx5y4UjDgjJLx8ni8Rrlcfj/WFq6iIJ/5RVf3qNZsmX1iFwkAPj8KhMLYmzAA0I4Zzckvdffx/juo7+y1O1yHxiag94aGJ+46epy+p2cgyYz6JnJS2HgZqCRnQH8lzvv8hlQRbhGjUqm87e23326Lrlj4xPzmw+Ott976YWVl5ZtY5rLZ5XKW797nbR0ZI7M8L8YiGQqY8T9DqFjEHUzjMrJjLUc8c3Vy6sk/FJTIAABYRaw+tVr9QGlp6b4YiIZL3Dh5L+T2229/V61W78Ba4zOZrFc3/Aglksg1bxiP/0ZNNApsSOUwyCmNs8Cj0lofzS0U4SgXoFar98ebcgHxrGAmWb9+/VOTnx3W2iXibP4rG344BgHIE33JEoiJcQj441sPF6VxbBAESL8aDkIaTb97QSmFQ6Fk4hxyfOPGjbgR2FgSdz6Yc7FYLF4AwEm5XH4P1vqyzAzuhNNl/k6ri7knM25BEAhAEAKSkuJym8RlUIfyhJygs33nE1skBe2reQK8Ma8jcrn80kOHDsVHduUFxLUFA850wjukVqs3Tu4xsdaVV1ewl2ZmjEdfsgRiZBgCnvg09NJ5ZER6Fvw/Ts+uvyFVtARnHVGpVPfV19fHpXIBiaBgJiktLd0/ucfEWktmsZgH77+HlZHEtURfsgRh0ooxTsSdLwaGIKuIyyAd9Tgs5/JPbBLnXgFwZkir1eq3KisrMSd2xAsJoWDAmXG0k3vME1hrXDqdvfuHN05aOGQnPDzGxgBA40vHZPAYVgiCCI0zmauk0ei9v88vSp/lN9q5bdu2h6MsVtAkjIJpbGycmB5Hi1n4eMuihSl/vf4aXfQlSxA8bgiMj8VVFj45BhYbCIDxvxYvMmfQGXiZuma5XL5WpVIFNHgvliSMggFn2m1OqFSq+/FqW359xeX5isWy+Kj0i0f0QwD4Y549PkUal9HJolPw5vXMZ5CHcwoGilmcZXgHqFSqzfX19UHNJo8VCaVgwJnWDu/W1dVtw1vf88ObWEI2m3T6YuHzwWDCGHMrBgLAUZjGIX0vGFzGT/78R2kZeE7dSf5WWVn5RhRFIkTCKRhwZhztk1qt9j9YawIWk/PNfXdTRRxOXNRixB3jsffFpPOYRhiCyDGwF7CEy2v7c9GiS/HSR7Ra7ScymezX0ZcsdBJSwWg0GrSysvJuAMAhrHWpKI3/5h0b3DAEOaMvXZzjdMBgbDSWVowrW8AknS8XkMNkdTxZUMKHAcCbBtFcWVn5Y41GE99ZkxeQkAoGnHH6WuVy+XWTih1rfW1Bfsq/br9tONBeJPOKoUE0Vtm92QLWAINKEcbkzeMUBgwPvVhSiqbS6HiZusNyuXxdY2NjwjVdi+tM3ovR39/v5fF46vLy8juwlGVpukgwZLHom4f0SbGRME5BURjQaH7A4UT1AUODIfOC9CQmDEFkWcD/4X08r6i/lJskw1lHVCrVT5599tmTUZYrLCSsBXOWhx9++LO6uroteOsv3nxDyiJR2lB0pUoAxsaiXjqQlsR0UGCItF7O4Za0jAPXpKQtxVuvq6v7XWVl5fvRlSp8JLyCAWfabb6o1Wpfx1qjUyjMT+/+CSuHz0848zKiuJwwMEY1ouRJ5zHIToTncBk/ueV/cgrW4a1rtdq3qqurn4muVOFlTigYcKby+pcAAMxEOwmfn7zvtpvJcbQXotOi0YooZfCYfSyyW933UADU/0hOweTWHa9Qd3j9+vUPaDSaKEsWXhLaB3Muo6OjbgDAh3K5fAMAYIbPpTAlhc+mUTu+6OrhzaW/mxAIAgMGEwEsVkS3SxQYsi5KT6LBMER2IZy8OSnU0d0LFxtzmKxinENGlErlVW+//TZmACORmFM/tOmq0iG5XH4b1vr/Z+/cY5vIrj9+Zvy2Y8exYycmHhIT5+UbFtj9/bZh2WLz0MarLoiXYyo1iFKkPuSqgnYl1G5F/uhDLaWvVdltRaS2Yllqt6W7qLTsrpSkXZEAKktK7PAOyZgCedIEEtuZeCoTR03ZGW8S7LEzMx8JCelYo+PJ9XfOPXPuOWtKlxp7Rh70dd69JzY3mmGKioOxMKORbJFOOWzUKMS6lyR7lxBXXAVG1rxLIBD4is/n+4BbrzIDrwQmwc2bN4P19fVqs9m8hsm+mrBK3u68/Ggslv3xqjlBLIaBVhsHuSJTIjNlN+VFZBJcjF4en5DWdR8os9tTjHn9eWNj46HR0dHcOpm6QHKyCVE6oGn6NAC8zGT7Q1fo5o7j/nLuvcpRlEoKqh3STIw4MeUprlWY88Qh9tP0n0Crxgilim3tvY9h2Esc+5RReJPkfZKGhgZfYrvEZNte67B9e73zstjTN0kkIoXR0bS/UcIx7FGpQS2eOQIAOY4Pv1G1/E4KcbmXHKHMK3i3RZohFAqNAMCZZLvNJxslY+uW2You3b13/erAoPhmAx7PUYqDwZDWB45Zqxw0aRVs1amC4vMW6xW30bSKxRxtampyHjlypJtjtzIObwUGppO+AwihMYQQ41bpxdKl2DvdV4ZHJiLiUzYWA8jXx0EmS5fIxO0mzbhcigu+odRqnb79G6Xl1ThgjP1BA4HAqz6fL6c70y0U3uZgZkiOow0AwA4m++2RBz3VP3ldG6WmxEgmT0tBRSXjWIz5YtDIr1YXaavSca3FjE2p6j6GVhGJu8vykT8ihLYv9noXNnibg5kh8YdDCDWSJNnOZC8r0Nt+tXXzsJiPAYCHY1J49PCpczEYBuNlBrHfiwSw/tfKKqRs4pJYkwihz/FVXEAIAgPTIhNpbm7+AlvP3l2rVlTufm7V37j3LAcZfPpBbYV5igdKGS703Ev0cIWju1qTx1ZMN5lYk6FQiNctRXidg5lNW1vboMPhuIgQ2spUg7DFUV18jgz33BgaFvZhvGgUwGCkQSJZ8Pa5vFAzppBKBH2CvcFs6dxmLl7NYp7w+/3bfD4fY1TNJwQRwczg9Xr/HAwGD7OYVW9ueUUlxfFF0es0Y8TjONy9s+Btkl4lu6ZVygTda9ehzjv/NcLGWvsTDAZ/5PV6T3PrVXbgfZL3SaxWq5okyQ4AYJyUd/Ffd7vXH/216d+RqJCTvnGodgCoVPN6AGEAkZVW/ZBKLhHsEHuLXHH7aM0zUr1UxjYRoJMgiBfC4fA4x65lBcFskWZIjqO96HK59jLZLVqtCQP86gc3bwk5h4ABhk2BLn9eAmPUyPuL85WCFRcAmPxxheNOikOMdFNT0+ZTp071cuxX1hCcwMB0PuaOx+PpMZvNm5i2iWvKlub3jIyc67x7f2l2PMwBYlEaCk044HPXmGWFmlGlTCLUt0cT+5YuO+/SG59nsU/6/f5dPp/vDMd+ZRVB5WBmU1tb+9tAIHCAyYYBqH+zY2tdw3L0Efee5QgUJYG+3jkPtDZq5LfyVTLBRn1fKikN7TAVf5rNHggEXvV6vce59Sr7CC4HM5tkEd67ALCJyT4Wjd6xHfrZyND4eC333uUI1TUUqNSfVHwX+VSZYViCY4JM7j6rzW99vRKtBgC2Sf6/Rwh5+FzvwoZgIxj4bxHeTpIkzzPZtQpFyd+/uEdi0WqFO5J2Dr17i7SKIaGKS7lKff2wvcbBJi4kSZ5FCDUKUVxA6AID0yIz3tzcvJetkrfGVFjz/fqNfdx7liMMD9EQT/3WukinFOo6enjQVknJcdzMYp8ppotw7FfOIMgk75O0tbX1OxyOywihLQwnr2GlpbgoRlHvfdjbZxOcKNM0DvF4FHT5jNukArWst0SvsgjtvmAAo98trwo+q81nOyE94ff7t/p8vg6OXcspBLUoUuH1ek8Gg8Gfspjl36vfWP9Shf1Djt3KDQb6ZRCLMUV4k3bT42M2gntQ7bJYb7j0xjo2ezAY/KHX6/0Lt17lHqLAzMLtdn8nEdCwmPFjDdsqd65Y3gIAc367whNwGPr4GSVTnqJfJsFLs+NS9ngmT9uyq7gk1fc+43a7f8ChSzmLKDCzCIfDD10u18sAcJvJbtKol7zt3e56bd3a9xObB+49zCKDgx8bcVKky1gf35zFrtK890bV8pVKnHX87TWXy7U5HA7z+hDjXBFcaPtJ9Pb2Ujqdris5jpbp/mDry222/ytZcqmjLxx7EImwDSvnF/G4BFRqCpTTCd18pZQkCtRmAa2hh26D+Z1v2uw1GgnrUYjI/v37t584cYLxASVEBF0Hk4qWlpYvu1yuI6k+Q8Xjg9vf8l96t/vKekFEgzrdJJTapCCVxp8j9L0KmWRZtl3iiN4DpeUnNxUWfTWVoLa2tu5ct27d77h1LbcRytNn3ly4cOEfZrM5ghDawCbEOIapP7ui1vqZqoqgWi4fuDE0NDQxSRl5K9zRKIBMRhnMhv5inZL3uRcFjl/0mCwt3yqzTzyv07NFtI9pb28/tHbtWraXBIKFnz+ENNLS0rLb5XIdnaMYT5y+ev3sW5f+SR/vvFwFAAQHLnKLQkE5NrwwoOffsQAaAEgACK43FJ6zKTQTe5aUvAIArOX/s2hFCG0MhUJiV8QnEAVmDvj9/i0ej+eXAMBWUMXEwOV79+/fGB7Jo6amaP4khbF4gaXwI4kE70827lrka+jxMChMplLhLyrViegzEZlVppgZ/T+QJHnC7XbvDoVC0cz7uvhY5IuDO5xOp6G1tfWvAPD/2fYly0zO6gg4lfxHpziHw2eOIYR2i5ELO/xPTKaJtra2YYIgXIFA4OsAcC/b/uQIiW2jPCkucQCgkjVCU8n/85WRQCCwB8OwRlFcRNKOx+Mx0DT9Jk3TFC08YvP4bCR5j6IZ9Idr/uR0OguyvQZFBMC+ffscZ8+e/QVN0wPZXvUcMh+Bmc2M2FBPcY1s8aivr+/4wYMHN1itVjGtIMItTqcT9/v9m2iaPknT9ES2fw0ZJl3iMCM0kTRdLxOQXV1dB5xOp+CnUy4UUY3TTF1dnYogiOq6ujoHQRAEAFgAgE/VvlMZqJ+iEtd0OBwShBDBcX1W4vuMB4PBR8l55j0kSd7q6Ojoam9v7w6Hw089iE7I/CcAAP//LazR1LfsgEMAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - hco.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - machineremediation.kubevirt.io
+          resources:
+          - machineremediationoperators
+          - machineremediationoperators/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - daemonsets
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: hyperconverged-cluster-operator
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - networkaddonsconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          - endpoints
+          - pods/exec
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - kubevirt-handler
+          - kubevirt-controller
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - put
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - delete
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancemigrations
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancepresets
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - limitranges
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - delete
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - update
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstances
+          verbs:
+          - update
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - version
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - kubevirt.io
+          - template.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - watch
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - daemonsets
+          verbs:
+          - create
+          - update
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - services
+          verbs:
+          - create
+          - update
+          - get
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: kubevirt-ssp-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+        - apiGroups:
+          - cdi.kubevirt.io
+          - upload.cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes
+          verbs:
+          - list
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims/finalizers
+          - pods/finalizers
+          - volumesnapshots/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - events
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: node-maintenance-operator
+      deployments:
+      - name: hco-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-operator
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                - name: KVM_EMULATION
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator:1.0.0
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-operator
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                - name: CONVERSION_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0
+                - name: VMWARE_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-vmware:v2.0.0
+                image: quay.io/kubevirt/hyperconverged-cluster-operator:1.0.0
+                imagePullPolicy: IfNotPresent
+                name: hyperconverged-cluster-operator
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: cluster-network-addons-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cluster-network-addons-operator
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                name: cluster-network-addons-operator
+            spec:
+              containers:
+              - env:
+                - name: MULTUS_IMAGE
+                  value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
+                - name: LINUX_BRIDGE_IMAGE
+                  value: quay.io/kubevirt/cni-default-plugins:v0.8.1
+                - name: LINUX_BRIDGE_MARKER_IMAGE
+                  value: quay.io/kubevirt/bridge-marker:0.2.0
+                - name: NMSTATE_HANDLER_IMAGE
+                  value: quay.io/nmstate/kubernetes-nmstate-handler:v0.15.3
+                - name: OVS_CNI_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-plugin:v0.10.0
+                - name: OVS_MARKER_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-marker:v0.10.0
+                - name: KUBEMACPOOL_IMAGE
+                  value: quay.io/kubevirt/kubemacpool:v0.8.2
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/cluster-network-addons-operator:0.27.2
+                - name: OPERATOR_NAME
+                  value: cluster-network-addons-operator
+                - name: OPERATOR_VERSION
+                  value: 0.27.2
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERAND_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/cluster-network-addons-operator:0.27.2
+                imagePullPolicy: IfNotPresent
+                name: cluster-network-addons-operator
+                resources: {}
+              serviceAccountName: cluster-network-addons-operator
+      - name: virt-operator
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              kubevirt.io: virt-operator
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              annotations:
+                scheduler.alpha.kubernetes.io/critical-pod: ""
+                scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly","operator":"Exists"}]'
+              labels:
+                kubevirt.io: virt-operator
+                prometheus.kubevirt.io: ""
+              name: virt-operator
+            spec:
+              containers:
+              - command:
+                - virt-operator
+                - --port
+                - "8443"
+                - -v
+                - "2"
+                env:
+                - name: OPERATOR_IMAGE
+                  value: docker.io/kubevirt/virt-operator:v0.26.0
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: docker.io/kubevirt/virt-operator:v0.26.0
+                imagePullPolicy: IfNotPresent
+                name: virt-operator
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8444
+                  name: webhooks
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /metrics
+                    port: 8443
+                    scheme: HTTPS
+                  initialDelaySeconds: 5
+                  timeoutSeconds: 10
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: kubevirt-operator
+      - name: kubevirt-ssp-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kubevirt-ssp-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: kubevirt-ssp-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: IMAGE_REFERENCE
+                  value: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.19
+                - name: WATCH_NAMESPACE
+                - name: KVM_INFO_TAG
+                - name: VALIDATOR_TAG
+                - name: VIRT_LAUNCHER_TAG
+                - name: NODE_LABELLER_TAG
+                - name: CPU_PLUGIN_TAG
+                - name: IMAGE_NAME_PREFIX
+                - name: OPERATOR_NAME
+                  value: kubevirt-ssp-operator
+                image: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.19
+                imagePullPolicy: Always
+                name: kubevirt-ssp-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              serviceAccountName: kubevirt-ssp-operator
+      - name: cdi-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cdi-operator
+              operator.cdi.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: cdi-operator
+                operator.cdi.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                - name: CONTROLLER_IMAGE
+                  value: docker.io/kubevirt/cdi-controller:v1.13.1
+                - name: IMPORTER_IMAGE
+                  value: docker.io/kubevirt/cdi-importer:v1.13.1
+                - name: CLONER_IMAGE
+                  value: docker.io/kubevirt/cdi-cloner:v1.13.1
+                - name: APISERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-apiserver:v1.13.1
+                - name: UPLOAD_SERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadserver:v1.13.1
+                - name: UPLOAD_PROXY_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadproxy:v1.13.1
+                - name: VERBOSITY
+                  value: "1"
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: docker.io/kubevirt/cdi-operator:v1.13.1
+                imagePullPolicy: IfNotPresent
+                name: cdi-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                  protocol: TCP
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cdi-operator
+      - name: node-maintenance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: node-maintenance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: node-maintenance-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: node-maintenance-operator
+                image: quay.io/kubevirt/node-maintenance-operator:v0.4.0
+                imagePullPolicy: Always
+                name: node-maintenance-operator
+                resources: {}
+              serviceAccountName: node-maintenance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - events
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        serviceAccountName: cdi-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  labels:
+    alm-owner-kubevirt: kubevirt-hyperconverged
+    operated-by: kubevirt-hyperconverged
+  links:
+  - name: KubeVirt project
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/hyperconverged-cluster-operator
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  replaces: kubevirt-hyperconverged-operator.v0.0.3
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-hyperconverged
+      operated-by: kubevirt-hyperconverged
+  version: 1.0.0

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/kubevirt00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/kubevirt00.crd.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    categories:
+    - all
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  scope: Namespaced
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/node-maintenance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/node-maintenance00.crd.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nodemaintenances.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: NodeMaintenance
+    listKind: NodeMaintenanceList
+    plural: nodemaintenances
+    singular: nodemaintenance
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            nodeName:
+              description: Node name to apply maintanance on/off
+              type: string
+            reason:
+              description: Reason for maintanance
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          properties:
+            evictionPods:
+              description: EvictionPods is the total number of pods up for eviction
+                from the start
+              format: int64
+              type: integer
+            lastError:
+              description: LastError represents the latest error if any in the latest
+                reconciliation
+              type: string
+            pendingPods:
+              description: PendingPods is a list of pending pods for eviction
+              items:
+                type: string
+              type: array
+            phase:
+              description: Phase is the represtation of the maintenanace progress
+                (Running,Succeeded)
+              type: string
+            totalpods:
+              description: TotalPods is the total number of all pods on the node from
+                the start
+              format: int64
+              type: integer
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/scheduling-scale-performance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/scheduling-scale-performance00.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtcommontemplatesbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtCommonTemplatesBundle
+    listKind: KubevirtCommonTemplatesBundleList
+    plural: kubevirtcommontemplatesbundles
+    singular: kubevirtcommontemplatesbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/scheduling-scale-performance01.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/scheduling-scale-performance01.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtmetricsaggregations.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtMetricsAggregation
+    listKind: KubevirtMetricsAggregationList
+    plural: kubevirtmetricsaggregations
+    singular: kubevirtmetricsaggregation
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/scheduling-scale-performance02.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/scheduling-scale-performance02.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtnodelabellerbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtNodeLabellerBundle
+    listKind: KubevirtNodeLabellerBundleList
+    plural: kubevirtnodelabellerbundles
+    singular: kubevirtnodelabellerbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/scheduling-scale-performance03.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/manifests/scheduling-scale-performance03.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirttemplatevalidators.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtTemplateValidator
+    listKind: KubevirtTemplateValidatorList
+    plural: kubevirttemplatevalidators
+    singular: kubevirttemplatevalidator
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/1.0.0/metadata/annotations.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.0.0/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: 1.0.0
+  operators.operatorframework.io.bundle.channels.v1: 1.0.0
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: community-kubevirt-hyperconverged

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/cluster-network-addons00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/cluster-network-addons00.crd.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/containerized-data-importer00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/containerized-data-importer00.crd.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.cdi.kubevirt.io: ""
+  name: cdis.cdi.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: cdi.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: CDI
+    listKind: CDIList
+    plural: cdis
+    shortNames:
+    - cdi
+    - cdis
+    singular: cdi
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            imagePullPolicy:
+              enum:
+              - Always
+              - IfNotPresent
+              - Never
+              type: string
+            uninstallStrategy:
+              enum:
+              - RemoveWorkloads
+              - BlockUninstallIfWorkloadsExist
+              type: string
+          type: object
+        status:
+          description: The most recently observed status of the CDI resource
+          properties:
+            conditions:
+              description: A list of current conditions of the CDI resource
+              items:
+                properties:
+                  lastHeartbeatTime:
+                    description: Last time the state of the condition was checked
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the state of the condition changed
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message related to the last condition change
+                    type: string
+                  reason:
+                    description: Reason the last condition changed
+                    type: string
+                  status:
+                    description: Current status of the condition, True, False, Unknown
+                    type: string
+                type: object
+              type: array
+            observedVersion:
+              description: The observed version of the CDI resource
+              type: string
+            operatorVersion:
+              description: The version of the CDI resource as defined by the operator
+              type: string
+            phase:
+              description: The current phase of the CDI resource
+              type: string
+            targetVersion:
+              description: The desired version of the CDI resource
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/hco00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/hco00.crd.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hyperconvergeds.hco.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: hco.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: HyperConverged
+    plural: hyperconvergeds
+    shortNames:
+    - hco
+    - hcos
+    singular: hyperconverged
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        metadata:
+          properties:
+            name:
+              pattern: kubevirt-hyperconverged
+              type: string
+            namespace:
+              pattern: kubevirt-hyperconverged
+              type: string
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/hco01.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/hco01.crd.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: v2vvmwares.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    kind: V2VVmware
+    listKind: V2VVmwareList
+    plural: v2vvmwares
+    singular: v2vvmware
+  scope: Namespaced
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/hco02.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/hco02.crd.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ovirtproviders.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    kind: OVirtProvider
+    listKind: OVirtProviderList
+    plural: ovirtproviders
+    singular: ovirtprovider
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: OVirtProvider is the Schema for the ovirtproviders API
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation
+                                    of an object. Servers should convert recognized schemas to the latest
+                                    internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this
+                                    object represents. Servers may infer this from the endpoint the client
+                                    submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: OVirtProviderSpec defines the desired state of OVirtProvider
+          properties:
+            connection:
+              type: string
+            timeToLive:
+              type: string
+            vms:
+              items:
+                description: OVirtVM aligns with maintained UI interface
+                properties:
+                  cluster:
+                    type: string
+                  detail:
+                    description: OVirtVMDetail contains ovirt vm details as json string
+                    properties:
+                      raw:
+                        type: string
+                    type: object
+                  detailRequest:
+                    type: boolean
+                  id:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - cluster
+                - id
+                - name
+                type: object
+              type: array
+          type: object
+        status:
+          description: OVirtProviderStatus defines the observed state of OVirtProvider
+          properties:
+            phase:
+              description: VirtualMachineProviderPhase defines provider phase
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/hostpath-provisioner00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/hostpath-provisioner00.crd.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.hostpathprovisioner.kubevirt.io: ""
+  name: hostpathprovisioners.hostpathprovisioner.kubevirt.io
+spec:
+  group: hostpathprovisioner.kubevirt.io
+  names:
+    kind: HostPathProvisioner
+    listKind: HostPathProvisionerList
+    plural: hostpathprovisioners
+    shortNames:
+    - hpp
+    - hpps
+    singular: hostpathprovisioner
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      description: Represents a HostPathProvisioner deployment
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: HostPathProvisionerSpec defines the desired state of HostPathProvisioner
+          properties:
+            imagePullPolicy:
+              enum:
+              - Always
+              - IfNotPresent
+              - Never
+              type: string
+            imageRegistry:
+              type: string
+            imageTag:
+              type: string
+            pathConfig:
+              description: describes the location and layout of PV storage on nodes
+              properties:
+                path:
+                  description: The provisioner will store PVs at this location on
+                    each node
+                  type: string
+                useNamingPrefix:
+                  description: Indicates whether the name of the requesting PVC is
+                    included in the directory name when dynamically provisioning a
+                    PV
+                  type: string
+              type: object
+          type: object
+        status:
+          description: HostPathProvisionerStatus defines the observed state of HostPathProvisioner
+          properties:
+            conditions:
+              description: Conditions contains the current conditions observed by
+                the operator
+              type: array
+            observedVersion:
+              description: The observed version of the HostPathProvisioner deployment
+              type: string
+            operatorVersion:
+              description: The version of the HostPathProvisioner Operator
+              type: string
+            targetVersion:
+              description: The targeted version of the HostPathProvisioner deployment
+              type: string
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/kubevirt-hyperconverged-operator.v1.1.0.clusterserviceversion.yaml
@@ -1,0 +1,1996 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1alpha1","kind":"HyperConverged","metadata":{"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{"BareMetalPlatform":false}},{"apiVersion":"networkaddonsoperator.network.kubevirt.io/v1alpha1","kind":"NetworkAddonsConfig","metadata":{"name":"cluster"},"spec":{"imagePullPolicy":"IfNotPresent","kubeMacPool":{"rangeEnd":"FD:FF:FF:FF:FF:FF","rangeStart":"02:00:00:00:00:00"},"linuxBridge":{},"macvtap":{},"multus":{},"nmstate":{},"ovs":{}}},{"apiVersion":"kubevirt.io/v1alpha3","kind":"KubeVirt","metadata":{"name":"kubevirt","namespace":"kubevirt"},"spec":{"imagePullPolicy":"Always"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.11.1"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.1.1"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"templateValidatorReplicas":2,"version":"v0.6.6"}},{"apiVersion":"cdi.kubevirt.io/v1alpha1","kind":"CDI","metadata":{"name":"cdi","namespace":"cdi"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"nodemaintenance.kubevirt.io/v1beta1","kind":"NodeMaintenance","metadata":{"name":"nodemaintenance-xyz"},"spec":{"nodeName":"node02","reason":"Test
+      node maintenance"}},{"apiVersion":"hostpathprovisioner.kubevirt.io/v1alpha1","kind":"HostPathProvisioner","metadata":{"name":"hostpath-provisioner"},"spec":{"imagePullPolicy":"IfNotPresent","pathConfig":{"path":"/var/hpvolumes","useNamingPrefix":"false"}}},{"apiVersion":"v2v.kubevirt.io/v1alpha1","kind":"VMImportConfig","metadata":{"name":"vm-import-operator-config"},"spec":{"imagePullPolicy":"IfNotPresent"}}]'
+    capabilities: Full Lifecycle
+    categories: OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
+    createdAt: "2020-08-17 07:18:03"
+    description: |-
+      **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+      Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+      Containerized Data Importer (CDI), Virtual Machine import operator and Cluster Network Addons (CNA) operators.
+
+      **KubeVirt** is a virtual machine management add-on for Kubernetes.
+      The aim is to provide a common ground for virtualization solutions on top of
+      Kubernetes.
+
+      # Virtualization extension for Kubernetes
+
+      At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+      additional virtualization resource types (especially the `VirtualMachine` type) through
+      [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+      By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+      resources alongside all other resources Kubernetes provides.
+
+      The resources themselves are not enough to launch virtual machines.
+      For this to happen the _functionality and business logic_ needs to be added to
+      the cluster. The functionality is not added to Kubernetes itself, but rather
+      added to a Kubernetes cluster by _running_ additional controllers and agents
+      on an existing cluster.
+
+      The necessary controllers and agents are provided by KubeVirt.
+
+      As of today KubeVirt can be used to declaratively
+
+        * Create a predefined VM
+        * Schedule a VM on a Kubernetes cluster
+        * Launch a VM
+        * Migrate a VM
+        * Stop a VM
+        * Delete a VM
+
+      # Start using KubeVirt
+
+        * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+        * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+      # Start developing KubeVirt
+
+      To set up a development environment please read our
+      [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+      To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+      You can learn more about how KubeVirt is designed (and why it is that way),
+      and learn more about the major components by taking a look at our developer documentation:
+
+        * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+        * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+        * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+      # Community
+
+      If you got enough of code and want to speak to people, then you got a couple of options:
+
+        * Follow us on [Twitter](https://twitter.com/kubevirt)
+        * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+        * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+        * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+      # License
+
+      KubeVirt is distributed under the
+      [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+    operatorframework.io/suggested-namespace: kubevirt-hyperconverged
+    operators.operatorframework.io/internal-objects: '["v2vvmwares.v2v.kubevirt.io","ovirtproviders.v2v.kubevirt.io","networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","kubevirtcommontemplatesbundles.ssp.kubevirt.io","kubevirtmetricsaggregations.ssp.kubevirt.io","kubevirtnodelabellerbundles.ssp.kubevirt.io","kubevirttemplatevalidators.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.nodemaintenance.kubevirt.io","vmimportconfigs.v2v.kubevirt.io"]'
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    support: "false"
+  name: kubevirt-hyperconverged-operator.v1.1.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents the deployment of HyperConverged Cluster Operator
+      displayName: HyperConverged Cluster Operator Deployment
+      kind: HyperConverged
+      name: hyperconvergeds.hco.kubevirt.io
+      version: v1alpha1
+    - description: V2V Vmware
+      displayName: V2V Vmware
+      kind: V2VVmware
+      name: v2vvmwares.v2v.kubevirt.io
+      version: v1alpha1
+    - description: V2V oVirt
+      displayName: V2V oVirt
+      kind: OVirtProvider
+      name: ovirtproviders.v2v.kubevirt.io
+      version: v1alpha1
+    - description: Cluster Network Addons
+      displayName: Cluster Network Addons
+      kind: NetworkAddonsConfig
+      name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+      version: v1alpha1
+    - description: Represents a KubeVirt deployment
+      displayName: KubeVirt deployment
+      kind: KubeVirt
+      name: kubevirts.kubevirt.io
+      version: v1alpha3
+    - description: Represents a deployment of the predefined VM templates
+      displayName: KubeVirt common templates
+      kind: KubevirtCommonTemplatesBundle
+      name: kubevirtcommontemplatesbundles.ssp.kubevirt.io
+      version: v1
+    - description: Provide aggregation rules for core kubevirt metrics
+      displayName: KubeVirt Metric Aggregation
+      kind: KubevirtMetricsAggregation
+      name: kubevirtmetricsaggregations.ssp.kubevirt.io
+      version: v1
+    - description: Represents a deployment of Node labeller component
+      displayName: KubeVirt Node labeller
+      kind: KubevirtNodeLabellerBundle
+      name: kubevirtnodelabellerbundles.ssp.kubevirt.io
+      version: v1
+    - description: Represents a deployment of admission control webhook to validate
+        the KubeVirt templates
+      displayName: KubeVirt Template Validator admission webhook
+      kind: KubevirtTemplateValidator
+      name: kubevirttemplatevalidators.ssp.kubevirt.io
+      version: v1
+    - description: Represents a CDI deployment
+      displayName: CDI deployment
+      kind: CDI
+      name: cdis.cdi.kubevirt.io
+      version: v1alpha1
+    - description: NodeMaintenance is the Schema for the nodemaintenances API kubebuilder:subresource:status
+      kind: NodeMaintenance
+      name: nodemaintenances.nodemaintenance.kubevirt.io
+      version: v1beta1
+    - description: Represents a HostPathProvisioner deployment
+      displayName: HostPathProvisioner deployment
+      kind: HostPathProvisioner
+      name: hostpathprovisioners.hostpathprovisioner.kubevirt.io
+      version: v1alpha1
+    - description: Represents a virtual machine import config
+      displayName: Virtual Machine import config
+      kind: VMImportConfig
+      name: vmimportconfigs.v2v.kubevirt.io
+      version: v1alpha1
+  description: |-
+    **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+    Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+    Containerized Data Importer (CDI), Virtual Machine import operator and Cluster Network Addons (CNA) operators.
+
+    **KubeVirt** is a virtual machine management add-on for Kubernetes.
+    The aim is to provide a common ground for virtualization solutions on top of
+    Kubernetes.
+
+    # Virtualization extension for Kubernetes
+
+    At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+    additional virtualization resource types (especially the `VirtualMachine` type) through
+    [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+    By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+    resources alongside all other resources Kubernetes provides.
+
+    The resources themselves are not enough to launch virtual machines.
+    For this to happen the _functionality and business logic_ needs to be added to
+    the cluster. The functionality is not added to Kubernetes itself, but rather
+    added to a Kubernetes cluster by _running_ additional controllers and agents
+    on an existing cluster.
+
+    The necessary controllers and agents are provided by KubeVirt.
+
+    As of today KubeVirt can be used to declaratively
+
+      * Create a predefined VM
+      * Schedule a VM on a Kubernetes cluster
+      * Launch a VM
+      * Migrate a VM
+      * Stop a VM
+      * Delete a VM
+
+    # Start using KubeVirt
+
+      * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+      * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+    # Start developing KubeVirt
+
+    To set up a development environment please read our
+    [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+    To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+    You can learn more about how KubeVirt is designed (and why it is that way),
+    and learn more about the major components by taking a look at our developer documentation:
+
+      * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+      * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+      * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+    # Community
+
+    If you got enough of code and want to speak to people, then you got a couple of options:
+
+      * Follow us on [Twitter](https://twitter.com/kubevirt)
+      * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+      * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+      * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+    # License
+
+    KubeVirt is distributed under the
+    [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+  displayName: KubeVirt HyperConverged Cluster Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAARgAAAEYCAYAAACHjumMAABam0lEQVR4nOydB3gb9fn4v3faw5Js2fKSvO0kkrMTsCFgBQKEslqIzB+6AAcocVpIKD9aWrBSaKEtJKUQEjLKKO0PLFo2hG1DEpvEcZYl7ynZkqf2lu7+jx2HXxLfOZJO077P8+Qp1ffu9Fo6vfd+30kFJCTTKBQKLgBgoUKhKAEA5AIAssRicVp5efnk62wAADL9zzv5r6GhwarT6QYAAL0qleqEVqs92djY6I3130FCQhJHVFRUcFpaWl5CUdSPEmMMRdFdCoUiP9Z/EwkJSYxRKBRFhw8f3o6iqImgYrkQF4qiHz/33HO3SqVSONZ/JwkJSRSpqKjgTlss0aCttrZ2baz/ZhISkgijUChKDh8+/DcURc1RUi5nmdx6ff3cc88ppFIpJdafAwkJSRipqKjgtbS0vBxlpYJHV21t7bWx/kxIogMUawFIIkdZWZl4+/bt/1NeXn4XACAp0PMQAGxDTqel3Wpnj7s9DA+CuLwIgkyaIQgAKAwgiEWBqRwqlV3M5TiKkzhUOgxzgxANBQAc2r59++4dO3a8qdPp/KH9hSTxDqlg5iBSqZS1c+fOR+Ry+f8AADiBnudDENsjp1qtz3f2pKEABJzCQIEgz63ZmdpfLyhkXJIiEAcp7mGlUnn/tm3bWoI8jyQBIBXMHGLSYtm6dWuVQqHYCAAI+Ifeb3eYdnX3gZd7+hkmr48V6vtDAHivzxCNVhfloT/ITBcBAGgBnopqtdoP9u/fv2v//v2fkxbN3IFUMHMAqVTK2blz5//I5fJfTyfEBcSkxbL1pNr2QldfRrhlKuUl9e9ZtRSUC5Nzgzz1u2mL5mS4ZSKJPqSCSWDKyspypi2We4KxWHpsdtPunn6wu7ufafX5mBEU0XdNetrIpsJc9IfZmWkAAHqgJ2q12o+mLZpPdTqdL4IykkQQUsEkIFKplLtz587fyOXyrQCAgLc0XgSxPXi8xbarpz/sFsvFKOZytPtWLfVfmSbMC/LUY0ql8hfbtm1ripBoJBGEVDAJhEKhyFUoFBunLZasQM/rstlNL3f3o7u6+1h2vz+SFsvF8MvThCObCvMQhSRLCAAIWBatVvvptEXzsU6nI+udEgRSwSQACoUiqba29jEAwEPB/Ch9COLc1Hzasrd3ID2yEgZPDps1tH/VMte69NSCIE89qVQqN23btu1whEQjCSOkgoljtmzZkl9VVXWvTCa7CwCQGeh5Q06X/ZU+rXdfTz+tz+EMOEwdA5AfZmXoHyjMg67NSJu0aBiBnqjVar+ctmg+0Ol0nsiKSRIqpIKJQxQKBa+2tvZxAMAvg/nReRHE8df2bstTrZ3JTr8/4PPigbKU5MG9q5Y4Svm84iBPbVEqlZu3bdtWHyHRSAhAKpg4QqFQ8Lds2bKxvLz8EQBAwNuaQafL/o/eAe++3gHaQHxbLBcDvT5DpK8uygPXZ6anwMH5aOp37NixTaVSHdbpdO7IikkSKKSCiQMqKiqgnTt3/lImkz0TTFTIgyCOP7d1Wf7U2pniQpCAQ8CJwMpkwdDuFUtsq1L4JUGe2lZZWXm7SqU6FSHRSIKAVDAxRKFQJE9bLA8AAAJu0qR1OKcslv29AzSt05XIFstFuVqUOrS5KB+6KStdQIGgQJWvBwDw0fbt26cygzUaTYSlJMGDVDAxYNpieUgmk/0pmKiQy++3P9PWZX26rSvFM8cslouxhM/Tv7RisfXy1JTiIO/b71Qq1QOVlZXHIygeCQ6kgokiCoUiZcuWLfeVl5f/YrrnbUAMOJz2/T393v19Wvqg0xVwKcBc5MrUFP3monz0h9kZAhoMB/pZeAEAB7Zv3/7S/v37D5AWTfQgFUyEEYvFUFVVVVlVVdUmiURyezAFgF+PjBlf7OqD3xsycP0oSjZoP4dsFtN4T36OsypPwsjlsIVBnNrb0NCwa8eOHftUKpUxgiKSkAomstTU1OQolcpdAIAfBHPeSZNlYlPzKd/hcaMoctLNDagQ5Pz1gkLtE9KSNBaFkhzEqS61Wv276urqHfX19WgERZzXkAomzExbLJdNWyyVIPC+KugJk9m8u7sf2dc7wPejKNlaMggymAzT1pIC123ZmbQCLicYi2agoaFh944dO/aoVKrxCIo4LyEVTBipqanJUyqVuwEA1wVznsnjndjYdBL5z6A+NXLSzQ9gANx/X764p7oorzCY6m0AgEetVtdUV1f/pb6+HomgiPMKUsEQZNpiuaKqquoBiUSyIQiLBWk2mi27u/uQV/q0PB/pYwkruWzWyP2Fucimwjwqn0YLRnEPNjQ0vLxjx46XVSrVSARFnBeQCoYACoUivba29g0AwLpgzpvweMarjp5E3x0ykBZLhIEBcP1lyaLehxcU5QeTEgAA8KrV6icrKyv/qNFoSIsmREgFEwJbtmwpnbRYZDLZnQAAQYCnIUcnTJaXe/qRV/u0pI8lymSxmGO/KMj1bSrKg4V0ejDO89Mqlerl7du3/6uxsdEUQRHnJKSCCQKFQpFZW1v7DADgxwCAgBXEmNszds/RE9AH+uFgnI8kkcHzpGxh9++lxTnBNEQHAAzX1dX9rrq6+lWNRkP2DA4QUsEEwJYtW5ZMWyx3AAD4AZ6GfDdhtOzu6kde79fxEUBaLPGEiEEff6Awz/tAYR6UzmQE0y+nddqi+WdjY+NEBEWcE5AKZhYUCkVWbW3tXwAAd5zZzgfGsMs9es/RE/DHhhHSYol/fI8tKup8snSRGA5idtSkYVpXV/dEdXX1Xo1GQ/YMxoFUMBhs2bJl2bTF8v8AALwAT/M3jButu7v7kDf6dQIkCIVEEnuS6TTjpsI89y8KcoGYzQqmZ3HHtEXzemNj41gERUxISAVzDgqFQlxbW/vs5H8GY7Hona6Re5pOUg8YRlIiKyFJFEAeKi7oeHapNIMCQYE68CeZqKur+0N1dfUujUZDdtibhlQwZyyWFdMWy+3BjFhts9gsT7V2+P49MChASYtlTpFEpZo3FeY5tpQUMNOZjGBKELpVKtWe7du3v9rY2Djv82jmtYJRKBQ5tbW1zwEAbgvmsxh3e8yPnW517u0dEJGKZW7DoVAsNbIFhq0lBZkUCArGR2Ouq6t7qrq6+gWNRjNvO+zNSwWzZcuWVVVVVZtkMtnkVijgoe2tFqtlV3c/8s9+HdPk9cZy/AdJlMnjsIwb83Ncd+flMLJYzGC2wr0qlWrf9u3bX2lsbNRHUMS4ZF4pmIqKCtbOnTv/JJPJHgzmbx91u82/OdXqfKVPm47Os8+M5HyYMGz73aLioUcXFqXTYDjQlIVJrHV1dc9UV1fv0Gg0zgiKGFfMix+LQqHI37Jly6by8vIqAEDA+2n1pMXS1Ye8MaBjmr0RHbFKkmBIWCzjPfkSZ1V+DlPCZgVj0Qxs37796f3797+u0WgcERQxLpjTCqaiooK9c+fOZ2Qy2S+DOW/Y5TY9ekrjeq1flz7XPyMSYtAgyPHowiLd7xYVi5gUSjBRJ5NKpXqosrLytQiKF3Pm5I9HoVAUnmOxBGzGnjZbzbu6e9F/9Q+yLD5fQs0VIoktWUyG6a78HOfG/Bx6fnAd9jTTzclf0Wg09giKGBPmjIIRi8W0qqqqH0y3TQi4HwsCgOetgUHbru4++NuxiWCeQCQkM4AB8NyQlT6+uTAfuTYjLT2I9h3OhoaG13fs2LGroaHhpE6ni7Ck0WFOKJiamppypVL5EgBgWTDnfTY8Olx19ART53QF46wjIQmI5QJ+7+6VS6iXpAgkQZ76plKp/NW2bdtGIyRa1EhYBSMWi+lVVVU3TLemDLgfCwKA93/7dZMWC3Ro3EhaLCQRBQLAtz4jbXRTYT5yY1a6KIim7y6tVvuv6fnbxxLVoklIBVNTU7NGqVTuBAAsCeY8jcVquLfpJOPwuDGYzEwSkrAg5SX17125BFyWmhLwyJpp/jM9f9sQIdEiRsIomGmL5aZpi+WqQM+btFg+04/YX+ruQz/QD5OKhSTW+O+UZBt+UZgLX5EmTA3CovFotdp/T1s0RxLFokkIBVNTU1OhVCpfBACUBnPeabNFf2/TKeZ3E6TFQhJ/rE1L1f5j9VJfHocd8NjgaT5QKpWbtm3bFvdaJq4VzJYtW+RbtmypkUgk8kDPQQDwHNAPO3Z29aEfG0ZIxUIS7/g3iDMNDxTmQVeJUlODmITg1Wq1b+3YseOpHTt2tEdYxpCJSwWjUChKa2trdwIArgzmvOMms+H+plOMo0YTqVhIEo41qSm6fauWuhckcQuDOM0HAPhHZWXl71UqVdxFneJKwWzZskVWVVX1qEwmqwQABJTo5keB5xP9sP3Frl7o0+FRMipEkuggN2Wl6zcV5sHXZYhSoAB/BwCACbVa/a/9+/dPWjWHIixjwMSFgpFKpWDnzp33yeXyvwEAWIGe1zRhMtzffIrZbDSTioVkznFpSvLgnpVLHEsEvOIgTz1QWVl5l0qlGo6QaAETcwUjlUqFBw4c2C6RSH4WyPF+FPV8ODTs2NnVCz4fGSMVC8lcB12fkaavLsoHP8hMT4EDn+00qFKpfrd169Z/6nS6mM11iqmCqampKVEqlQcBAGkAAD0AIHO24xsnjIYHmk4xT5gtpGIhmXesEPCHdq1cbL8kJTlgi0atVu8sLS3dHFnJ8ImZgqmpqVmiVCr/AwAomn7JON2u8rzaDR+CuD/QDztf7OoDX5EWCwkJuEqUqt9cmIfenJ0hoEAQO4BTnpBIJE/pdDo0CuKdR0wUTE1NTb5SqTyF0U3OdO6kxA6rzaJoOIacIi0WEpIZLOYn6d8qW4ks4iVlz3LY5IM7Wa1W/7a0tPSZKIo3RdQVjFQqZR04cOBriURyKcbyBAAgxeByef7c1u3b29NPt/v95FB4EhIcqBDkvk2cOfr4ohKajJ+ENUDOON1kzadWq59Yv379M9G0ZKI+bXBkZOQ1Pp9/Pc4y47jR3Hd1fQP3s+FRlhdFyYbaJCSzgABAVVusvN3dfdQsFuvEymR++jkjd2zTiXu0yddEItHVEolEq1KpjkdLvqgqmOeee+628vLyJ/HW//T1N947PzwwYOJOmXwxj3CRkCQKKADUD/TDWV02u3Z9hgihwTALADA2uSM49ziZTLYGAPBpfX19VELYUf0Royh6anLriLX2dN233sc++5I2pZQXLuoBLHZRNGUjIZkr5HJY2kNr1ziyWcwFOIfoZTLZQo1GY4m0LFHbgrz11lv34SmXN0+1+B777Evq9zKNj0fd201CMlfotzslD7dqPFYf7sjszH379v0mGrJEZYsklUpZL7300gGAkSTk9vnA9a++gdg8nv+TxelAQHqGDUBQwDOLSEhIzgBBoI3HpwsbLSbWDUIRTIFmblQkEskqAMCe+vr6iE42iIoFU1VVddO54edz+WntOy6D1XZ+pAhF04B2oDcaspGQzDGQElFSH4BARpfTTtk12I+XxctSKpUvicXiiAoTFQWjUCh+gvX6p51dPlWLGjv1eXxsJXA4SCVDQhIESQzqKSGH/n0L2doRPfzB2DCektmgUCiC6lgQLBFXMBUVFZBEIsH8I145Nmu0jAbGRvwRE4yEZA6SKWCiF2bD/6W/G4x43Jh+zaqqqjsiKU/EFYxcLr8SazaRD0HQzzq7cb1QUxiNycDvH4+kfCQkcwUWjXJKyGHkXPg6AgD87ugwpoKRyWTXS6XSiEWTI65glErlLVivv6tpMxmdrtkrQxFECIwTxkjJRkIyh0DyUzl6CADMoW+fG8fwtkm5CoVihlIKF9HwwWAOQfv3ydOBRYjGRqnTXbtISEhw4DKoGgGLthZvfcjtonY47Ji/I6lUuiZSckVUwSgUikltKr3w9UlV+kl7Z2A9KpzOPGAyRS21mYQkEcnkM30X6+f7tXEccytUWVm5PlJyRVTBiMXipVivtw6PeF3BzH4e1AkBikY865CEJBFhUuFWIYc+W0X1FA1mI17Q5BqxWBwRXRBRBVNeXo45yvXU8HBw7+txFwCTcSRccpGQzCXyhBwtDEFpFzuu02mnO/yYOia9vLw8LxKyRdqCwZy8eHzIEHz4eXSULH4kIbkADp3SmsKhXxHo8W0OG6YfpqysLKi57oESEwtGPTwS6DS7/8NuywN2O+mLISE5hww+yxNMo/xupwOzv5JEIlkeVsGmiZiC2bBhAxsAsBBr7dig3hvCJSlA288CKOoiLh0JSeJDhSFDKoeO1WQKl3Z8CwbTX0qUiCkYmUx2BdZso0GLBQzbbIFOrzsfp3MhsFgGwyEfCUmik8pljFBgKCOYc7qdDszffMJZMAqF4lqs199vbSdWvTk2SrZyICEBwJnBYwY6wuR7epwO1I1gZoiIa2pqcsMi2TlE0oLBjK1/3dMXeHgaC4tZDNzuNkLXICFJcNK4jMNsOqUk2PN8KEo5YbXgJa5iJsUSISIKZjrBbob/BUFR8GlHVyj+l3NhgoF+L5ndSzJfgSFoNDeFHXJ6/3cWI2ZEVqlUhj3hLlIWzBKsa3eOT/gsbnfQZt0MbNbFwGYdIHwdEpIEJJVLN9CpcLDjZL/nsNmE93C+RiqVhlUnRMqCwQxPn9Qbwvcm4+MxG4dJQhJDPJk8ZmhBkmm0bifD5MPcSHBlMhlm5DdUIqJgpFIpZoLdiVAS7PCYGBcBv5+0YkjmFUIO/RCHQcVr5h0w7Q47pobBMw5CJSJDzWQyGaaQLcPD4Xw/Hhjo776u7FJRNos5rxpTddkcrm/GxjHL8ucDV4lSO+8vyL0w4oFavT672mKF39QO0vUudyAjVRMKCAITeULOrPPbA6XbaadeysPsYjv52/13ON4DRELBlJWVcQAApVhrh/q13rA2GjcZlxYAtPOl1csIa/REwuL1ORd9+vXAkNMVsT4e8UoKnTb2dvkqZjKdhrVNmIpQPr14kWtXd5/p6bZO5ojbQ8jnx6NSXVeJUr2rUwSubBaTQoWgqA8rPMvXlon+Vo8tLPkqp21WBKTP/C0qFIrycFz/LGFXMBKJpBTruh1j4/4Jp5O4g/d84NeajtGevewSD5tKIbQvTSR4NGrqC8tKG25raJp3CuauXIkxmU6b1cHJoMDMh0oKmOXC5LGyrw4yQp3/tVzAt3y05hI0k8XkAwCSQhY6PPg+VI+GzSrrdNjx8smWSaVSoNFowvI+YffBKBQKzJTjD9s6POF+r0kc4+PC3zSdmHe+mFvFmStXJQu6Yy1HlLH/ojAv4IfUpcLk1P+UrzJAZ1oQBcX/k2SNflFRRp9WLjHn84mxpgGXM+i8FzwMHjdlwovr6A05QnUhkXDyYvpfvuruiYxpiaL8F+u/NescTqL5NYkG/eGSgnmVC/RQcf7p4iSOJJhzbhVnZv4gQxRUL6EyocD0v2UrhSl0ergt7pDwA2D6c39XWMcpowBADWajG2tNKpWGzdEbCQtmRgTJ6/eDr3p6IxZWRs2mxfs0bbpIXT9eUUiyMhfzkzpiLUc0EDHoI0+VLgxpS3ibODi/6NOLFyHRnHp6MT4eG55wIkhQijUQmqxmTLcCXpAmFML6IVZUVEz+z4wtUuvomNvp9UXyaUDfe+SYHw3BFE5kKBDE27tqqfHMQ25uc09+jolDpWaFcm65MDlg63ZBEndEnpaaEsr7RIoPx8Iaff2ew+YJTLdFOEPVYVUwcrn8ksk93IWvnzZE5gM6l6GhoeTnWzu0kX6feOPSlORL1qendcZajkgCA2C5ryA3ZAdnHocd8P33k5zsmEWJsDhqMXW12G0RGb9o8/sZOpcT66EctwoGs4L62JAec68XVhBE+LvPvzLafPgTv+co0MMLCud0hfmjC4s0+Rx2yD8yGIICvs+XCHjOUN8nAnj+3N/NjOR2rcOJGU3KqqmpyQ/H9cOtYDCLpTTDo8QqqAPEYTAUvdbeNRyN94on1qWn5a8VCU/GWo5IkMVkDtdISwjd7L12R8BbSCGdHjfbzW9NE+N6jzuiw6M7HdjdU6RSaVgKH8OmYBQKBQsAUIa11jQ4GHkL5gzcvU3N9ii9VzzB/PelKydNe1usBQk3GwtyLAwKJaiubRdybMIUsP+vw2qLmwzg90YNwbeWDZIupx1TB4RrlEk4LZglWFm6PRNG37jDGbUv7WR3L/89XTirKhODDCajdGN+zpzKB6JB0MS9+TmE7x2VTh/wsYfGjXERKOhw2MYaLSbMXP7wvo8d7++Vl5WVEVZw4bRgMAscP2hrj+6e1udNrz7w2aAfRePG1I0Wm4vyoDMpDnODx6Ul7WI266Lzfmaj1+6wvDdkCFhJvd6nS3H6/TG3BHdoe31ohGoFz2XM66GMeDA3GDyJREK4BCdsCgZvyNrXPX1RT+Ef7O3L+0/vwLybo7RUwC+5Iyf7cKzlCAc5bJb+t4uKCWWuIgD47z5ynBaMxvWiCO3Frt6YJm2etFpMp2zWoHrtEuGw2Yj594ZjlEnYFAzWiJLJL/bTjq7oWxIoKtx/7HjMn0IxgPL66uUSBgwnvKP7voJcKxWCCFWMf2kYddePTQQ80uMsT7S0czqstgki702Ed8cMUQ2VH7WYMbdCEokkPhSMVCqlYFVQt46MuF0+X0ycZl9q2rhNRtO8GzdLhaGch4oLxmMtBxFYFHj0nvwcHtHr/L2rJ6TtogtB6Jd9dZD5wZAh6krG4HHb6ozBK0UiHLGYvH505kcVjoS7sOzxFArFCgDAjKKw04aRmCUt+d2uzF99/tXRw5W3riZ6rU8No8O/b2mLitl8qVDge3H5YkJjPKuL8uh/bu9yAADiJiISDE/KFnZnMhmYEclAaTaazR/qR0IuVBz3eNk3HzrKfrA437BNugDm02kiIvIEyku6Pp8HRSLuezkXB+KnaV1OJI/FvtDgiBsFg5lg1zyo90WqqVUgNJxWZ9dfuWa0IkN00bm9s3FZajK3126fvOk44ZMOm2ajCflVUYG1JIkTcnsACZtV9Li05OsnNR1rwytd5CnksAe3LCgk1LbRh6Dee5tOhiXE+3xnb8bznb2ghMsZz+GwUDoEz1pwyKTAyNuXreZDAATte+x2OlxfGscFlBjUfnQ47CCPNeN5JKypqVm8bdu206FeNyxbJJlMhjnuQDM6GtseLX5/1t5jxwlvk5KoVM4T0pKobLcQAOCdXb2E768/yBasyGYxe8MjVfS4vzDXDgNAKDz7vt7gbjaZw2q9ddjswi+Gx1I/NowIZ/v330FD2ueG0ZACDO+MGuBkKi0mhWWd2Bm9QC6XExplQljBlJWVTX6Rl2KtHdVFLcEOl/+ePEUfsDsIy7GpME8gZjGj4jh+tU/L1DtdZoKX4VcX5REbchdleFSq4a68HML9V57v6IlpJfSWEy1cp98fVHrGoNvl+s5spLqR2GRXdDmwJz7K5fLriVyX8BchkUhkAMMc1FutyLDNHlVnFRZOm13y24ONp4hehwrDrJ/kiqNS52Tx+ZgPnWghnD/0UHGBAALAGB6pIs8zSxb1pTGCm7V8IafNFvs3YxMx9T1prDbBX9u6rYEe7/Ij3q0dmkkTAnZgT12MOO1OG55mu0KhUIS8EyGsYPA62L2naYublP03G78TacwWE9Hr3JUnidqTsVanz2iaMBFSDiwKJXtzUV5C9MlZkMTVPVCYJyNyDZff734xDNvLcPBUa0fyM21deh+CuGY7bsztcd178uSYzuMS6rET3qKC2eejal2YzzTadJZ+SBD+wYjFYswmwf9Vt8VN2Tviduc+8+3hMaLXWZDE5T26oDBqw/cfPaUh3MHs0YVFAgYMx33pRI20xE607+0Lnb3+/b0DM9qFxAIvitJ+e7o1c8ln9Y5d3X2GHptjUtFPaRAvgpjrR8cntp5QG7M++Ix22mWNi2jf58YxTAudSCNwwjcwiqJNAICV577mRxDAfOIpjw9B4qYRN4PDGdD++sH0NAadUGW3F0GsvHc+obsQJCoV4l9VlBvWilIJZXVu7+j+8uGTmqvDJ1V4yWGz2vpvWCcBABCJ0vlzP/rCNeBwRjzSR4BxDpXitPv8GWejq6lcur5ElBSWUSREKeUm+V9esHiGYaBWq/9RWlpaFco1CVkwGzZsYAIApBe+fsow7Iwn5TKJ224XP1x/kHBjJhoMJ92dL4na9u8Xx06xXEE6DC9ka0nhimIuJ14jSt7XLlnuJqhcwHuDBlucK5dJhHafX3xWucAQ8OSmsOOi7+8krTYb5PTP3GESaaFJSMHIZLLLJrf6F76uHolxeBob+J/fHEpqt1oDdr7h8bNcSdiaL1+MDpud/6Z2aNZ9fAAkby7Kj8vSibVpwj55mhDTjxcMf+/qjZseuoGSymE4GFRKcqzlOIsfoHCn0461TSqtqKgI6TdN6EvBS7Br0g3FPDyNCeLP3dd0nHCdTpkwmVeRJoxaOv7zHT2TTzxCEay78iRp2Sxm3I052VyUT1gxfD0yNvHVyFis5xYFTTqPGXeV791OB1ZiLF0ul8tDuR5RCwYzCadtdCxuzL4L2d/UTA9DKwfKi8tLiVoVAXPCbEn6Z5+WkJOaR6NmvLC8NK62SekMuuNWcSahbvkIAJ6fHzkR8cZM4SaZTTckMalxY72cpd1hw3yQKZXKkBLuQlYwCoVCAABYjLV2RKeL2o8vWIxGU+bbXT2ErZhSPi/7ylRh1HJMtp7SJE14vIR8Pz/KzrxiVbIgPCP7wsCNmel0rByqYPhXn9apdToTynqBAPDmCePH93IuOBbMJCEl3BGxYDA72BmsVp/R6YqLsBsOtH1HjoVlC3dvQfQmt465PZxXegeIFlwyHi4piJsBdWVC4g/wF7v6wiJLNBFy6XYWjRLxbnWh0Omw+3FS/RYpFIrUYK9HxILBTL45NqiPmxsYj6/bO/hHx8YJWzG3ijPpAho1ah37Xuruo3kRhND7KSTZuYv5PMKZzeEglUEnVAj7zqB++IjRFPXRrhAA4Lr0NOcfZAssr65eZnt19TLHYwuLvfI0oY8KXdz/nxGHvpezeFGUMuB0YOoYsVgc9OD9kBUM3njJ08MjUYuwhIrf50v51cefE+54x6ZQOApxVtQUTI/dwflrexehjGQKBAR7Vy2dmLyXwidZaGD1IAmUSUV7z9ETUd8aLeXzbNobr5k4cGUZ63FpCe/neRLuz/Mk7D8uXkj7Wn4ZtWndlf58Dhv3D2PRKCYekxZ3vpdz6XBg78TLy8uDjvaFrGBkMhnmm53QG+JewUzS2NaWV6cbIpzhWpUfvW3SJH/QdAoH7E5CIedLUwRXrk8XqcMnVWgMOkN31e3pGfCYvNFtZnZLVvpwnfwyajaLiTv5camAR2lbvxa9Q5KFaQWk8xhx//vAq6wOpYVmSAqmoqKCgufgPTGkT5TBZ0n7mo4T9sVcKkxOWSNMiVr5gBtB6Lt7+oh+xvCvFxSESaLQaRwP2UeO7uzqjeo2Y2Uyf+zdyy9JFdBpF3XO0mEYfvWS5aCIyzlPycAQ8GQkMeOmhAaPLqcDU0aJRBKdLZJcLr8CADAjVd7m8SCd4xPxmGSHyTunWzgDdgfhPi/bl8noIIpzsff1DtBNHi8hua9OT1uwNk0Y0wbhHxtGgNET/E6tdmDQ2Wq1RdVJ+sSiEgdWUAOPSSXzweWrUfo5/anyhZwxGIbiolZqNjocuJXVxRs2bAjK5xWSglEqlZgJdp+0dxkRFE2YnASH05n6my/r+oleZ3WKIG2tSEi4WjtQRt0e9m9OtxLt9cJ6s2zl5EOCaN+ZkDF7fWBnV3CpOcMuN7j32Kmobo0KOGz1zdkZQXdFXMhLolwtSpv6sTKoFEs6j0moFUW0MPl8FLzKaplMdlUw1wrVB4OZdPNNX3+814LM4M0jTZnq8QnCldZ35Uqi2shjT0+/SG22ErJiREzGynsLcnrCJ1XwPNPWBVTaoYCOtXp94GdHjgNLdMeP+/auWurBKokJhPLpUHwGb8rgj/vt0VkazEa8hLugJj4GrWAUCkUSAGAF1tq7mta46QETKCiCpO5vPkk4EnRHjpjNplCi9vejAMB/7+oh3Ptkc+FUqn7MeqjY/X5Q2XgMPN3aMetx3TY7WPZ5PfhseDRqsk1ymTC55ypRatC+h7MUctgIBAFfOi8qxfdh44jVjJdCEFkFgzdgbcRu9+rMlrgOv+HxRvNxhsXrJZR9TIMh9o5lsqiOuXijf5DTZ3cQ2potEfBK75Bkfxk+qULjsZZ2sOyzevCUpgN8PjwKjhvNoGF8AvyzTwvuPnp8Srn02KPfAfQeglFCCIJATjJnmArDhMewRJNmi9nvxe6ul6NQKAKethl0ohPWgDUw1X93yEO05D5WjJotoj83HFH/8crLCXVUu68gN2ObpsM85HRFJfnL4ffTq4+fnvhoDWZL5EChvFG2ovC/g/pBN4IQGtNKlJNmy9S/eIEJw6N35+cQmkhh9HmN2QImoWvEAjeKUPpcTqSYzZlhhEil0kmLLqDIadgsmNaR0YTZX2Lxt/pvU4fsDqKtHGj35Emiut34WD+ScXBsnJDlBANQ+FBxQcJPgww3DxTmGWEACFnlWp+LQrTeKlZ04iTcBdMfJmgFU15ejtk+r2FAG/cJRLPhcLrStx9qJBxR+WVxPo0Jw1Ed+P/oqVYq0TD5IwsKRSl0Wty1c4gVFAiYtpQUELLIxz0eS4PVGPPG96Fy2m7FS7gLuIVmUAqmoqKCDQDAHIp1bFAfnz1gguCVpmaqB0E8RK4hYjCSHl5QGNVO/ofHjbwPh4YJlT4IGXTx35aWtoZPqsTm1wuK2iVsFqEt457BAZsXoPFc+DsrXU474YS7oBSMXC6/GivUZnQ6fQMmU0L6X85lwmbL+OOhRsLlub9dWMQR0mlR9UhuPn6aY/f5CL3nT/PE8qV8XsxLCGJNGp0+UrOohFCfmgGX0/rRxEjQ1cfxRLfT4feimIZxZk1NTUCp4EEpGLwEu/da241oAsX4Z+OPn34hGHO7CdX6cKhU/u2S7Kj2xOl3OJP+2a8jZH0BALgPlRREdXsXj/wkV2xiUSlZRK7xwdiwH01Q38tZ3AhCUdtteBMfAwpXB+uDwVQwh/oHEt56OYsfQUT7jzYTzsqtys+Jekn+C129NAQAQkrmxznZuQuSuCfCJRMEAFidLDBvEGf6FOJM5Lr0NFMyjRa3DckAAK77CnIIJa24/H7ngfG47EsdNI1mI6YJE+jEx4AVjEKhEAEASrDW3lG3zamn3r6m49QzuWyhsyKZL1wnShsIn1QXR2OxcfZ09xHqFUyD4bTdKxfrifYAnmSDOMs6fPO1xiPrruCryldRa8tXwQeuLBPob7oW2bFMNsKiUOLOb3dXnuTEQl5SLpFrvDE8aJ3weRPW93IujWbcZ+3VUqn0oruWgBUMXnhaZ7a4xh0OYaDXSQS6RkZEr51SE65R+uvSRUwoylmyj55uFQy73IQyiq9IFV7GplBCLp8Q0ukeVdlKs6p8JTuNwZgR5mVQYPZDxQWi5nVXuHLYrLiZdsCmUIx/Kl1EqF5ozONx/NswFPUmWJGiy2mHrNilGSyZTDZjZNGFBKxg8JrNHBsais0w3cgCb/3gY5rb7yf0hF0m4IuuSU+LWhHkJBavj7Wvt59QM6nn2rtHHH5/yMPe9q1aatsgyeJfrPZmIS+J/+7lqy1ErcVwUSnJGs1kMfKJXOPA+IjPjUZnKF80QAGAO512zIekQqG4aD4MYQvmtIFwY7i4ZMJuz/7fFg3hcPNdedEtgpzk5e4BmsvvD8mK0Tmcphp1e8gOzrvzJCM/zM4IuJXCcgE/6y9LFhEeiBcGkE2FeYSmbCAAeD8YH0mYbgKB0o3TH2byGXqxcwlbMKcMw4T6qsYze48cI5w8WCnJ4vJp1Ki2RNA6nZw/aDpCyrnf0zvgdiFISE77FDrNsXfVMm6wwYNHFhTlZzIZhCvaiXBtelrT6hQBoS5cH4wabDq3K2ET6/Bod0TYgtmwYcPkTbMAa+34UOIn2OFxuLcv+ave/sB6CeBAgSDW35ctjnrPlb+2d6d12+xBlT7YfT7Tvp7+kH8gm4vyvRQIhOLcpP0gUxSzbRIMgP1vy2R8Ii1k7X6/a8+Qds4pFzDlh7HhfS5LpVLprA/hgD5QmUxWgVVP4fB6ka7xiTnhLceBvvmDj70owTT8n+WJs3LZrKhm9/pQlPpSV3CtNX/f0m7Uu9whVf1CACCbi0J3X5SlJMesZcQt2RlDi3hJmA/QQPlyYsxv8nnjctYRUXocThQn4U6oUChKZzs3IAWDNyL2vdb2iURqohMKrYbh3AOd3UTHxFLvjkFezCt9WpbZ6w0ou7fDajP+vbNHHOp7Pb14kT6NQQ85esKlUWP249xUmEf0u0HeHTXM2d+BH6Bws8WC+QCQSqWzJtwFasFgXuRw/0BCTdQLlT1HjhG+xsYYOHuNXi/z9b7Asnt3dvX5EABCclDmsFiWRxcWiUI59yx+hMAMEwIs4SedWJeelkfkGodMRnu70z4nrZezfGcxYeqKyspKYgpGoVCk4SXY/belNW5yGCLJR23tSa1j44RaqWWzWan35EmimngHpiYf9tL8KDpr5qzB5Z54rV8bcjZ2ddGUBUAoetJiscYi3cGza8USmEg7BS+CeF/Q9c7ZQMdZGizYGb0AgMvKyspwfU+BWDCY0aNhm901ZLXOqQQ7PLx+P/PhTz4jnK38/PJSFgWCojrwrMNm5zzf2Tur/2fLCbXdHOKMIQYMe6qL8ghvD+pHie5Cg+cqUWr/ZakpmBNKA+Vb84RPOwcjRxcy4HJSTD7MW5cpkUhwG7UFYsFgKpgm3WDMnHKx4JPWdnHTkJ6Qo5ZLpabdmZMdVWfvJI+3tCUPOp2YeTHNRtP4m9rBkCuHd61YMsqhUgmN4mgcN441jBuj/rC6MyebsNX07uhwQvdBCoYOhx3z85otXH1RBSOVSjEVTMvISFxkX0YReM+RY4RvyJ/nigklc4WCw+9n7u3BHpz/fGdwY0PORcrjmu7OlxCqOgYA+O5pOhmLH6m3UpxF6Ltod9gsx6zmOe17OZcupx3v8wpdweC1xzs+NHe95ni8daqFNepwEmoauzY9jbcqmR/d1vhnxpzQbT7feT6zdqtt4i3tUMiO+s2FU2FpQsrhPzq9pdUS/a02l0o9mUSjhlzUiADge3agZ85l7c5G2C2YDRs2pE4+qLDWDvcPEO09knBYXC72z1XvOIm0p4QBoL92yXIEDkO1cjDoXW72nY3N7rOyexDEddvhJsiNICE5OFcI+Kb7CnMJ5UChAPgeb2mLSd3OAi7XSsS5++XEqFdjt81538u5tNhw8zZXbtiwAfNemFXByGSy1Vh5Lg6P1zdosc6rD/csn3V0JndPGAlVK0t5SWkrkvlEG4wHzUeGYUG71TYl+6GxCbvaYg25oXWNtMRFgSBCPU9OmSz2VqstJr2EDG4XIdnrTVGdUBMXjHg8wO7HfC4yZTIZpitlVgWjVCoVWK+/earFiKDonGioEyx+FKU/++1hopEg+DcLi6MaTZoEQQHl8Zb2yff1/+ZUa8jm/Y2Z6cabszNCrrY+y+9Ot8asEn/Q6Vpu9flCaslxymax1RnH590D1g9Q+BvTBF5dUiXW6xfzwWCOiD08oJ3L5QEX5dVjx9l2r5dQDtCPxJm8NAY96o9BlW4o5cETLYNHjKaQB4E9WEyoo8EUzUaz4SPDSCwH9bE/1o8EvU1FAfA/N9BDnW8RjrMcsZgwfa94ybi4CkahUOQAADAjBO9o2uZsgWMguHw+5q8//oyQgoEBYL6wvDQmU8b+3tkb8rhCKY9rX5eeRiiD24eg7o1NJ2MefXmhs3dShqB8id8Yx3xdTkfMZY8V31lMfhyzc+F0Uu554CoYvPB0v8lkm3A4UghJOQfY/d3RjAGzmVCV9O2S7JwiLiembQqCAQIA+WVRvjeUiaDn8v6QwXHcZA64Z0ykODQ+kf0HTcfsQ7HPwYMg3p26/qg65+MNs89HGXJjJ4ZLpdIZ0SRcBYPntDk+ZIh6Hke8svfIMaKfBXxXriRhErXuzBGbfpIrJux7+1tnT9zcQzXqdtlTrR1DF7NkOqw27+3NzSODHvecaXAfKh127HA1VkrLbBYMZgr1Sb1h3oWn8dh7tBlGCYab7y3MQYhOZYwWvyzKg7hUKiH/2+fDo4ZvxybiqWct9HhLe9aKz78xnTZbDBcu+hDEu7en31H29UH3MPDMe8sdnOkPg/lQxLJgcE1dvAS7U4bhOdNvlCjDNhvng9Z2882LFoT8gxExGGnVhXl9O7v7CFX0RprVyQLrpcJkQorB5fc7NzWfjsvoy3GTWbTks3p0VbJgNJ/D4jFgmGr3+32HxiYoI24PWyxgmSEIECqJmCt0OrA7gARswdTU1CQDAIqw1o4NDs2pESVE2XOU8DYJPLtUmkSDoHieFQQeLM73E+n4Nslb2iFXl80eT9bLhUBNRlOaSqdnvDEwSHln0MAYcXumHsLpvHnr151BhxN7GBsAYGFNTc15ShjvhrkGKwXc5HS5B0zmkMObc5ED7Z2cU4ZhQtEgJoUi/FmeOOptNQNlYRLXrJBkEf2F+Z7vTMzU+kw+c4RBheNZMUaVMa8XNngwA8nwhcMZMRWMUqnEzH95t7VtHCUYQZhr+FEUfujDA4QjCz/LlcSN4/NCdq9c4qTDMCEF8+bA4NhxkyXhthgUGHLnpbDnvWP3QhrMRsx7XqlUnpcPM+OmFounuiZeg3XyIQJNieYyX/f0pjQMaAml/l+ZJhSUC5OHwydVeFidzLdWpAkJZe2avV7HlpPqhFMuk6QnMV0QBJH3/QUcsZjwDI1rp3XIFDMUTHl5+eQqZn+Q/7Zo4tpPEEv2HGkiaoHQdiyVEapxigS3iTMJRw1f79N5DC53QiqYDB4jYdIIoskR/IS73GkdMgWWBYMZPRq0WOwTTiehsZpzGdVpDUNvsRJSEJcKkwvKU5LjKvGumMshFPVBAHDv7OpNSN8Ln0WzMmkU0ueIgQtBKP1OB6azVywWLz/731gWDGb+S5NuaL6WXwSE3eulPvb5l4QLGO8tiP70gdng02iEOhe+1NU70W6zJ+QWI4OMHM1KJ3aTxPOGNM5QMGVlZZgWTMvwSEIkg8WS146dELSPjhHaRt4mzmJwqZSARo1EA5cfCXnrN+xy2x873RazkgA6DPvWiVKN9+bnuB9ZUGjfmJ/jXytKdVGhi+962DSKNYVNI3O+ZqHTga1gysrKvrdgZjhqJBIJ3ojYedmeIRjQqezeY+izP8AMwgUEj0bl3ZqdOfp6vy4uKtZH3FOFJyFZIPt7B7xWny8mCuaGTJHxpRVL4Bw262zF9lllQemx2T0/OXIcNIwbce/p/DSOB4KgeTGWJ1Q6nQ5MTS2RSL43Us57Om3YsCEFAIA5n7d5UE8m2AXAGydOUeweD6HP6t78nLixFj8fDq27p9uPOF7u6Y+J7+Wl5YtNH665VJDDZmHmrhRwOfTDV62h/n5RMWYyRxKTauczafNiYgYROh02vPs0r6amZspfe56CkclkV2NZNS6fz9s1MUFq8wAYttnpz9QfJBR5WZMmTFsp4Ed9hhIW/xk0cE0eb9AzRWo07aYBhzPqvpd78iSWB4ryBAH0CoafLF3IuDtPMiNJMpPHjCs/WLxi8vngARfms/T7hLvzFIxSqcQcEfuOunWUaIn+fOLZbw9zBy0WIr4Y+PnlpXA8FEF6EIRxw8HvILvPF/Dfc3BswvyXti7CHe+CpSJN6HpCWhKU32T3yiWMBUnc731eTBrFnsKhJ2TUKxY0mLEHsp1NuPtewYjFYgoA4IdYB3/U3km604PA5fNRdhxsIJTde3lqivimzPSoTx/A4vC4MeWWQ0dd4+6Lbv2Q/+r0plsOHWGhBOuWQuHpxQv9uRx2UAqGDsOMTYW5Z5UnWpLORWAIIp27AfKVEde4vamsrIz+/U1QXl5eAABIxTryXU3rvBqyFg72Hm2mexGEkC/m7vz46RXz5ciY4PKvDvr+d2BwcNqffR52n99615HjttsamgQTHm/UAwKL+UmOcmFKSFuyNakpU99TMptu59KppCsgCNR2K+REMI2YJIlEsuD7bU9ZWRlm9Kh7fMJs93hntMIjmR2L201/4vOvxp++bl3IiWo3ZqZzizickS67ndBg+XDRbrMn3fldc9LTbZ2WUj6PlUqnu90IQu21O7x1I2NsL4rGbFbWxvyckJVxKZ83dW4Gj0H6XoIEBQDqctiQxVweVsrL8u8VDF54+oTBQO5HQ+SZ+oPCLZeXW0VcTkhPRRoMs/+4eOHw7Y3Hwi8cAU6brbzT5qnSq7P3Rky30EwY9m/MD3mG2uQ2icqmU6zJbHpCJgTGmi6nA17MnZnwPKlTvtc6eBbMiSEDWX9EgJePNBHa5lRKsrIXJXGjPs86kXhuqczIplJCthT1LpezMHWqVCpuK9rjmQ6HHdPyUygUy7//QPEsGM3IaFwkfCUq+442TyoYIiUE9Hvyc+b1FIfZyGGz7JuK8giNP2l32GlJTNL3EiqdTjveQ/SMBVNTU4NbQX1ENxh3Fb6JxIDZzNn13dGg80jO5c6cbAYNgshERwzuzZ+awELI93PQPBGXbTwThR6nA/FiO3pTzlowV2MlJlncbofObInlcKw5wcMffSp0EhjUlsViJj9YnD+jIfV8Z/KGvb8wj1CE0+H3O74wjpEV0wRwIwistmPf3lMKRqFQYJYHqE6rTeS+lDhOn4/2j6bjhJLmfi8tSeJTqYSGvc01freo2JDGoBNSDi/q+pBYRr/mCt9ZTJj395TykMlkJViLJ/XDCdkkKB7Z39RMSMHwabRUhSQrbqqsY00yjeZUyhYS6pOrd7tc742R93g4GHS7MA2Rsy9iThA42D8Q9dnJc5XjeoPg/dZ2PZFrbMyPr14xseS+ghw3BQKEfCcfjA3HTSJjomP0eTG3qmcVDOaTYNBsIb+AMPLAex8mIQgSctj/UmGy6HJhSk94pUpM7ivII6RsEQD8748Nk1ujMOHw+3DHDIBzemWch4dAsyGSmQxZrNy31a1EtjnQ9mUyOgCAcOkGm0IxXpee1qsQZw0qxFm6K1JTugAACRExvCdPoi/gsgkFH/5tGPQafT6ygDdM+NGZ5SPgnAppzEUUoKQFE2b2HDkGKhfLQj7/khSBWJ4mHK4bHQ+pPzIFghxPSEu6H1lQmM6iUPLPXXP4/d33HztlfqNftyJkASMMHYbdL6xYTChz2OrzefYODZAFvGGERaFg6pCzFgrmuAwRlxPzdgFzja+6ewTfaXWExpP8PFcS0vagmMsZPXr1FaYnpCWLWRTKjPomNoVS+M9Lli/5/MqyjiwmMy4HwW3Ml1jYFAoh6+X9sWHYh5LurHAiotExFfZZBYPpfKzIzyVzYMIMCgC8+f2PCGX3/iQ3m8OmwEEpAAmbNX7y2gpkeTI/6yKHUtelp5X857JVplDliyRVBIoap0HfGzWQ2iXMFLDYmPfzlIJRq9VqrMVlmRlk9mgEaBrUi77u7g3ZQqDCcNKOZaUjwZzzx9IFDhaFEvC2qkyYnDu5lQpJwAhxU2a6fkWyIIXINd4fG3YOetxkAW+YWcThYnZxnFIwKpWqEWvxpoULyEbfEeLlI02Ezr+vIDcnk8kIqARBykvq/2muJGifzTbZAomQTiM0sTJcQAD49q1aihJJ/HQhiPcFbR9ZWxdmIAC8S7g8zEj0WQtmUsHM6MCWI+ALioUphAa7k2DzrqaN3zNhJOKLYVTl51y0a97kl79/1dLJbUUoDwv69ZnxMWvvDkn2mIjJuNj2blY+HhsBDoTsnRZuFnG4LiaMrfenXn377bdHAQBHsA74kWxRhMWbn7j9ftqdb71NQVA05LyYzUX5dAYMzxpavjtfMlwmTM4J9T3KUwSER8eGAeSxRcWEQspeBPH+a1hHRkUjQIVAiKe1Nd+rnYaGhpNYR1xdiFmmRBIGvtMOpp42DIe8BUlnMpJvFWfOagXdLs4O9fJTcKjUmCejrUlN0cv4SYTKAg6ZjR6Dx0PmvYQf5BKeAFNxa7XaE98rGJVKVYt10LXFhbyK/DyyZCBCPF33LaGIxt6VSwQpdBrmNvbSFMHwtRlphLYVJi/habiEYFFg+5uXrqCc0z0vaExer/fp/i6yJUMEuF6Y1l3C5mAqf5VK9d/vFcynn376DQBAh3Xg7h/eSIMAFNs7bY6iatGkGqzW/lDP51CpKbeLszGzgx8szvcRrYY/abLEtI3k9RkiYzabRWgEyoGJUcTm95NZ6WGGCcPjj+YU4n039v3793/8/Yeu0WiQ2traJ7COXJiWmrRx9XJSwUQABEXh+9/9kEokL6aqYGavsEVJXP0GcRahsa1+ALxfDI/GNNnyBxkiQvcdAoDv/dFhUrlEgJ9miM00GMbsBKhWq3doNBrneR/87bff/goAoB3rhN+vraAyKBSydWMEeL+1Pfuk3hBy17uVyYKMq0Wpnee+tmvlEgsNhglZH6/09Du1TldMZwSJmAxCTuYDY8PufreTzHsJMwUsdvPPMsWYY44AABPV1dVPASzzefv27S9gnZEj4NO/2PhzKIlBJzRQjASbvUebCfli/rpEyoKmUw0q0oT6ijQhZo+fQBlzezyPnmqNud9CxAhdwdj9Pu/uoQFyiFqYSafTtX8tWiSEAcBs9tXQ0LCvvr5+yhiZoWD279+/BwDQhXXimtwc+mPyK+MhbDnneLX5eLLT6w25X8zyZL54XXrq1CTIh4rzkQBmM8/KK70D/gmvN+ZP/jG3J+TtzZfGcf+410tGjsIL8tvcotEMOgNvToxrx44d28/+nxlfnkaj8SqVyg0AAMzw6dY15azbSqVk68YwY/d4mb/99AsnkVYMd+VK0BUC/uBN2ZmE0uk9COLZ3dMf8/D0JOMeT6g+GP97o4a4+BvmEJ77snK+Xc0TLMNZR2pra+9TqVTfp05gfgH19fXDMpnMKpPJfnDhGgWGoQ2LZfT/tmicI3Z7zJ9wc4nvtIPJ961eMZzEYIQ0QkPKT4LKhSmWTCaD0CTIv7R32d/W6eMipZ5BgQc3iLOCDrUfNE043xzRky0Zwsg1KanHH5LkX4ZnHavV6v1XXXXVU+e+hqvhGxoamq+77roCkUi05MK1yauX5YjRfx4/5fchCPmUCCNcOt26tiA/JAUDQxA9g8kgVAGvdTg9ioZjDB+KxkXkpdNmpynEme2pDEZmoOc4/X7/Yz3tsMXvI+/NMCFhsDpq8ktSORQK3r156pZbbvmpTqc7r0Aa9ybS6XS+6urqnwEAjmKtr8jKpP/nx7f7z0QCScLF/qZmLoqzPY0Ge3r6/U6/P25+mB4ESbv50FHEj6IBj21RjeidOreLtK7DBAOCh15cIEPT6HQ8JT8il8uvbmxsnBEJnfUpVV9fj1ZWVm4EAGC2Fri+pIj1P1deTrZ0CCODFivvk/bOmBSYWn0+177egbhRLmfptNlXbTjcpLd4fb2zHYcA4P1YPzKybzD+/oYExveb3MLRVBp9Ac46olKpHqivrx/DWryoGaxSqU7V1dX9CM/5+Mdrr+aszM5KiF6uiQLRVg6hUtPS7jW43HHZouPdIcPylPc+hQ4YRj/BSkq0+/zjN3773fDdJ06w/QSnDZD8Hzemig5cK0yb4SY5S11dnbKysvK/eOsBhzIPHz78h/Ly8sex1sYdDk/5rn1I5/gE6VQLA1QY9p341QM9MlEaoVyWYOiw2lzST+uY/vhvJekv4LDbViYLaAIaDfUgfqbJ66N9MTzK9kEoq0TE9SUxaTEtb5grlPEF6ueKpPkAAEyHv1ar/c/69esVGo0G96YJWMFIpVKKWq3+BgBwGdb6N339roo9r5AKJkxcV1zYd+Dun2YAAKLymT50osX5fGdvQj/5c5LZdnEyi1QuYQAGkE61eIUvg87IwzlkrLKycqFKpZo1Az3gSIFGo/HLZLIbAQCY7TWvzMtlvnTLDVYoDCM1SAD4tLM774h2EHNfG26GXW7na326hHaKQgAgoiQGmVQXBjgwZXTfoiXG2ZSLUqm86mLKBcwWpsZidHTUBQA4IZfLq7DWV4uzGYMWi6t5SJ/QN2u8gAJgvnnRAkJ9UALhgWOnXEeMpoS2XoQcuiOdx0zovyFeqMqStF+VnIqXTAdUKtUvN2/e/Gkg1wo612Hbtm2H1Wp1FVaLTTDl9F1HE/N5ZFFkGFCdVqeN2OwRneR43Gh2vjEwGFLeTTyRwWOS6RJhYDE3qe3HGWK8iBFQq9Uvbd269dVArxdSMlVpaek/1Gr1Pqy1NA6b9tLNN5AFkWHA4nYzH//iKy+eMg8HL3T1xr1X92JwGVQTn0Ujh9gTZ/y3uUUUGAA8P1ZdaWlptU6nC1iZh5ytuXHjxscmH4BYazctWsBRrpNbyCQ84uw72lzUOTZOaGg+Ht02u/NN7WCiVxujBakcCtHizvkOFYKMfy+R9eYyWcU4h4xUVlbeH+x1Q1YwjY2NRplMdiUAADNpo+YqOW/rmnIyP4YgCIpSnv32MBpuZe1FEO9tDU3A6U/sUg9REsPKZVATfosXY3yP5RYNrEzir8JZ1ymVynKVStUR7IUJ1ZtoNBqbUqnciHfz/3n9NdzlmZlxMVcnkXn9+MkMq9vTGc5rvjdk8J00WeLGKVrC5YCrRUJQnpIMWJTAb8v0JCZpuRDkB0LRgetmSaZTKpUPbtu2LSRfYFi+nLfeemtDZWXlv7Bm74za7e7yXfuQ7glj3NzMich9q1e2vfyjm/LClRez5quD7kPjxphuj9IYdPCEtAQoxFkgnfl/ovhRFNSNjIG9PQPg7cEh4MfxEglYNKs0k8ch+qCcz5TxBOrniqWT9xWm30WtVj+5fv36J3Q6zHbdFyVs2r+lpeVZmUz2MNZaXU+fY+2+V+Oi/D+R6X3kwd685OR8otc5oB+xXn/wu5huK9IZDHDoqstBIXf2vLg93f3g/uZTmGsrc5LHGVRYGCER5zwwBHS1shW+TAYTM99FrVa/U1paeiuR9wjb/ru5ublh48aNVwAAZgz5yksW0IRslumTji4a+bQJHQ6dbrm6sIBQI2+Hz++58dAR2BjDTm+FHDZy8Ko1IJ/DvugDbmWKAKTS6eCA4fxR3EIO3ZzOYxJqTTGfYcOUsV0LF4/ms9h4Ien+zZs3V2o0GkKFt2H7sTc2Nlrlcvl6AMAA1vovyy8V3LNyBVl5TYD9Tc1CP4IQyot5Uzvo77E7YlrSUSMt8eWwWQFbz5uL88GNmef30Ernkb4XIvw0I3tgIZu7GGfZrlQq16pUKi3R9wlrBKG/v9/L4/HU5eXld2Ipr/IcMfiwrcM15nDEZcVuvGP3eOlcOl17eW5OSijfHQqA7+6jx6FhtydmkaMl/CTnC8sXU2EICurhxqFQwZvaoan/5jGpFkkKe9L8Ia3hELgqWXjowZyCUghnXrlKpdq8efPmL8PxXhF5CrS0tOyTyWSY5QRjdodrwfYXwITTSRZGhgAVhr3jjz86yGPg1ongsr9nwLzx2MmIlx7MRp38MktFmhCzG/1s2H0+wHvnk6lw5TKxYIRNpxBqCzpfKWCxW/4pXVY0S7DgSwiC1oXr/SLyBNi4ceNvAACnsdZSOWzmS7fcQHbCCxEfgtD2HW0OOrN31O12P3JKE9NI3uXCZFcoygWcmWAJSvlJIJlNM5PKJTToEGRQ5hezZlEuw5WVlZvC+Z4RUTCNjY1jcrn86kmDBWv99iWlnN9UrBmNxHvPB/Y3NScDAAaDOqdX6zd6vTHdmj5QmEeoLEHEYID0JNLwDRHnc8XS7kIWpxBn3VNXV3d9KMl0sxGxPWx9ff2oSqV64MzWfyZ/um5d+k0LF5BJeCGgGRkV1p5qGQ3UCnT5/a5d3X0xzdjNY7Ndt4ozCclgQX2mZDadzKcKgZ9mZGtWJPEvx1tXqVS/Xbt2LWbpDxEi6iSrrKx8u66u7k9YaxAAYO+tN9G4dDo5YykENn/wcaEXQQKqUXqytdM54HDGNKnu2aWLPCwKJWQLyoMgTi8ddUMQtmOSBJ/F3KSGX2TnLpzlkPeVSuX2SLx3xL3w1dXVj2u12vew1tK5XGb9fXfDySwm2d4hSEbtjiTVKfVFLcBum93517aumDp2lwp47tvEWYSqnZstZhOLQU0Pn1Tzg2wGs+evRYty8TJ1tVrtdzKZ7A6NRhOR94+4gtFoNOjDDz98HwDAiLW+IiuTvW3dWkek5ZiL7G06ljypa2Y75qWuPr83xjOOflGQ6yd6r31mHEv4thIxwP2HghJ7EoWKN7jOt3///iqNRhOx319U9uUajcYOAPhcLpcrAJjZ8X1VdhZDa7ZMnNAbyHKCIOg3mjjrCgvacgR8zBvI7PW67jp6nOqK4XC8VDrds3fVUohJoYScOWzwuIeeHegW+AEgOyUGjuORnIJjawQpq3HWXbW1tRs2b958MJJCRO3Jtm3btmaVSvV7rDUKDMP/uO0W4Spxlila8swFUACgX374iQQFANMX82qf1mv0+mLqs3iqdKGLT6MR8v/s1PWbPShKPnyCoFKU2fbDtIw1eOtqtXr77bff/kGk5Yiq6bx169Y9arX6Fbz11zb8iCFgMsntUhAcH9KLvurumTEYz4eg7he7+mLaBLuYy3FvLMglFPXpdjoGvzaO4bZwJJlJAYut/nmmWDLLIV+sX78eM/gSbqKqYHQ6nb+6uvoeAEAD1rpUlMZ6/+d3eiGMwVok+Lz83bHJH/F5Dt/tHd3mLps9piHdu/IkHgpEbFvz3qgBRcmSgIBJptL69y1ckiSg0tJwDumWy+U36nS6qDSDi/oXV19fDyorK3Gdvlfk5vCV69aSoesgeK+1LatrfOL7MIDW4XQoNe2Eqq7DwQ2ZIkLZ2mafV//ZxGhImb/zFOcjuYVWBgzP6GgwjXv79u331NfXRy1qG5Mng0qlaqmrq7sZbxzt41dVJK/Jy4nKTKC5gMfvpz3yyWdZZyNKL3f3e51+JNb5It7FAj4hGf6h141b/X5SwQTIL7Jyv6wQpJTirdfV1d378MMPfxNNmWJmeq5du/ZgQ0PDH7DWIADAxz//cVJpuojM9A2QdzVtkhNDBrPZ67Xu7e2PtXIBGQyGHsaIGAbKoNs19O6oIWqjcxOdtQLhyZ9mZl+Ht67VanetXbv2n9GVKsZ728rKyifVavXzWGtJDAbj3Z/eQRMwySS8QHm6/lvq//v6sGXE7Yl5Or3Z56XgWaiB8C/DoMeHojFXlInAIg732O/yiyQAJ4yvVqvfvuyyyx6KvmRxMuoBRdHPAADXYK3tONgwsfXjT1OiL1WCAlNQULoYApTYDwuw/ej6fg6Vmhv0eX5/z00nj2Z5UISsbLwI2Qxm91ulK3gQAHhO3RNyuXxlfX19TLoXxIV3frpE3IC19qvLLhX8dPnSkehLlaAgfggYJ2ItxRQf60dCyb71/13b6yaVS0DYH8kp8MyiXGxbt26tipVyAfGiYFQqVVddXd16AMCM7RAFhuHXFT8SrcjKxIw6kWAwFh/+8Vf6tEErGK3LafhkfGRRZCSaW/y/9Mz21TwB3meF1NXVKXbs2NEcZbHOIy4UDDjj9D2pUqkew1t/TfEjehKDQQ5yCwSnAwCTKea1O58YRsS7u/uPB9pWAgHA84K2z0d2Irs4hSz26Z9l4CfTNTQ0/Hnt2rUHoivVTOLCB3MWqVQK1Gr1ewCAm7HW63v7jPK9r3LxnFkk50Cno0BaCgEo5l8x+urqZeqf50lww6fgzCwk10+OHm8foLgWAgASfZxtRBHS6H1vl66g0mFYjHPIEZlMdrlGo4n5jPjYewLPYXR0dHK79P7NN9+8js/nz/jw8pIFLBRFTfW9/WRdysXw+yHAZALAinlACfpAP5w06HRpCzhsu4jJOC+vxYeirs+GR+13Hz3hHwAuhEmjpMZO1ITA8UR+8XABi12Es94qk8nWTRcYx5y4UjDgjJLx8ni8Rrlcfj/WFq6iIJ/5RVf3qNZsmX1iFwkAPj8KhMLYmzAA0I4Zzckvdffx/juo7+y1O1yHxiag94aGJ+46epy+p2cgyYz6JnJS2HgZqCRnQH8lzvv8hlQRbhGjUqm87e23326Lrlj4xPzmw+Ott976YWVl5ZtY5rLZ5XKW797nbR0ZI7M8L8YiGQqY8T9DqFjEHUzjMrJjLUc8c3Vy6sk/FJTIAABYRaw+tVr9QGlp6b4YiIZL3Dh5L+T2229/V61W78Ba4zOZrFc3/Aglksg1bxiP/0ZNNApsSOUwyCmNs8Cj0lofzS0U4SgXoFar98ebcgHxrGAmWb9+/VOTnx3W2iXibP4rG344BgHIE33JEoiJcQj441sPF6VxbBAESL8aDkIaTb97QSmFQ6Fk4hxyfOPGjbgR2FgSdz6Yc7FYLF4AwEm5XH4P1vqyzAzuhNNl/k6ri7knM25BEAhAEAKSkuJym8RlUIfyhJygs33nE1skBe2reQK8Ma8jcrn80kOHDsVHduUFxLUFA850wjukVqs3Tu4xsdaVV1ewl2ZmjEdfsgRiZBgCnvg09NJ5ZER6Fvw/Ts+uvyFVtARnHVGpVPfV19fHpXIBiaBgJiktLd0/ucfEWktmsZgH77+HlZHEtURfsgRh0ooxTsSdLwaGIKuIyyAd9Tgs5/JPbBLnXgFwZkir1eq3KisrMSd2xAsJoWDAmXG0k3vME1hrXDqdvfuHN05aOGQnPDzGxgBA40vHZPAYVgiCCI0zmauk0ei9v88vSp/lN9q5bdu2h6MsVtAkjIJpbGycmB5Hi1n4eMuihSl/vf4aXfQlSxA8bgiMj8VVFj45BhYbCIDxvxYvMmfQGXiZuma5XL5WpVIFNHgvliSMggFn2m1OqFSq+/FqW359xeX5isWy+Kj0i0f0QwD4Y549PkUal9HJolPw5vXMZ5CHcwoGilmcZXgHqFSqzfX19UHNJo8VCaVgwJnWDu/W1dVtw1vf88ObWEI2m3T6YuHzwWDCGHMrBgLAUZjGIX0vGFzGT/78R2kZeE7dSf5WWVn5RhRFIkTCKRhwZhztk1qt9j9YawIWk/PNfXdTRRxOXNRixB3jsffFpPOYRhiCyDGwF7CEy2v7c9GiS/HSR7Ra7ScymezX0ZcsdBJSwWg0GrSysvJuAMAhrHWpKI3/5h0b3DAEOaMvXZzjdMBgbDSWVowrW8AknS8XkMNkdTxZUMKHAcCbBtFcWVn5Y41GE99ZkxeQkAoGnHH6WuVy+XWTih1rfW1Bfsq/br9tONBeJPOKoUE0Vtm92QLWAINKEcbkzeMUBgwPvVhSiqbS6HiZusNyuXxdY2NjwjVdi+tM3ovR39/v5fF46vLy8juwlGVpukgwZLHom4f0SbGRME5BURjQaH7A4UT1AUODIfOC9CQmDEFkWcD/4X08r6i/lJskw1lHVCrVT5599tmTUZYrLCSsBXOWhx9++LO6uroteOsv3nxDyiJR2lB0pUoAxsaiXjqQlsR0UGCItF7O4Za0jAPXpKQtxVuvq6v7XWVl5fvRlSp8JLyCAWfabb6o1Wpfx1qjUyjMT+/+CSuHz0848zKiuJwwMEY1ouRJ5zHIToTncBk/ueV/cgrW4a1rtdq3qqurn4muVOFlTigYcKby+pcAAMxEOwmfn7zvtpvJcbQXotOi0YooZfCYfSyyW933UADU/0hOweTWHa9Qd3j9+vUPaDSaKEsWXhLaB3Muo6OjbgDAh3K5fAMAYIbPpTAlhc+mUTu+6OrhzaW/mxAIAgMGEwEsVkS3SxQYsi5KT6LBMER2IZy8OSnU0d0LFxtzmKxinENGlErlVW+//TZmACORmFM/tOmq0iG5XH4b1vr/Z+/cY5vIrj9+Zvy2Y8exYycmHhIT5+UbFtj9/bZh2WLz0MarLoiXYyo1iFKkPuSqgnYl1G5F/uhDLaWvVdltRaS2Yllqt6W7qLTsrpSkXZEAKktK7PAOyZgCedIEEtuZeCoTR03ZGW8S7LEzMx8JCelYo+PJ9XfOPXPuOWtKlxp7Rh70dd69JzY3mmGKioOxMKORbJFOOWzUKMS6lyR7lxBXXAVG1rxLIBD4is/n+4BbrzIDrwQmwc2bN4P19fVqs9m8hsm+mrBK3u68/Ggslv3xqjlBLIaBVhsHuSJTIjNlN+VFZBJcjF4en5DWdR8os9tTjHn9eWNj46HR0dHcOpm6QHKyCVE6oGn6NAC8zGT7Q1fo5o7j/nLuvcpRlEoKqh3STIw4MeUprlWY88Qh9tP0n0Crxgilim3tvY9h2Esc+5RReJPkfZKGhgZfYrvEZNte67B9e73zstjTN0kkIoXR0bS/UcIx7FGpQS2eOQIAOY4Pv1G1/E4KcbmXHKHMK3i3RZohFAqNAMCZZLvNJxslY+uW2You3b13/erAoPhmAx7PUYqDwZDWB45Zqxw0aRVs1amC4vMW6xW30bSKxRxtampyHjlypJtjtzIObwUGppO+AwihMYQQ41bpxdKl2DvdV4ZHJiLiUzYWA8jXx0EmS5fIxO0mzbhcigu+odRqnb79G6Xl1ThgjP1BA4HAqz6fL6c70y0U3uZgZkiOow0AwA4m++2RBz3VP3ldG6WmxEgmT0tBRSXjWIz5YtDIr1YXaavSca3FjE2p6j6GVhGJu8vykT8ihLYv9noXNnibg5kh8YdDCDWSJNnOZC8r0Nt+tXXzsJiPAYCHY1J49PCpczEYBuNlBrHfiwSw/tfKKqRs4pJYkwihz/FVXEAIAgPTIhNpbm7+AlvP3l2rVlTufm7V37j3LAcZfPpBbYV5igdKGS703Ev0cIWju1qTx1ZMN5lYk6FQiNctRXidg5lNW1vboMPhuIgQ2spUg7DFUV18jgz33BgaFvZhvGgUwGCkQSJZ8Pa5vFAzppBKBH2CvcFs6dxmLl7NYp7w+/3bfD4fY1TNJwQRwczg9Xr/HAwGD7OYVW9ueUUlxfFF0es0Y8TjONy9s+Btkl4lu6ZVygTda9ehzjv/NcLGWvsTDAZ/5PV6T3PrVXbgfZL3SaxWq5okyQ4AYJyUd/Ffd7vXH/216d+RqJCTvnGodgCoVPN6AGEAkZVW/ZBKLhHsEHuLXHH7aM0zUr1UxjYRoJMgiBfC4fA4x65lBcFskWZIjqO96HK59jLZLVqtCQP86gc3bwk5h4ABhk2BLn9eAmPUyPuL85WCFRcAmPxxheNOikOMdFNT0+ZTp071cuxX1hCcwMB0PuaOx+PpMZvNm5i2iWvKlub3jIyc67x7f2l2PMwBYlEaCk044HPXmGWFmlGlTCLUt0cT+5YuO+/SG59nsU/6/f5dPp/vDMd+ZRVB5WBmU1tb+9tAIHCAyYYBqH+zY2tdw3L0Efee5QgUJYG+3jkPtDZq5LfyVTLBRn1fKikN7TAVf5rNHggEXvV6vce59Sr7CC4HM5tkEd67ALCJyT4Wjd6xHfrZyND4eC333uUI1TUUqNSfVHwX+VSZYViCY4JM7j6rzW99vRKtBgC2Sf6/Rwh5+FzvwoZgIxj4bxHeTpIkzzPZtQpFyd+/uEdi0WqFO5J2Dr17i7SKIaGKS7lKff2wvcbBJi4kSZ5FCDUKUVxA6AID0yIz3tzcvJetkrfGVFjz/fqNfdx7liMMD9EQT/3WukinFOo6enjQVknJcdzMYp8ppotw7FfOIMgk75O0tbX1OxyOywihLQwnr2GlpbgoRlHvfdjbZxOcKNM0DvF4FHT5jNukArWst0SvsgjtvmAAo98trwo+q81nOyE94ff7t/p8vg6OXcspBLUoUuH1ek8Gg8Gfspjl36vfWP9Shf1Djt3KDQb6ZRCLMUV4k3bT42M2gntQ7bJYb7j0xjo2ezAY/KHX6/0Lt17lHqLAzMLtdn8nEdCwmPFjDdsqd65Y3gIAc367whNwGPr4GSVTnqJfJsFLs+NS9ngmT9uyq7gk1fc+43a7f8ChSzmLKDCzCIfDD10u18sAcJvJbtKol7zt3e56bd3a9xObB+49zCKDgx8bcVKky1gf35zFrtK890bV8pVKnHX87TWXy7U5HA7z+hDjXBFcaPtJ9Pb2Ujqdris5jpbp/mDry222/ytZcqmjLxx7EImwDSvnF/G4BFRqCpTTCd18pZQkCtRmAa2hh26D+Z1v2uw1GgnrUYjI/v37t584cYLxASVEBF0Hk4qWlpYvu1yuI6k+Q8Xjg9vf8l96t/vKekFEgzrdJJTapCCVxp8j9L0KmWRZtl3iiN4DpeUnNxUWfTWVoLa2tu5ct27d77h1LbcRytNn3ly4cOEfZrM5ghDawCbEOIapP7ui1vqZqoqgWi4fuDE0NDQxSRl5K9zRKIBMRhnMhv5inZL3uRcFjl/0mCwt3yqzTzyv07NFtI9pb28/tHbtWraXBIKFnz+ENNLS0rLb5XIdnaMYT5y+ev3sW5f+SR/vvFwFAAQHLnKLQkE5NrwwoOffsQAaAEgACK43FJ6zKTQTe5aUvAIArOX/s2hFCG0MhUJiV8QnEAVmDvj9/i0ej+eXAMBWUMXEwOV79+/fGB7Jo6amaP4khbF4gaXwI4kE70827lrka+jxMChMplLhLyrViegzEZlVppgZ/T+QJHnC7XbvDoVC0cz7uvhY5IuDO5xOp6G1tfWvAPD/2fYly0zO6gg4lfxHpziHw2eOIYR2i5ELO/xPTKaJtra2YYIgXIFA4OsAcC/b/uQIiW2jPCkucQCgkjVCU8n/85WRQCCwB8OwRlFcRNKOx+Mx0DT9Jk3TFC08YvP4bCR5j6IZ9Idr/uR0OguyvQZFBMC+ffscZ8+e/QVN0wPZXvUcMh+Bmc2M2FBPcY1s8aivr+/4wYMHN1itVjGtIMItTqcT9/v9m2iaPknT9ES2fw0ZJl3iMCM0kTRdLxOQXV1dB5xOp+CnUy4UUY3TTF1dnYogiOq6ujoHQRAEAFgAgE/VvlMZqJ+iEtd0OBwShBDBcX1W4vuMB4PBR8l55j0kSd7q6Ojoam9v7w6Hw089iE7I/CcAAP//LazR1LfsgEMAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - hco.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - v2v.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - machineremediation.kubevirt.io
+          resources:
+          - machineremediationoperators
+          - machineremediationoperators/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - daemonsets
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        serviceAccountName: hyperconverged-cluster-operator
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - networkaddonsconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          - endpoints
+          - pods/exec
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - patch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - kubevirt-handler
+          - kubevirt-controller
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - put
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - delete
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancemigrations
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancepresets
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - limitranges
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - update
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstances
+          verbs:
+          - update
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - version
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - kubevirt.io
+          - ssp.kubevirt.io
+          - template.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+          - delete
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - daemonsets
+          verbs:
+          - create
+          - update
+          - get
+          - list
+          - patch
+          - watch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - update
+          - get
+          - patch
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - create
+          - watch
+          - patch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: kubevirt-ssp-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          - upload.cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - '*'
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes
+          verbs:
+          - list
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims/finalizers
+          - pods/finalizers
+          - volumesnapshots/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - events
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - nodemaintenance.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: node-maintenance-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - list
+          - watch
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - clusterrolebindings
+          verbs:
+          - update
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - clusterroles
+          verbs:
+          - update
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - hostpath-provisioner-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - hostpathprovisioner.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - delete
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+        serviceAccountName: hostpath-provisioner-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - v2v.kubevirt.io
+          resources:
+          - vmimportconfigs
+          - vmimportconfigs/finalizers
+          - vmimportconfigs/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        serviceAccountName: vm-import-operator
+      deployments:
+      - name: hco-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-operator
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                - name: KVM_EMULATION
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-operator
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                - name: CONVERSION_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-v2v-conversion:v2.0.0
+                - name: VMWARE_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-vmware:v2.0.0-5
+                - name: SMBIOS
+                  value: |-
+                    Family: KubeVirt
+                    Manufacturer: KubeVirt
+                    Product: None
+                - name: MACHINETYPE
+                - name: HCO_KV_IO_VERSION
+                  value: 1.1.0
+                - name: KUBEVIRT_VERSION
+                  value: v0.30.4
+                - name: CDI_VERSION
+                  value: v1.18.2
+                - name: NETWORK_ADDONS_VERSION
+                  value: 0.39.4
+                - name: SSP_VERSION
+                  value: v1.0.40
+                - name: NMO_VERSION
+                  value: v0.6.0
+                - name: HPPO_VERSION
+                  value: v0.4.3
+                - name: VM_IMPORT_VERSION
+                  value: v0.0.4
+                image: quay.io/kubevirt/hyperconverged-cluster-operator:1.1.0
+                imagePullPolicy: IfNotPresent
+                name: hyperconverged-cluster-operator
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: cluster-network-addons-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cluster-network-addons-operator
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                name: cluster-network-addons-operator
+            spec:
+              containers:
+              - env:
+                - name: MULTUS_IMAGE
+                  value: nfvpe/multus:v3.4.1
+                - name: LINUX_BRIDGE_IMAGE
+                  value: quay.io/kubevirt/cni-default-plugins:v0.8.6
+                - name: LINUX_BRIDGE_MARKER_IMAGE
+                  value: quay.io/kubevirt/bridge-marker:0.3.0
+                - name: NMSTATE_HANDLER_IMAGE
+                  value: quay.io/nmstate/kubernetes-nmstate-handler:v0.21.0
+                - name: OVS_CNI_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-plugin:v0.12.0
+                - name: OVS_MARKER_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-marker:v0.12.0
+                - name: KUBEMACPOOL_IMAGE
+                  value: quay.io/kubevirt/kubemacpool:v0.14.6
+                - name: MACVTAP_CNI_IMAGE
+                  value: quay.io/kubevirt/macvtap-cni:v0.2.0
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/cluster-network-addons-operator:0.39.4
+                - name: OPERATOR_NAME
+                  value: cluster-network-addons-operator
+                - name: OPERATOR_VERSION
+                  value: 0.39.4
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERAND_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/cluster-network-addons-operator:0.39.4
+                imagePullPolicy: IfNotPresent
+                name: cluster-network-addons-operator
+                resources: {}
+              serviceAccountName: cluster-network-addons-operator
+      - name: virt-operator
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              kubevirt.io: virt-operator
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              annotations:
+                scheduler.alpha.kubernetes.io/critical-pod: ""
+              labels:
+                kubevirt.io: virt-operator
+                prometheus.kubevirt.io: ""
+              name: virt-operator
+            spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: kubevirt.io
+                          operator: In
+                          values:
+                          - virt-operator
+                      topologyKey: kubernetes.io/hostname
+                    weight: 1
+              containers:
+              - command:
+                - virt-operator
+                - --port
+                - "8443"
+                - -v
+                - "2"
+                env:
+                - name: OPERATOR_IMAGE
+                  value: docker.io/kubevirt/virt-operator:v0.30.4
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: docker.io/kubevirt/virt-operator:v0.30.4
+                imagePullPolicy: IfNotPresent
+                name: virt-operator
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8444
+                  name: webhooks
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /metrics
+                    port: 8443
+                    scheme: HTTPS
+                  initialDelaySeconds: 5
+                  timeoutSeconds: 10
+                resources: {}
+                volumeMounts:
+                - mountPath: /etc/virt-operator/certificates
+                  name: kubevirt-operator-certs
+                  readOnly: true
+              priorityClassName: kubevirt-cluster-critical
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: kubevirt-operator
+              tolerations:
+              - key: CriticalAddonsOnly
+                operator: Exists
+              volumes:
+              - name: kubevirt-operator-certs
+                secret:
+                  optional: true
+                  secretName: kubevirt-operator-certs
+      - name: kubevirt-ssp-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kubevirt-ssp-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: kubevirt-ssp-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: IMAGE_REFERENCE
+                  value: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.40
+                - name: WATCH_NAMESPACE
+                - name: KVM_INFO_TAG
+                - name: VALIDATOR_TAG
+                - name: VIRT_LAUNCHER_TAG
+                - name: NODE_LABELLER_TAG
+                - name: CPU_PLUGIN_TAG
+                - name: IMAGE_NAME_PREFIX
+                - name: OPERATOR_NAME
+                  value: kubevirt-ssp-operator
+                - name: OPERATOR_VERSION
+                  value: v1.0.40
+                image: quay.io/fromani/kubevirt-ssp-operator-container:v1.0.40
+                imagePullPolicy: Always
+                name: kubevirt-ssp-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              serviceAccountName: kubevirt-ssp-operator
+      - name: cdi-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cdi-operator
+              operator.cdi.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: cdi-operator
+                operator.cdi.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                  value: v1.18.2
+                - name: CONTROLLER_IMAGE
+                  value: docker.io/kubevirt/cdi-controller:v1.18.2
+                - name: IMPORTER_IMAGE
+                  value: docker.io/kubevirt/cdi-importer:v1.18.2
+                - name: CLONER_IMAGE
+                  value: docker.io/kubevirt/cdi-cloner:v1.18.2
+                - name: APISERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-apiserver:v1.18.2
+                - name: UPLOAD_SERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadserver:v1.18.2
+                - name: UPLOAD_PROXY_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadproxy:v1.18.2
+                - name: VERBOSITY
+                  value: "1"
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: docker.io/kubevirt/cdi-operator:v1.18.2
+                imagePullPolicy: IfNotPresent
+                name: cdi-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                  protocol: TCP
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cdi-operator
+      - name: node-maintenance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: node-maintenance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: node-maintenance-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: node-maintenance-operator
+                image: quay.io/kubevirt/node-maintenance-operator:v0.6.0
+                imagePullPolicy: Always
+                name: node-maintenance-operator
+                resources: {}
+              serviceAccountName: node-maintenance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+      - name: hostpath-provisioner-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hostpath-provisioner-operator
+              operator.hostpath-provisioner.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hostpath-provisioner-operator
+                operator.hostpath-provisioner.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: hostpath-provisioner-operator
+                - name: PROVISIONER_IMAGE
+                  value: quay.io/kubevirt/hostpath-provisioner:v0.4.0
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: quay.io/kubevirt/hostpath-provisioner-operator:v0.4.3
+                imagePullPolicy: IfNotPresent
+                name: hostpath-provisioner-operator
+                resources: {}
+              serviceAccountName: hostpath-provisioner-operator
+      - name: vm-import-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: vm-import-operator
+              operator.v2v.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: vm-import-operator
+                operator.v2v.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                  value: v0.0.4
+                - name: CONTROLLER_IMAGE
+                  value: quay.io/kubevirt/vm-import-controller:v0.0.4
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                - name: OS_CONFIGMAP_NAME
+                - name: OS_CONFIGMAP_NAMESPACE
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                image: quay.io/kubevirt/vm-import-operator:v0.0.4
+                imagePullPolicy: IfNotPresent
+                name: vm-import-operator
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: vm-import-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - events
+          - secrets
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - daemonsets
+          verbs:
+          - delete
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - ""
+          resourceNames:
+          - hostpath-provisioner-admin
+          resources:
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        serviceAccountName: hostpath-provisioner-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  labels:
+    alm-owner-kubevirt: kubevirt-hyperconverged
+    operated-by: kubevirt-hyperconverged
+  links:
+  - name: KubeVirt project
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/hyperconverged-cluster-operator
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  replaces: kubevirt-hyperconverged-operator.v1.0.0
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-hyperconverged
+      operated-by: kubevirt-hyperconverged
+  version: 1.1.0

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/kubevirt00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/kubevirt00.crd.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    categories:
+    - all
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  scope: Namespaced
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/node-maintenance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/node-maintenance00.crd.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nodemaintenances.nodemaintenance.kubevirt.io
+spec:
+  group: nodemaintenance.kubevirt.io
+  names:
+    kind: NodeMaintenance
+    listKind: NodeMaintenanceList
+    plural: nodemaintenances
+    singular: nodemaintenance
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            nodeName:
+              description: Node name to apply maintanance on/off
+              type: string
+            reason:
+              description: Reason for maintanance
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          properties:
+            evictionPods:
+              description: EvictionPods is the total number of pods up for eviction
+                from the start
+              format: int64
+              type: integer
+            lastError:
+              description: LastError represents the latest error if any in the latest
+                reconciliation
+              type: string
+            pendingPods:
+              description: PendingPods is a list of pending pods for eviction
+              items:
+                type: string
+              type: array
+            phase:
+              description: Phase is the represtation of the maintenanace progress
+                (Running,Succeeded)
+              type: string
+            totalpods:
+              description: TotalPods is the total number of all pods on the node from
+                the start
+              format: int64
+              type: integer
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/scheduling-scale-performance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/scheduling-scale-performance00.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtcommontemplatesbundles.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: KubevirtCommonTemplatesBundle
+    listKind: KubevirtCommonTemplatesBundleList
+    plural: kubevirtcommontemplatesbundles
+    singular: kubevirtcommontemplatesbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/scheduling-scale-performance01.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/scheduling-scale-performance01.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtmetricsaggregations.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: KubevirtMetricsAggregation
+    listKind: KubevirtMetricsAggregationList
+    plural: kubevirtmetricsaggregations
+    singular: kubevirtmetricsaggregation
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/scheduling-scale-performance02.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/scheduling-scale-performance02.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtnodelabellerbundles.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: KubevirtNodeLabellerBundle
+    listKind: KubevirtNodeLabellerBundleList
+    plural: kubevirtnodelabellerbundles
+    singular: kubevirtnodelabellerbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/scheduling-scale-performance03.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/scheduling-scale-performance03.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirttemplatevalidators.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: KubevirtTemplateValidator
+    listKind: KubevirtTemplateValidatorList
+    plural: kubevirttemplatevalidators
+    singular: kubevirttemplatevalidator
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/vm-import-operator00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/manifests/vm-import-operator00.crd.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.v2v.kubevirt.io: ""
+  name: vmimportconfigs.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: VMImportConfig
+    listKind: VMImportConfigList
+    plural: vmimportconfigs
+    singular: vmimportconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VMImportConfig is the Schema for the vmimportconfigs API
+      properties:
+        apiVersion:
+          description: APIVersion defines the versioned schema of this representation
+            of an object
+          type: string
+        kind:
+          description: Kind is a string value representing the REST resource this
+            object represents
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: VMImportConfigSpec defines the desired state of VMImportConfig
+          properties:
+            imagePullPolicy:
+              enum:
+              - Always
+              - IfNotPresent
+              - Never
+              type: string
+          type: object
+        status:
+          description: VMImportConfigStatus defines the observed state of VMImportConfig
+          properties:
+            conditions:
+              description: A list of current conditions of the VMImportConfig resource
+              items:
+                properties:
+                  lastHeartbeatTime:
+                    description: Last time the state of the condition was checked
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the state of the condition changed
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message related to the last condition change
+                    type: string
+                  reason:
+                    description: Reason the last condition changed
+                    type: string
+                  status:
+                    description: Current status of the condition, True, False, Unknown
+                    type: string
+                type: object
+              type: array
+            observedVersion:
+              description: The observed version of the VMImportConfig resource
+              type: string
+            operatorVersion:
+              description: The version of the VMImportConfig resource as defined by
+                the operator
+              type: string
+            targetVersion:
+              description: The desired version of the VMImportConfig resource
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.1.0/metadata/annotations.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.1.0/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: 1.1.0
+  operators.operatorframework.io.bundle.channels.v1: 1.1.0
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: community-kubevirt-hyperconverged
+  com.redhat.openshift.versions: "=v4.5"

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/cluster-network-addons00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/cluster-network-addons00.crd.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+      type: object
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/containerized-data-importer00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/containerized-data-importer00.crd.yaml
@@ -1,0 +1,1681 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.cdi.kubevirt.io: ""
+  name: cdis.cdi.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: cdi.kubevirt.io
+  names:
+    kind: CDI
+    listKind: CDIList
+    plural: cdis
+    shortNames:
+    - cdi
+    - cdis
+    singular: cdi
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CDI is the CDI Operator CRD
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CDISpec defines our specification for the CDI installation
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes CDI infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              uninstallStrategy:
+                description: CDIUninstallStrategy defines the state to leave CDI on uninstall
+                enum:
+                - RemoveWorkloads
+                - BlockUninstallIfWorkloadsExist
+                type: string
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: CDIStatus defines the status of the CDI installation
+            properties:
+              conditions:
+                description: A list of current conditions of the CDI resource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the CDI resource
+                type: string
+              operatorVersion:
+                description: The version of the CDI resource as defined by the operator
+                type: string
+              phase:
+                description: CDIPhase is the current phase of the CDI deployment
+                type: string
+              targetVersion:
+                description: The desired version of the CDI resource
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CDI is the CDI Operator CRD
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CDISpec defines our specification for the CDI installation
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes CDI infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              uninstallStrategy:
+                description: CDIUninstallStrategy defines the state to leave CDI on uninstall
+                enum:
+                - RemoveWorkloads
+                - BlockUninstallIfWorkloadsExist
+                type: string
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: CDIStatus defines the status of the CDI installation
+            properties:
+              conditions:
+                description: A list of current conditions of the CDI resource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the CDI resource
+                type: string
+              operatorVersion:
+                description: The version of the CDI resource as defined by the operator
+                type: string
+              phase:
+                description: CDIPhase is the current phase of the CDI deployment
+                type: string
+              targetVersion:
+                description: The desired version of the CDI resource
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/hco00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/hco00.crd.yaml
@@ -1,0 +1,985 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hyperconvergeds.hco.kubevirt.io
+spec:
+  group: hco.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: HyperConverged
+    listKind: HyperConvergedList
+    plural: hyperconvergeds
+    shortNames:
+    - hco
+    - hcos
+    singular: hyperconverged
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HyperConverged is the Schema for the hyperconvergeds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                pattern: kubevirt-hyperconverged
+                type: string
+            type: object
+          spec:
+            description: HyperConvergedSpec defines the desired state of HyperConverged
+            properties:
+              BareMetalPlatform:
+                description: BareMetalPlatform indicates whether the infrastructure is baremetal.
+                type: boolean
+              LocalStorageClassName:
+                description: LocalStorageClassName the name of the local storage class.
+                type: string
+              version:
+                description: operator version
+                type: string
+            type: object
+          status:
+            description: HyperConvergedStatus defines the observed state of HyperConverged
+            properties:
+              conditions:
+                description: Conditions describes the state of the HyperConverged resource.
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              relatedObjects:
+                description: RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster.
+                items:
+                  description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              versions:
+                description: 'Versions is a list of HCO component versions, as name/version pairs. The version with a name of "operator" is the HCO version itself, as described here: https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version'
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HyperConverged is the Schema for the hyperconvergeds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                pattern: kubevirt-hyperconverged
+                type: string
+            type: object
+          spec:
+            description: HyperConvergedSpec defines the desired state of HyperConverged
+            properties:
+              bareMetalPlatform:
+                description: BareMetalPlatform indicates whether the infrastructure is baremetal.
+                type: boolean
+              infra:
+                description: infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.
+                properties:
+                  nodePlacement:
+                    description: NodePlacement describes node scheduling configuration.
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              localStorageClassName:
+                description: LocalStorageClassName the name of the local storage class.
+                type: string
+              version:
+                description: operator version
+                type: string
+              workloads:
+                description: workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload.
+                properties:
+                  nodePlacement:
+                    description: NodePlacement describes node scheduling configuration.
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            type: object
+          status:
+            description: HyperConvergedStatus defines the observed state of HyperConverged
+            properties:
+              conditions:
+                description: Conditions describes the state of the HyperConverged resource.
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              relatedObjects:
+                description: RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster.
+                items:
+                  description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              versions:
+                description: 'Versions is a list of HCO component versions, as name/version pairs. The version with a name of "operator" is the HCO version itself, as described here: https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version'
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/hco01.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/hco01.crd.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: v2vvmwares.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    kind: V2VVmware
+    listKind: V2VVmwareList
+    plural: v2vvmwares
+    singular: v2vvmware
+  scope: Namespaced
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/hco02.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/hco02.crd.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ovirtproviders.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    kind: OVirtProvider
+    listKind: OVirtProviderList
+    plural: ovirtproviders
+    singular: ovirtprovider
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: OVirtProvider is the Schema for the ovirtproviders API
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation
+                                    of an object. Servers should convert recognized schemas to the latest
+                                    internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this
+                                    object represents. Servers may infer this from the endpoint the client
+                                    submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: OVirtProviderSpec defines the desired state of OVirtProvider
+          properties:
+            connection:
+              type: string
+            timeToLive:
+              type: string
+            vms:
+              items:
+                description: OVirtVM aligns with maintained UI interface
+                properties:
+                  cluster:
+                    type: string
+                  detail:
+                    description: OVirtVMDetail contains ovirt vm details as json string
+                    properties:
+                      raw:
+                        type: string
+                    type: object
+                  detailRequest:
+                    type: boolean
+                  id:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - cluster
+                - id
+                - name
+                type: object
+              type: array
+          type: object
+        status:
+          description: OVirtProviderStatus defines the observed state of OVirtProvider
+          properties:
+            phase:
+              description: VirtualMachineProviderPhase defines provider phase
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/hostpath-provisioner00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/hostpath-provisioner00.crd.yaml
@@ -1,0 +1,201 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.hostpathprovisioner.kubevirt.io: ""
+  name: hostpathprovisioners.hostpathprovisioner.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: hostpathprovisioner.kubevirt.io
+  names:
+    kind: HostPathProvisioner
+    listKind: HostPathProvisionerList
+    plural: hostpathprovisioners
+    shortNames:
+    - hpp
+    - hpps
+    singular: hostpathprovisioner
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HostPathProvisioner is the Schema for the hostpathprovisioners
+          API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostPathProvisionerSpec defines the desired state of HostPathProvisioner
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              imageRegistry:
+                type: string
+              imageTag:
+                type: string
+              pathConfig:
+                description: PathConfig describes the location and layout of PV storage
+                  on nodes
+                properties:
+                  path:
+                    description: Path The path the directories for the PVs are created
+                      under
+                    type: string
+                  useNamingPrefix:
+                    description: UseNamingPrefix Use the name of the PVC requesting
+                      the PV as part of the directory created
+                    type: string
+                type: object
+            required:
+            - pathConfig
+            type: object
+          status:
+            description: HostPathProvisionerStatus defines the observed state of HostPathProvisioner
+            properties:
+              conditions:
+                description: Conditions contains the current conditions observed by
+                  the operator
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: ObservedVersion The observed version of the HostPathProvisioner
+                  deployment
+                type: string
+              operatorVersion:
+                description: OperatorVersion The version of the HostPathProvisioner
+                  Operator
+                type: string
+              targetVersion:
+                description: TargetVersion The targeted version of the HostPathProvisioner
+                  deployment
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HostPathProvisioner is the Schema for the hostpathprovisioners
+          API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostPathProvisionerSpec defines the desired state of HostPathProvisioner
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              imageRegistry:
+                type: string
+              imageTag:
+                type: string
+              pathConfig:
+                description: PathConfig describes the location and layout of PV storage
+                  on nodes
+                properties:
+                  path:
+                    description: Path The path the directories for the PVs are created
+                      under
+                    type: string
+                  useNamingPrefix:
+                    description: UseNamingPrefix Use the name of the PVC requesting
+                      the PV as part of the directory created
+                    type: boolean
+                type: object
+            required:
+            - pathConfig
+            type: object
+          status:
+            description: HostPathProvisionerStatus defines the observed state of HostPathProvisioner
+            properties:
+              conditions:
+                description: Conditions contains the current conditions observed by
+                  the operator
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: ObservedVersion The observed version of the HostPathProvisioner
+                  deployment
+                type: string
+              operatorVersion:
+                description: OperatorVersion The version of the HostPathProvisioner
+                  Operator
+                type: string
+              targetVersion:
+                description: TargetVersion The targeted version of the HostPathProvisioner
+                  deployment
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/kubevirt-hyperconverged-operator.v1.2.0.clusterserviceversion.yaml
@@ -1,0 +1,2399 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{"BareMetalPlatform":false}},{"apiVersion":"networkaddonsoperator.network.kubevirt.io/v1","kind":"NetworkAddonsConfig","metadata":{"name":"cluster"},"spec":{"imagePullPolicy":"IfNotPresent","kubeMacPool":{"rangeEnd":"FD:FF:FF:FF:FF:FF","rangeStart":"02:00:00:00:00:00"},"linuxBridge":{},"macvtap":{},"multus":{},"nmstate":{},"ovs":{}}},{"apiVersion":"kubevirt.io/v1alpha3","kind":"KubeVirt","metadata":{"name":"kubevirt","namespace":"kubevirt"},"spec":{"imagePullPolicy":"Always"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"templateValidatorReplicas":2}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle","namespace":"kubevirt"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation","namespace":"kubevirt"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle","namespace":"kubevirt"}},{"apiVersion":"cdi.kubevirt.io/v1beta1","kind":"CDI","metadata":{"name":"cdi","namespace":"cdi"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"nodemaintenance.kubevirt.io/v1beta1","kind":"NodeMaintenance","metadata":{"name":"nodemaintenance-example"},"spec":{"nodeName":"node02","reason":"Test node maintenance"}},{"apiVersion":"hostpathprovisioner.kubevirt.io/v1beta1","kind":"HostPathProvisioner","metadata":{"name":"hostpath-provisioner"},"spec":{"imagePullPolicy":"IfNotPresent","pathConfig":{"path":"/var/hpvolumes","useNamingPrefix":false}}},{"apiVersion":"v2v.kubevirt.io/v1beta1","kind":"VMImportConfig","metadata":{"name":"vm-import-operator-config"},"spec":{"imagePullPolicy":"IfNotPresent"}}]'
+    capabilities: Full Lifecycle
+    categories: OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+    createdAt: "2020-10-23 09:15:17"
+    description: |-
+      **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+      Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+      Containerized Data Importer (CDI), Virtual Machine import operator and Cluster Network Addons (CNA) operators.
+
+      **KubeVirt** is a virtual machine management add-on for Kubernetes.
+      The aim is to provide a common ground for virtualization solutions on top of
+      Kubernetes.
+
+      # Virtualization extension for Kubernetes
+
+      At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+      additional virtualization resource types (especially the `VirtualMachine` type) through
+      [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+      By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+      resources alongside all other resources Kubernetes provides.
+
+      The resources themselves are not enough to launch virtual machines.
+      For this to happen the _functionality and business logic_ needs to be added to
+      the cluster. The functionality is not added to Kubernetes itself, but rather
+      added to a Kubernetes cluster by _running_ additional controllers and agents
+      on an existing cluster.
+
+      The necessary controllers and agents are provided by KubeVirt.
+
+      As of today KubeVirt can be used to declaratively
+
+        * Create a predefined VM
+        * Schedule a VM on a Kubernetes cluster
+        * Launch a VM
+        * Migrate a VM
+        * Stop a VM
+        * Delete a VM
+
+      # Start using KubeVirt
+
+        * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+        * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+      # Start developing KubeVirt
+
+      To set up a development environment please read our
+      [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+      To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+      You can learn more about how KubeVirt is designed (and why it is that way),
+      and learn more about the major components by taking a look at our developer documentation:
+
+        * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+        * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+        * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+      # Community
+
+      If you got enough of code and want to speak to people, then you got a couple of options:
+
+        * Follow us on [Twitter](https://twitter.com/kubevirt)
+        * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+        * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+        * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+      # License
+
+      KubeVirt is distributed under the
+      [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+    operatorframework.io/suggested-namespace: kubevirt-hyperconverged
+    operators.operatorframework.io/internal-objects: '["v2vvmwares.v2v.kubevirt.io","ovirtproviders.v2v.kubevirt.io","networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","kubevirtcommontemplatesbundles.ssp.kubevirt.io","kubevirtmetricsaggregations.ssp.kubevirt.io","kubevirtnodelabellerbundles.ssp.kubevirt.io","kubevirttemplatevalidators.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.nodemaintenance.kubevirt.io","vmimportconfigs.v2v.kubevirt.io"]'
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    support: "false"
+  name: kubevirt-hyperconverged-operator.v1.2.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents the deployment of HyperConverged Cluster Operator
+      displayName: HyperConverged Cluster Operator Deployment
+      kind: HyperConverged
+      name: hyperconvergeds.hco.kubevirt.io
+      specDescriptors:
+      - description: nodeAffinity describes node affinity scheduling rules for the infra pods.
+        displayName: Infra components node affinity
+        path: infra.nodePlacement.affinity.nodeAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+      - description: podAffinity describes pod affinity scheduling rules for the infra pods.
+        displayName: Infra components pod affinity
+        path: infra.nodePlacement.affinity.podAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAffinity
+      - description: podAntiAffinity describes pod anti affinity scheduling rules for the infra pods.
+        displayName: Infra components pod anti-affinity
+        path: infra.nodePlacement.affinity.podAntiAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
+      - description: nodeAffinity describes node affinity scheduling rules for the workloads pods.
+        displayName: Workloads components node affinity
+        path: workloads.nodePlacement.affinity.nodeAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+      - description: podAffinity describes pod affinity scheduling rules for the workloads pods.
+        displayName: Workloads components pod affinity
+        path: workloads.nodePlacement.affinity.podAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAffinity
+      - description: podAntiAffinity describes pod anti affinity scheduling rules for the workloads pods.
+        displayName: Workloads components pod anti-affinity
+        path: workloads.nodePlacement.affinity.podAntiAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
+      - description: HIDDEN FIELDS - operator version.
+        displayName: HIDDEN FIELDS - operator version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      version: v1beta1
+    - description: V2V Vmware
+      displayName: V2V Vmware
+      kind: V2VVmware
+      name: v2vvmwares.v2v.kubevirt.io
+      version: v1alpha1
+    - description: V2V oVirt
+      displayName: V2V oVirt
+      kind: OVirtProvider
+      name: ovirtproviders.v2v.kubevirt.io
+      version: v1alpha1
+    - description: Cluster Network Addons
+      displayName: Cluster Network Addons
+      kind: NetworkAddonsConfig
+      name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+      version: v1
+    - description: Represents a KubeVirt deployment
+      displayName: KubeVirt deployment
+      kind: KubeVirt
+      name: kubevirts.kubevirt.io
+      version: v1alpha3
+    - description: Represents a deployment of the predefined VM templates
+      displayName: KubeVirt common templates
+      kind: KubevirtCommonTemplatesBundle
+      name: kubevirtcommontemplatesbundles.ssp.kubevirt.io
+      version: v1
+    - description: Provide aggregation rules for core kubevirt metrics
+      displayName: KubeVirt Metric Aggregation
+      kind: KubevirtMetricsAggregation
+      name: kubevirtmetricsaggregations.ssp.kubevirt.io
+      version: v1
+    - description: Represents a deployment of Node labeller component
+      displayName: KubeVirt Node labeller
+      kind: KubevirtNodeLabellerBundle
+      name: kubevirtnodelabellerbundles.ssp.kubevirt.io
+      version: v1
+    - description: Represents a deployment of admission control webhook to validate the KubeVirt templates
+      displayName: KubeVirt Template Validator admission webhook
+      kind: KubevirtTemplateValidator
+      name: kubevirttemplatevalidators.ssp.kubevirt.io
+      version: v1
+    - description: Represents a CDI deployment
+      displayName: CDI deployment
+      kind: CDI
+      name: cdis.cdi.kubevirt.io
+      version: v1beta1
+    - description: NodeMaintenance is the Schema for the nodemaintenances API
+      kind: NodeMaintenance
+      name: nodemaintenances.nodemaintenance.kubevirt.io
+      version: v1beta1
+    - description: Represents a HostPathProvisioner deployment
+      displayName: HostPathProvisioner deployment
+      kind: HostPathProvisioner
+      name: hostpathprovisioners.hostpathprovisioner.kubevirt.io
+      version: v1beta1
+    - description: Represents a virtual machine import config
+      displayName: Virtual Machine import config
+      kind: VMImportConfig
+      name: vmimportconfigs.v2v.kubevirt.io
+      version: v1beta1
+  description: |-
+    **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+    Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+    Containerized Data Importer (CDI), Virtual Machine import operator and Cluster Network Addons (CNA) operators.
+
+    **KubeVirt** is a virtual machine management add-on for Kubernetes.
+    The aim is to provide a common ground for virtualization solutions on top of
+    Kubernetes.
+
+    # Virtualization extension for Kubernetes
+
+    At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+    additional virtualization resource types (especially the `VirtualMachine` type) through
+    [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+    By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+    resources alongside all other resources Kubernetes provides.
+
+    The resources themselves are not enough to launch virtual machines.
+    For this to happen the _functionality and business logic_ needs to be added to
+    the cluster. The functionality is not added to Kubernetes itself, but rather
+    added to a Kubernetes cluster by _running_ additional controllers and agents
+    on an existing cluster.
+
+    The necessary controllers and agents are provided by KubeVirt.
+
+    As of today KubeVirt can be used to declaratively
+
+      * Create a predefined VM
+      * Schedule a VM on a Kubernetes cluster
+      * Launch a VM
+      * Migrate a VM
+      * Stop a VM
+      * Delete a VM
+
+    # Start using KubeVirt
+
+      * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+      * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+    # Start developing KubeVirt
+
+    To set up a development environment please read our
+    [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+    To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+    You can learn more about how KubeVirt is designed (and why it is that way),
+    and learn more about the major components by taking a look at our developer documentation:
+
+      * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+      * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+      * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+    # Community
+
+    If you got enough of code and want to speak to people, then you got a couple of options:
+
+      * Follow us on [Twitter](https://twitter.com/kubevirt)
+      * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+      * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+      * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+    # License
+
+    KubeVirt is distributed under the
+    [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+  displayName: KubeVirt HyperConverged Cluster Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAARgAAAEYCAYAAACHjumMAABam0lEQVR4nOydB3gb9fn4v3faw5Js2fKSvO0kkrMTsCFgBQKEslqIzB+6AAcocVpIKD9aWrBSaKEtJKUQEjLKKO0PLFo2hG1DEpvEcZYl7ynZkqf2lu7+jx2HXxLfOZJO077P8+Qp1ffu9Fo6vfd+30kFJCTTKBQKLgBgoUKhKAEA5AIAssRicVp5efnk62wAADL9zzv5r6GhwarT6QYAAL0qleqEVqs92djY6I3130FCQhJHVFRUcFpaWl5CUdSPEmMMRdFdCoUiP9Z/EwkJSYxRKBRFhw8f3o6iqImgYrkQF4qiHz/33HO3SqVSONZ/JwkJSRSpqKjgTlss0aCttrZ2baz/ZhISkgijUChKDh8+/DcURc1RUi5nmdx6ff3cc88ppFIpJdafAwkJSRipqKjgtbS0vBxlpYJHV21t7bWx/kxIogMUawFIIkdZWZl4+/bt/1NeXn4XACAp0PMQAGxDTqel3Wpnj7s9DA+CuLwIgkyaIQgAKAwgiEWBqRwqlV3M5TiKkzhUOgxzgxANBQAc2r59++4dO3a8qdPp/KH9hSTxDqlg5iBSqZS1c+fOR+Ry+f8AADiBnudDENsjp1qtz3f2pKEABJzCQIEgz63ZmdpfLyhkXJIiEAcp7mGlUnn/tm3bWoI8jyQBIBXMHGLSYtm6dWuVQqHYCAAI+Ifeb3eYdnX3gZd7+hkmr48V6vtDAHivzxCNVhfloT/ITBcBAGgBnopqtdoP9u/fv2v//v2fkxbN3IFUMHMAqVTK2blz5//I5fJfTyfEBcSkxbL1pNr2QldfRrhlKuUl9e9ZtRSUC5Nzgzz1u2mL5mS4ZSKJPqSCSWDKyspypi2We4KxWHpsdtPunn6wu7ufafX5mBEU0XdNetrIpsJc9IfZmWkAAHqgJ2q12o+mLZpPdTqdL4IykkQQUsEkIFKplLtz587fyOXyrQCAgLc0XgSxPXi8xbarpz/sFsvFKOZytPtWLfVfmSbMC/LUY0ql8hfbtm1ripBoJBGEVDAJhEKhyFUoFBunLZasQM/rstlNL3f3o7u6+1h2vz+SFsvF8MvThCObCvMQhSRLCAAIWBatVvvptEXzsU6nI+udEgRSwSQACoUiqba29jEAwEPB/Ch9COLc1Hzasrd3ID2yEgZPDps1tH/VMte69NSCIE89qVQqN23btu1whEQjCSOkgoljtmzZkl9VVXWvTCa7CwCQGeh5Q06X/ZU+rXdfTz+tz+EMOEwdA5AfZmXoHyjMg67NSJu0aBiBnqjVar+ctmg+0Ol0nsiKSRIqpIKJQxQKBa+2tvZxAMAvg/nReRHE8df2bstTrZ3JTr8/4PPigbKU5MG9q5Y4Svm84iBPbVEqlZu3bdtWHyHRSAhAKpg4QqFQ8Lds2bKxvLz8EQBAwNuaQafL/o/eAe++3gHaQHxbLBcDvT5DpK8uygPXZ6anwMH5aOp37NixTaVSHdbpdO7IikkSKKSCiQMqKiqgnTt3/lImkz0TTFTIgyCOP7d1Wf7U2pniQpCAQ8CJwMpkwdDuFUtsq1L4JUGe2lZZWXm7SqU6FSHRSIKAVDAxRKFQJE9bLA8AAAJu0qR1OKcslv29AzSt05XIFstFuVqUOrS5KB+6KStdQIGgQJWvBwDw0fbt26cygzUaTYSlJMGDVDAxYNpieUgmk/0pmKiQy++3P9PWZX26rSvFM8cslouxhM/Tv7RisfXy1JTiIO/b71Qq1QOVlZXHIygeCQ6kgokiCoUiZcuWLfeVl5f/YrrnbUAMOJz2/T393v19Wvqg0xVwKcBc5MrUFP3monz0h9kZAhoMB/pZeAEAB7Zv3/7S/v37D5AWTfQgFUyEEYvFUFVVVVlVVdUmiURyezAFgF+PjBlf7OqD3xsycP0oSjZoP4dsFtN4T36OsypPwsjlsIVBnNrb0NCwa8eOHftUKpUxgiKSkAomstTU1OQolcpdAIAfBHPeSZNlYlPzKd/hcaMoctLNDagQ5Pz1gkLtE9KSNBaFkhzEqS61Wv276urqHfX19WgERZzXkAomzExbLJdNWyyVIPC+KugJk9m8u7sf2dc7wPejKNlaMggymAzT1pIC123ZmbQCLicYi2agoaFh944dO/aoVKrxCIo4LyEVTBipqanJUyqVuwEA1wVznsnjndjYdBL5z6A+NXLSzQ9gANx/X764p7oorzCY6m0AgEetVtdUV1f/pb6+HomgiPMKUsEQZNpiuaKqquoBiUSyIQiLBWk2mi27u/uQV/q0PB/pYwkruWzWyP2Fucimwjwqn0YLRnEPNjQ0vLxjx46XVSrVSARFnBeQCoYACoUivba29g0AwLpgzpvweMarjp5E3x0ykBZLhIEBcP1lyaLehxcU5QeTEgAA8KrV6icrKyv/qNFoSIsmREgFEwJbtmwpnbRYZDLZnQAAQYCnIUcnTJaXe/qRV/u0pI8lymSxmGO/KMj1bSrKg4V0ejDO89Mqlerl7du3/6uxsdEUQRHnJKSCCQKFQpFZW1v7DADgxwCAgBXEmNszds/RE9AH+uFgnI8kkcHzpGxh9++lxTnBNEQHAAzX1dX9rrq6+lWNRkP2DA4QUsEEwJYtW5ZMWyx3AAD4AZ6GfDdhtOzu6kde79fxEUBaLPGEiEEff6Awz/tAYR6UzmQE0y+nddqi+WdjY+NEBEWcE5AKZhYUCkVWbW3tXwAAd5zZzgfGsMs9es/RE/DHhhHSYol/fI8tKup8snSRGA5idtSkYVpXV/dEdXX1Xo1GQ/YMxoFUMBhs2bJl2bTF8v8AALwAT/M3jButu7v7kDf6dQIkCIVEEnuS6TTjpsI89y8KcoGYzQqmZ3HHtEXzemNj41gERUxISAVzDgqFQlxbW/vs5H8GY7Hona6Re5pOUg8YRlIiKyFJFEAeKi7oeHapNIMCQYE68CeZqKur+0N1dfUujUZDdtibhlQwZyyWFdMWy+3BjFhts9gsT7V2+P49MChASYtlTpFEpZo3FeY5tpQUMNOZjGBKELpVKtWe7du3v9rY2Djv82jmtYJRKBQ5tbW1zwEAbgvmsxh3e8yPnW517u0dEJGKZW7DoVAsNbIFhq0lBZkUCArGR2Ouq6t7qrq6+gWNRjNvO+zNSwWzZcuWVVVVVZtkMtnkVijgoe2tFqtlV3c/8s9+HdPk9cZy/AdJlMnjsIwb83Ncd+flMLJYzGC2wr0qlWrf9u3bX2lsbNRHUMS4ZF4pmIqKCtbOnTv/JJPJHgzmbx91u82/OdXqfKVPm47Os8+M5HyYMGz73aLioUcXFqXTYDjQlIVJrHV1dc9UV1fv0Gg0zgiKGFfMix+LQqHI37Jly6by8vIqAEDA+2n1pMXS1Ye8MaBjmr0RHbFKkmBIWCzjPfkSZ1V+DlPCZgVj0Qxs37796f3797+u0WgcERQxLpjTCqaiooK9c+fOZ2Qy2S+DOW/Y5TY9ekrjeq1flz7XPyMSYtAgyPHowiLd7xYVi5gUSjBRJ5NKpXqosrLytQiKF3Pm5I9HoVAUnmOxBGzGnjZbzbu6e9F/9Q+yLD5fQs0VIoktWUyG6a78HOfG/Bx6fnAd9jTTzclf0Wg09giKGBPmjIIRi8W0qqqqH0y3TQi4HwsCgOetgUHbru4++NuxiWCeQCQkM4AB8NyQlT6+uTAfuTYjLT2I9h3OhoaG13fs2LGroaHhpE6ni7Ck0WFOKJiamppypVL5EgBgWTDnfTY8Olx19ART53QF46wjIQmI5QJ+7+6VS6iXpAgkQZ76plKp/NW2bdtGIyRa1EhYBSMWi+lVVVU3TLemDLgfCwKA93/7dZMWC3Ro3EhaLCQRBQLAtz4jbXRTYT5yY1a6KIim7y6tVvuv6fnbxxLVoklIBVNTU7NGqVTuBAAsCeY8jcVquLfpJOPwuDGYzEwSkrAg5SX17125BFyWmhLwyJpp/jM9f9sQIdEiRsIomGmL5aZpi+WqQM+btFg+04/YX+ruQz/QD5OKhSTW+O+UZBt+UZgLX5EmTA3CovFotdp/T1s0RxLFokkIBVNTU1OhVCpfBACUBnPeabNFf2/TKeZ3E6TFQhJ/rE1L1f5j9VJfHocd8NjgaT5QKpWbtm3bFvdaJq4VzJYtW+RbtmypkUgk8kDPQQDwHNAPO3Z29aEfG0ZIxUIS7/g3iDMNDxTmQVeJUlODmITg1Wq1b+3YseOpHTt2tEdYxpCJSwWjUChKa2trdwIArgzmvOMms+H+plOMo0YTqVhIEo41qSm6fauWuhckcQuDOM0HAPhHZWXl71UqVdxFneJKwWzZskVWVVX1qEwmqwQABJTo5keB5xP9sP3Frl7o0+FRMipEkuggN2Wl6zcV5sHXZYhSoAB/BwCACbVa/a/9+/dPWjWHIixjwMSFgpFKpWDnzp33yeXyvwEAWIGe1zRhMtzffIrZbDSTioVkznFpSvLgnpVLHEsEvOIgTz1QWVl5l0qlGo6QaAETcwUjlUqFBw4c2C6RSH4WyPF+FPV8ODTs2NnVCz4fGSMVC8lcB12fkaavLsoHP8hMT4EDn+00qFKpfrd169Z/6nS6mM11iqmCqampKVEqlQcBAGkAAD0AIHO24xsnjIYHmk4xT5gtpGIhmXesEPCHdq1cbL8kJTlgi0atVu8sLS3dHFnJ8ImZgqmpqVmiVCr/AwAomn7JON2u8rzaDR+CuD/QDztf7OoDX5EWCwkJuEqUqt9cmIfenJ0hoEAQO4BTnpBIJE/pdDo0CuKdR0wUTE1NTb5SqTyF0U3OdO6kxA6rzaJoOIacIi0WEpIZLOYn6d8qW4ks4iVlz3LY5IM7Wa1W/7a0tPSZKIo3RdQVjFQqZR04cOBriURyKcbyBAAgxeByef7c1u3b29NPt/v95FB4EhIcqBDkvk2cOfr4ohKajJ+ENUDOON1kzadWq59Yv379M9G0ZKI+bXBkZOQ1Pp9/Pc4y47jR3Hd1fQP3s+FRlhdFyYbaJCSzgABAVVusvN3dfdQsFuvEymR++jkjd2zTiXu0yddEItHVEolEq1KpjkdLvqgqmOeee+628vLyJ/HW//T1N947PzwwYOJOmXwxj3CRkCQKKADUD/TDWV02u3Z9hgihwTALADA2uSM49ziZTLYGAPBpfX19VELYUf0Royh6anLriLX2dN233sc++5I2pZQXLuoBLHZRNGUjIZkr5HJY2kNr1ziyWcwFOIfoZTLZQo1GY4m0LFHbgrz11lv34SmXN0+1+B777Evq9zKNj0fd201CMlfotzslD7dqPFYf7sjszH379v0mGrJEZYsklUpZL7300gGAkSTk9vnA9a++gdg8nv+TxelAQHqGDUBQwDOLSEhIzgBBoI3HpwsbLSbWDUIRTIFmblQkEskqAMCe+vr6iE42iIoFU1VVddO54edz+WntOy6D1XZ+pAhF04B2oDcaspGQzDGQElFSH4BARpfTTtk12I+XxctSKpUvicXiiAoTFQWjUCh+gvX6p51dPlWLGjv1eXxsJXA4SCVDQhIESQzqKSGH/n0L2doRPfzB2DCektmgUCiC6lgQLBFXMBUVFZBEIsH8I145Nmu0jAbGRvwRE4yEZA6SKWCiF2bD/6W/G4x43Jh+zaqqqjsiKU/EFYxcLr8SazaRD0HQzzq7cb1QUxiNycDvH4+kfCQkcwUWjXJKyGHkXPg6AgD87ugwpoKRyWTXS6XSiEWTI65glErlLVivv6tpMxmdrtkrQxFECIwTxkjJRkIyh0DyUzl6CADMoW+fG8fwtkm5CoVihlIKF9HwwWAOQfv3ydOBRYjGRqnTXbtISEhw4DKoGgGLthZvfcjtonY47Ji/I6lUuiZSckVUwSgUikltKr3w9UlV+kl7Z2A9KpzOPGAyRS21mYQkEcnkM30X6+f7tXEccytUWVm5PlJyRVTBiMXipVivtw6PeF3BzH4e1AkBikY865CEJBFhUuFWIYc+W0X1FA1mI17Q5BqxWBwRXRBRBVNeXo45yvXU8HBw7+txFwCTcSRccpGQzCXyhBwtDEFpFzuu02mnO/yYOia9vLw8LxKyRdqCwZy8eHzIEHz4eXSULH4kIbkADp3SmsKhXxHo8W0OG6YfpqysLKi57oESEwtGPTwS6DS7/8NuywN2O+mLISE5hww+yxNMo/xupwOzv5JEIlkeVsGmiZiC2bBhAxsAsBBr7dig3hvCJSlA288CKOoiLh0JSeJDhSFDKoeO1WQKl3Z8CwbTX0qUiCkYmUx2BdZso0GLBQzbbIFOrzsfp3MhsFgGwyEfCUmik8pljFBgKCOYc7qdDszffMJZMAqF4lqs199vbSdWvTk2SrZyICEBwJnBYwY6wuR7epwO1I1gZoiIa2pqcsMi2TlE0oLBjK1/3dMXeHgaC4tZDNzuNkLXICFJcNK4jMNsOqUk2PN8KEo5YbXgJa5iJsUSISIKZjrBbob/BUFR8GlHVyj+l3NhgoF+L5ndSzJfgSFoNDeFHXJ6/3cWI2ZEVqlUhj3hLlIWzBKsa3eOT/gsbnfQZt0MbNbFwGYdIHwdEpIEJJVLN9CpcLDjZL/nsNmE93C+RiqVhlUnRMqCwQxPn9Qbwvcm4+MxG4dJQhJDPJk8ZmhBkmm0bifD5MPcSHBlMhlm5DdUIqJgpFIpZoLdiVAS7PCYGBcBv5+0YkjmFUIO/RCHQcVr5h0w7Q47pobBMw5CJSJDzWQyGaaQLcPD4Xw/Hhjo776u7FJRNos5rxpTddkcrm/GxjHL8ucDV4lSO+8vyL0w4oFavT672mKF39QO0vUudyAjVRMKCAITeULOrPPbA6XbaadeysPsYjv52/13ON4DRELBlJWVcQAApVhrh/q13rA2GjcZlxYAtPOl1csIa/REwuL1ORd9+vXAkNMVsT4e8UoKnTb2dvkqZjKdhrVNmIpQPr14kWtXd5/p6bZO5ojbQ8jnx6NSXVeJUr2rUwSubBaTQoWgqA8rPMvXlon+Vo8tLPkqp21WBKTP/C0qFIrycFz/LGFXMBKJpBTruh1j4/4Jp5O4g/d84NeajtGevewSD5tKIbQvTSR4NGrqC8tKG25raJp3CuauXIkxmU6b1cHJoMDMh0oKmOXC5LGyrw4yQp3/tVzAt3y05hI0k8XkAwCSQhY6PPg+VI+GzSrrdNjx8smWSaVSoNFowvI+YffBKBQKzJTjD9s6POF+r0kc4+PC3zSdmHe+mFvFmStXJQu6Yy1HlLH/ojAv4IfUpcLk1P+UrzJAZ1oQBcX/k2SNflFRRp9WLjHn84mxpgGXM+i8FzwMHjdlwovr6A05QnUhkXDyYvpfvuruiYxpiaL8F+u/NescTqL5NYkG/eGSgnmVC/RQcf7p4iSOJJhzbhVnZv4gQxRUL6EyocD0v2UrhSl0ergt7pDwA2D6c39XWMcpowBADWajG2tNKpWGzdEbCQtmRgTJ6/eDr3p6IxZWRs2mxfs0bbpIXT9eUUiyMhfzkzpiLUc0EDHoI0+VLgxpS3ibODi/6NOLFyHRnHp6MT4eG55wIkhQijUQmqxmTLcCXpAmFML6IVZUVEz+z4wtUuvomNvp9UXyaUDfe+SYHw3BFE5kKBDE27tqqfHMQ25uc09+jolDpWaFcm65MDlg63ZBEndEnpaaEsr7RIoPx8Iaff2ew+YJTLdFOEPVYVUwcrn8ksk93IWvnzZE5gM6l6GhoeTnWzu0kX6feOPSlORL1qendcZajkgCA2C5ryA3ZAdnHocd8P33k5zsmEWJsDhqMXW12G0RGb9o8/sZOpcT66EctwoGs4L62JAec68XVhBE+LvPvzLafPgTv+co0MMLCud0hfmjC4s0+Rx2yD8yGIICvs+XCHjOUN8nAnj+3N/NjOR2rcOJGU3KqqmpyQ/H9cOtYDCLpTTDo8QqqAPEYTAUvdbeNRyN94on1qWn5a8VCU/GWo5IkMVkDtdISwjd7L12R8BbSCGdHjfbzW9NE+N6jzuiw6M7HdjdU6RSaVgKH8OmYBQKBQsAUIa11jQ4GHkL5gzcvU3N9ii9VzzB/PelKydNe1usBQk3GwtyLAwKJaiubRdybMIUsP+vw2qLmwzg90YNwbeWDZIupx1TB4RrlEk4LZglWFm6PRNG37jDGbUv7WR3L/89XTirKhODDCajdGN+zpzKB6JB0MS9+TmE7x2VTh/wsYfGjXERKOhw2MYaLSbMXP7wvo8d7++Vl5WVEVZw4bRgMAscP2hrj+6e1udNrz7w2aAfRePG1I0Wm4vyoDMpDnODx6Ul7WI266Lzfmaj1+6wvDdkCFhJvd6nS3H6/TG3BHdoe31ohGoFz2XM66GMeDA3GDyJREK4BCdsCgZvyNrXPX1RT+Ef7O3L+0/vwLybo7RUwC+5Iyf7cKzlCAc5bJb+t4uKCWWuIgD47z5ynBaMxvWiCO3Frt6YJm2etFpMp2zWoHrtEuGw2Yj594ZjlEnYFAzWiJLJL/bTjq7oWxIoKtx/7HjMn0IxgPL66uUSBgwnvKP7voJcKxWCCFWMf2kYddePTQQ80uMsT7S0czqstgki702Ed8cMUQ2VH7WYMbdCEokkPhSMVCqlYFVQt46MuF0+X0ycZl9q2rhNRtO8GzdLhaGch4oLxmMtBxFYFHj0nvwcHtHr/L2rJ6TtogtB6Jd9dZD5wZAh6krG4HHb6ozBK0UiHLGYvH505kcVjoS7sOzxFArFCgDAjKKw04aRmCUt+d2uzF99/tXRw5W3riZ6rU8No8O/b2mLitl8qVDge3H5YkJjPKuL8uh/bu9yAADiJiISDE/KFnZnMhmYEclAaTaazR/qR0IuVBz3eNk3HzrKfrA437BNugDm02kiIvIEyku6Pp8HRSLuezkXB+KnaV1OJI/FvtDgiBsFg5lg1zyo90WqqVUgNJxWZ9dfuWa0IkN00bm9s3FZajK3126fvOk44ZMOm2ajCflVUYG1JIkTcnsACZtV9Li05OsnNR1rwytd5CnksAe3LCgk1LbRh6Dee5tOhiXE+3xnb8bznb2ghMsZz+GwUDoEz1pwyKTAyNuXreZDAATte+x2OlxfGscFlBjUfnQ47CCPNeN5JKypqVm8bdu206FeNyxbJJlMhjnuQDM6GtseLX5/1t5jxwlvk5KoVM4T0pKobLcQAOCdXb2E768/yBasyGYxe8MjVfS4vzDXDgNAKDz7vt7gbjaZw2q9ddjswi+Gx1I/NowIZ/v330FD2ueG0ZACDO+MGuBkKi0mhWWd2Bm9QC6XExplQljBlJWVTX6Rl2KtHdVFLcEOl/+ePEUfsDsIy7GpME8gZjGj4jh+tU/L1DtdZoKX4VcX5REbchdleFSq4a68HML9V57v6IlpJfSWEy1cp98fVHrGoNvl+s5spLqR2GRXdDmwJz7K5fLriVyX8BchkUhkAMMc1FutyLDNHlVnFRZOm13y24ONp4hehwrDrJ/kiqNS52Tx+ZgPnWghnD/0UHGBAALAGB6pIs8zSxb1pTGCm7V8IafNFvs3YxMx9T1prDbBX9u6rYEe7/Ij3q0dmkkTAnZgT12MOO1OG55mu0KhUIS8EyGsYPA62L2naYublP03G78TacwWE9Hr3JUnidqTsVanz2iaMBFSDiwKJXtzUV5C9MlZkMTVPVCYJyNyDZff734xDNvLcPBUa0fyM21deh+CuGY7bsztcd178uSYzuMS6rET3qKC2eejal2YzzTadJZ+SBD+wYjFYswmwf9Vt8VN2Tviduc+8+3hMaLXWZDE5T26oDBqw/cfPaUh3MHs0YVFAgYMx33pRI20xE607+0Lnb3+/b0DM9qFxAIvitJ+e7o1c8ln9Y5d3X2GHptjUtFPaRAvgpjrR8cntp5QG7M++Ix22mWNi2jf58YxTAudSCNwwjcwiqJNAICV577mRxDAfOIpjw9B4qYRN4PDGdD++sH0NAadUGW3F0GsvHc+obsQJCoV4l9VlBvWilIJZXVu7+j+8uGTmqvDJ1V4yWGz2vpvWCcBABCJ0vlzP/rCNeBwRjzSR4BxDpXitPv8GWejq6lcur5ElBSWUSREKeUm+V9esHiGYaBWq/9RWlpaFco1CVkwGzZsYAIApBe+fsow7Iwn5TKJ224XP1x/kHBjJhoMJ92dL4na9u8Xx06xXEE6DC9ka0nhimIuJ14jSt7XLlnuJqhcwHuDBlucK5dJhHafX3xWucAQ8OSmsOOi7+8krTYb5PTP3GESaaFJSMHIZLLLJrf6F76uHolxeBob+J/fHEpqt1oDdr7h8bNcSdiaL1+MDpud/6Z2aNZ9fAAkby7Kj8vSibVpwj55mhDTjxcMf+/qjZseuoGSymE4GFRKcqzlOIsfoHCn0461TSqtqKgI6TdN6EvBS7Br0g3FPDyNCeLP3dd0nHCdTpkwmVeRJoxaOv7zHT2TTzxCEay78iRp2Sxm3I052VyUT1gxfD0yNvHVyFis5xYFTTqPGXeV791OB1ZiLF0ul8tDuR5RCwYzCadtdCxuzL4L2d/UTA9DKwfKi8tLiVoVAXPCbEn6Z5+WkJOaR6NmvLC8NK62SekMuuNWcSahbvkIAJ6fHzkR8cZM4SaZTTckMalxY72cpd1hw3yQKZXKkBLuQlYwCoVCAABYjLV2RKeL2o8vWIxGU+bbXT2ErZhSPi/7ylRh1HJMtp7SJE14vIR8Pz/KzrxiVbIgPCP7wsCNmel0rByqYPhXn9apdToTynqBAPDmCePH93IuOBbMJCEl3BGxYDA72BmsVp/R6YqLsBsOtH1HjoVlC3dvQfQmt465PZxXegeIFlwyHi4piJsBdWVC4g/wF7v6wiJLNBFy6XYWjRLxbnWh0Omw+3FS/RYpFIrUYK9HxILBTL45NqiPmxsYj6/bO/hHx8YJWzG3ijPpAho1ah37Xuruo3kRhND7KSTZuYv5PMKZzeEglUEnVAj7zqB++IjRFPXRrhAA4Lr0NOcfZAssr65eZnt19TLHYwuLvfI0oY8KXdz/nxGHvpezeFGUMuB0YOoYsVgc9OD9kBUM3njJ08MjUYuwhIrf50v51cefE+54x6ZQOApxVtQUTI/dwflrexehjGQKBAR7Vy2dmLyXwidZaGD1IAmUSUV7z9ETUd8aLeXzbNobr5k4cGUZ63FpCe/neRLuz/Mk7D8uXkj7Wn4ZtWndlf58Dhv3D2PRKCYekxZ3vpdz6XBg78TLy8uDjvaFrGBkMhnmm53QG+JewUzS2NaWV6cbIpzhWpUfvW3SJH/QdAoH7E5CIedLUwRXrk8XqcMnVWgMOkN31e3pGfCYvNFtZnZLVvpwnfwyajaLiTv5camAR2lbvxa9Q5KFaQWk8xhx//vAq6wOpYVmSAqmoqKCgufgPTGkT5TBZ0n7mo4T9sVcKkxOWSNMiVr5gBtB6Lt7+oh+xvCvFxSESaLQaRwP2UeO7uzqjeo2Y2Uyf+zdyy9JFdBpF3XO0mEYfvWS5aCIyzlPycAQ8GQkMeOmhAaPLqcDU0aJRBKdLZJcLr8CADAjVd7m8SCd4xPxmGSHyTunWzgDdgfhPi/bl8noIIpzsff1DtBNHi8hua9OT1uwNk0Y0wbhHxtGgNET/E6tdmDQ2Wq1RdVJ+sSiEgdWUAOPSSXzweWrUfo5/anyhZwxGIbiolZqNjocuJXVxRs2bAjK5xWSglEqlZgJdp+0dxkRFE2YnASH05n6my/r+oleZ3WKIG2tSEi4WjtQRt0e9m9OtxLt9cJ6s2zl5EOCaN+ZkDF7fWBnV3CpOcMuN7j32Kmobo0KOGz1zdkZQXdFXMhLolwtSpv6sTKoFEs6j0moFUW0MPl8FLzKaplMdlUw1wrVB4OZdPNNX3+814LM4M0jTZnq8QnCldZ35Uqi2shjT0+/SG22ErJiREzGynsLcnrCJ1XwPNPWBVTaoYCOtXp94GdHjgNLdMeP+/auWurBKokJhPLpUHwGb8rgj/vt0VkazEa8hLugJj4GrWAUCkUSAGAF1tq7mta46QETKCiCpO5vPkk4EnRHjpjNplCi9vejAMB/7+oh3Ptkc+FUqn7MeqjY/X5Q2XgMPN3aMetx3TY7WPZ5PfhseDRqsk1ymTC55ypRatC+h7MUctgIBAFfOi8qxfdh44jVjJdCEFkFgzdgbcRu9+rMlrgOv+HxRvNxhsXrJZR9TIMh9o5lsqiOuXijf5DTZ3cQ2potEfBK75Bkfxk+qULjsZZ2sOyzevCUpgN8PjwKjhvNoGF8AvyzTwvuPnp8Srn02KPfAfQeglFCCIJATjJnmArDhMewRJNmi9nvxe6ul6NQKAKethl0ohPWgDUw1X93yEO05D5WjJotoj83HFH/8crLCXVUu68gN2ObpsM85HRFJfnL4ffTq4+fnvhoDWZL5EChvFG2ovC/g/pBN4IQGtNKlJNmy9S/eIEJw6N35+cQmkhh9HmN2QImoWvEAjeKUPpcTqSYzZlhhEil0kmLLqDIadgsmNaR0YTZX2Lxt/pvU4fsDqKtHGj35Emiut34WD+ScXBsnJDlBANQ+FBxQcJPgww3DxTmGWEACFnlWp+LQrTeKlZ04iTcBdMfJmgFU15ejtk+r2FAG/cJRLPhcLrStx9qJBxR+WVxPo0Jw1Ed+P/oqVYq0TD5IwsKRSl0Wty1c4gVFAiYtpQUELLIxz0eS4PVGPPG96Fy2m7FS7gLuIVmUAqmoqKCDQDAHIp1bFAfnz1gguCVpmaqB0E8RK4hYjCSHl5QGNVO/ofHjbwPh4YJlT4IGXTx35aWtoZPqsTm1wuK2iVsFqEt457BAZsXoPFc+DsrXU474YS7oBSMXC6/GivUZnQ6fQMmU0L6X85lwmbL+OOhRsLlub9dWMQR0mlR9UhuPn6aY/f5CL3nT/PE8qV8XsxLCGJNGp0+UrOohFCfmgGX0/rRxEjQ1cfxRLfT4feimIZxZk1NTUCp4EEpGLwEu/da241oAsX4Z+OPn34hGHO7CdX6cKhU/u2S7Kj2xOl3OJP+2a8jZH0BALgPlRREdXsXj/wkV2xiUSlZRK7xwdiwH01Q38tZ3AhCUdtteBMfAwpXB+uDwVQwh/oHEt56OYsfQUT7jzYTzsqtys+Jekn+C129NAQAQkrmxznZuQuSuCfCJRMEAFidLDBvEGf6FOJM5Lr0NFMyjRa3DckAAK77CnIIJa24/H7ngfG47EsdNI1mI6YJE+jEx4AVjEKhEAEASrDW3lG3zamn3r6m49QzuWyhsyKZL1wnShsIn1QXR2OxcfZ09xHqFUyD4bTdKxfrifYAnmSDOMs6fPO1xiPrruCryldRa8tXwQeuLBPob7oW2bFMNsKiUOLOb3dXnuTEQl5SLpFrvDE8aJ3weRPW93IujWbcZ+3VUqn0oruWgBUMXnhaZ7a4xh0OYaDXSQS6RkZEr51SE65R+uvSRUwoylmyj55uFQy73IQyiq9IFV7GplBCLp8Q0ukeVdlKs6p8JTuNwZgR5mVQYPZDxQWi5nVXuHLYrLiZdsCmUIx/Kl1EqF5ozONx/NswFPUmWJGiy2mHrNilGSyZTDZjZNGFBKxg8JrNHBsais0w3cgCb/3gY5rb7yf0hF0m4IuuSU+LWhHkJBavj7Wvt59QM6nn2rtHHH5/yMPe9q1aatsgyeJfrPZmIS+J/+7lqy1ErcVwUSnJGs1kMfKJXOPA+IjPjUZnKF80QAGAO512zIekQqG4aD4MYQvmtIFwY7i4ZMJuz/7fFg3hcPNdedEtgpzk5e4BmsvvD8mK0Tmcphp1e8gOzrvzJCM/zM4IuJXCcgE/6y9LFhEeiBcGkE2FeYSmbCAAeD8YH0mYbgKB0o3TH2byGXqxcwlbMKcMw4T6qsYze48cI5w8WCnJ4vJp1Ki2RNA6nZw/aDpCyrnf0zvgdiFISE77FDrNsXfVMm6wwYNHFhTlZzIZhCvaiXBtelrT6hQBoS5cH4wabDq3K2ET6/Bod0TYgtmwYcPkTbMAa+34UOIn2OFxuLcv+ave/sB6CeBAgSDW35ctjnrPlb+2d6d12+xBlT7YfT7Tvp7+kH8gm4vyvRQIhOLcpP0gUxSzbRIMgP1vy2R8Ii1k7X6/a8+Qds4pFzDlh7HhfS5LpVLprA/hgD5QmUxWgVVP4fB6ka7xiTnhLceBvvmDj70owTT8n+WJs3LZrKhm9/pQlPpSV3CtNX/f0m7Uu9whVf1CACCbi0J3X5SlJMesZcQt2RlDi3hJmA/QQPlyYsxv8nnjctYRUXocThQn4U6oUChKZzs3IAWDNyL2vdb2iURqohMKrYbh3AOd3UTHxFLvjkFezCt9WpbZ6w0ou7fDajP+vbNHHOp7Pb14kT6NQQ85esKlUWP249xUmEf0u0HeHTXM2d+BH6Bws8WC+QCQSqWzJtwFasFgXuRw/0BCTdQLlT1HjhG+xsYYOHuNXi/z9b7Asnt3dvX5EABCclDmsFiWRxcWiUI59yx+hMAMEwIs4SedWJeelkfkGodMRnu70z4nrZezfGcxYeqKyspKYgpGoVCk4SXY/belNW5yGCLJR23tSa1j44RaqWWzWan35EmimngHpiYf9tL8KDpr5qzB5Z54rV8bcjZ2ddGUBUAoetJiscYi3cGza8USmEg7BS+CeF/Q9c7ZQMdZGizYGb0AgMvKyspwfU+BWDCY0aNhm901ZLXOqQQ7PLx+P/PhTz4jnK38/PJSFgWCojrwrMNm5zzf2Tur/2fLCbXdHOKMIQYMe6qL8ghvD+pHie5Cg+cqUWr/ZakpmBNKA+Vb84RPOwcjRxcy4HJSTD7MW5cpkUhwG7UFYsFgKpgm3WDMnHKx4JPWdnHTkJ6Qo5ZLpabdmZMdVWfvJI+3tCUPOp2YeTHNRtP4m9rBkCuHd61YMsqhUgmN4mgcN441jBuj/rC6MyebsNX07uhwQvdBCoYOhx3z85otXH1RBSOVSjEVTMvISFxkX0YReM+RY4RvyJ/nigklc4WCw+9n7u3BHpz/fGdwY0PORcrjmu7OlxCqOgYA+O5pOhmLH6m3UpxF6Ltod9gsx6zmOe17OZcupx3v8wpdweC1xzs+NHe95ni8daqFNepwEmoauzY9jbcqmR/d1vhnxpzQbT7feT6zdqtt4i3tUMiO+s2FU2FpQsrhPzq9pdUS/a02l0o9mUSjhlzUiADge3agZ85l7c5G2C2YDRs2pE4+qLDWDvcPEO09knBYXC72z1XvOIm0p4QBoL92yXIEDkO1cjDoXW72nY3N7rOyexDEddvhJsiNICE5OFcI+Kb7CnMJ5UChAPgeb2mLSd3OAi7XSsS5++XEqFdjt81538u5tNhw8zZXbtiwAfNemFXByGSy1Vh5Lg6P1zdosc6rD/csn3V0JndPGAlVK0t5SWkrkvlEG4wHzUeGYUG71TYl+6GxCbvaYg25oXWNtMRFgSBCPU9OmSz2VqstJr2EDG4XIdnrTVGdUBMXjHg8wO7HfC4yZTIZpitlVgWjVCoVWK+/earFiKDonGioEyx+FKU/++1hopEg+DcLi6MaTZoEQQHl8Zb2yff1/+ZUa8jm/Y2Z6cabszNCrrY+y+9Ot8asEn/Q6Vpu9flCaslxymax1RnH590D1g9Q+BvTBF5dUiXW6xfzwWCOiD08oJ3L5QEX5dVjx9l2r5dQDtCPxJm8NAY96o9BlW4o5cETLYNHjKaQB4E9WEyoo8EUzUaz4SPDSCwH9bE/1o8EvU1FAfA/N9BDnW8RjrMcsZgwfa94ybi4CkahUOQAADAjBO9o2uZsgWMguHw+5q8//oyQgoEBYL6wvDQmU8b+3tkb8rhCKY9rX5eeRiiD24eg7o1NJ2MefXmhs3dShqB8id8Yx3xdTkfMZY8V31lMfhyzc+F0Uu554CoYvPB0v8lkm3A4UghJOQfY/d3RjAGzmVCV9O2S7JwiLiembQqCAQIA+WVRvjeUiaDn8v6QwXHcZA64Z0ykODQ+kf0HTcfsQ7HPwYMg3p26/qg65+MNs89HGXJjJ4ZLpdIZ0SRcBYPntDk+ZIh6Hke8svfIMaKfBXxXriRhErXuzBGbfpIrJux7+1tnT9zcQzXqdtlTrR1DF7NkOqw27+3NzSODHvecaXAfKh127HA1VkrLbBYMZgr1Sb1h3oWn8dh7tBlGCYab7y3MQYhOZYwWvyzKg7hUKiH/2+fDo4ZvxybiqWct9HhLe9aKz78xnTZbDBcu+hDEu7en31H29UH3MPDMe8sdnOkPg/lQxLJgcE1dvAS7U4bhOdNvlCjDNhvng9Z2882LFoT8gxExGGnVhXl9O7v7CFX0RprVyQLrpcJkQorB5fc7NzWfjsvoy3GTWbTks3p0VbJgNJ/D4jFgmGr3+32HxiYoI24PWyxgmSEIECqJmCt0OrA7gARswdTU1CQDAIqw1o4NDs2pESVE2XOU8DYJPLtUmkSDoHieFQQeLM73E+n4Nslb2iFXl80eT9bLhUBNRlOaSqdnvDEwSHln0MAYcXumHsLpvHnr151BhxN7GBsAYGFNTc15ShjvhrkGKwXc5HS5B0zmkMObc5ED7Z2cU4ZhQtEgJoUi/FmeOOptNQNlYRLXrJBkEf2F+Z7vTMzU+kw+c4RBheNZMUaVMa8XNngwA8nwhcMZMRWMUqnEzH95t7VtHCUYQZhr+FEUfujDA4QjCz/LlcSN4/NCdq9c4qTDMCEF8+bA4NhxkyXhthgUGHLnpbDnvWP3QhrMRsx7XqlUnpcPM+OmFounuiZeg3XyIQJNieYyX/f0pjQMaAml/l+ZJhSUC5OHwydVeFidzLdWpAkJZe2avV7HlpPqhFMuk6QnMV0QBJH3/QUcsZjwDI1rp3XIFDMUTHl5+eQqZn+Q/7Zo4tpPEEv2HGkiaoHQdiyVEapxigS3iTMJRw1f79N5DC53QiqYDB4jYdIIoskR/IS73GkdMgWWBYMZPRq0WOwTTiehsZpzGdVpDUNvsRJSEJcKkwvKU5LjKvGumMshFPVBAHDv7OpNSN8Ln0WzMmkU0ueIgQtBKP1OB6azVywWLz/731gWDGb+S5NuaL6WXwSE3eulPvb5l4QLGO8tiP70gdng02iEOhe+1NU70W6zJ+QWI4OMHM1KJ3aTxPOGNM5QMGVlZZgWTMvwSEIkg8WS146dELSPjhHaRt4mzmJwqZSARo1EA5cfCXnrN+xy2x873RazkgA6DPvWiVKN9+bnuB9ZUGjfmJ/jXytKdVGhi+962DSKNYVNI3O+ZqHTga1gysrKvrdgZjhqJBIJ3ojYedmeIRjQqezeY+izP8AMwgUEj0bl3ZqdOfp6vy4uKtZH3FOFJyFZIPt7B7xWny8mCuaGTJHxpRVL4Bw262zF9lllQemx2T0/OXIcNIwbce/p/DSOB4KgeTGWJ1Q6nQ5MTS2RSL43Us57Om3YsCEFAIA5n7d5UE8m2AXAGydOUeweD6HP6t78nLixFj8fDq27p9uPOF7u6Y+J7+Wl5YtNH665VJDDZmHmrhRwOfTDV62h/n5RMWYyRxKTauczafNiYgYROh02vPs0r6amZspfe56CkclkV2NZNS6fz9s1MUFq8wAYttnpz9QfJBR5WZMmTFsp4Ed9hhIW/xk0cE0eb9AzRWo07aYBhzPqvpd78iSWB4ryBAH0CoafLF3IuDtPMiNJMpPHjCs/WLxi8vngARfms/T7hLvzFIxSqcQcEfuOunWUaIn+fOLZbw9zBy0WIr4Y+PnlpXA8FEF6EIRxw8HvILvPF/Dfc3BswvyXti7CHe+CpSJN6HpCWhKU32T3yiWMBUnc731eTBrFnsKhJ2TUKxY0mLEHsp1NuPtewYjFYgoA4IdYB3/U3km604PA5fNRdhxsIJTde3lqivimzPSoTx/A4vC4MeWWQ0dd4+6Lbv2Q/+r0plsOHWGhBOuWQuHpxQv9uRx2UAqGDsOMTYW5Z5UnWpLORWAIIp27AfKVEde4vamsrIz+/U1QXl5eAABIxTryXU3rvBqyFg72Hm2mexGEkC/m7vz46RXz5ciY4PKvDvr+d2BwcNqffR52n99615HjttsamgQTHm/UAwKL+UmOcmFKSFuyNakpU99TMptu59KppCsgCNR2K+REMI2YJIlEsuD7bU9ZWRlm9Kh7fMJs93hntMIjmR2L201/4vOvxp++bl3IiWo3ZqZzizickS67ndBg+XDRbrMn3fldc9LTbZ2WUj6PlUqnu90IQu21O7x1I2NsL4rGbFbWxvyckJVxKZ83dW4Gj0H6XoIEBQDqctiQxVweVsrL8u8VDF54+oTBQO5HQ+SZ+oPCLZeXW0VcTkhPRRoMs/+4eOHw7Y3Hwi8cAU6brbzT5qnSq7P3Rky30EwY9m/MD3mG2uQ2icqmU6zJbHpCJgTGmi6nA17MnZnwPKlTvtc6eBbMiSEDWX9EgJePNBHa5lRKsrIXJXGjPs86kXhuqczIplJCthT1LpezMHWqVCpuK9rjmQ6HHdPyUygUy7//QPEsGM3IaFwkfCUq+442TyoYIiUE9Hvyc+b1FIfZyGGz7JuK8giNP2l32GlJTNL3EiqdTjveQ/SMBVNTU4NbQX1ENxh3Fb6JxIDZzNn13dGg80jO5c6cbAYNgshERwzuzZ+awELI93PQPBGXbTwThR6nA/FiO3pTzlowV2MlJlncbofObInlcKw5wcMffSp0EhjUlsViJj9YnD+jIfV8Z/KGvb8wj1CE0+H3O74wjpEV0wRwIwistmPf3lMKRqFQYJYHqE6rTeS+lDhOn4/2j6bjhJLmfi8tSeJTqYSGvc01freo2JDGoBNSDi/q+pBYRr/mCt9ZTJj395TykMlkJViLJ/XDCdkkKB7Z39RMSMHwabRUhSQrbqqsY00yjeZUyhYS6pOrd7tc742R93g4GHS7MA2Rsy9iThA42D8Q9dnJc5XjeoPg/dZ2PZFrbMyPr14xseS+ghw3BQKEfCcfjA3HTSJjomP0eTG3qmcVDOaTYNBsIb+AMPLAex8mIQgSctj/UmGy6HJhSk94pUpM7ivII6RsEQD8748Nk1ujMOHw+3DHDIBzemWch4dAsyGSmQxZrNy31a1EtjnQ9mUyOgCAcOkGm0IxXpee1qsQZw0qxFm6K1JTugAACRExvCdPoi/gsgkFH/5tGPQafT6ygDdM+NGZ5SPgnAppzEUUoKQFE2b2HDkGKhfLQj7/khSBWJ4mHK4bHQ+pPzIFghxPSEu6H1lQmM6iUPLPXXP4/d33HztlfqNftyJkASMMHYbdL6xYTChz2OrzefYODZAFvGGERaFg6pCzFgrmuAwRlxPzdgFzja+6ewTfaXWExpP8PFcS0vagmMsZPXr1FaYnpCWLWRTKjPomNoVS+M9Lli/5/MqyjiwmMy4HwW3Ml1jYFAoh6+X9sWHYh5LurHAiotExFfZZBYPpfKzIzyVzYMIMCgC8+f2PCGX3/iQ3m8OmwEEpAAmbNX7y2gpkeTI/6yKHUtelp5X857JVplDliyRVBIoap0HfGzWQ2iXMFLDYmPfzlIJRq9VqrMVlmRlk9mgEaBrUi77u7g3ZQqDCcNKOZaUjwZzzx9IFDhaFEvC2qkyYnDu5lQpJwAhxU2a6fkWyIIXINd4fG3YOetxkAW+YWcThYnZxnFIwKpWqEWvxpoULyEbfEeLlI02Ezr+vIDcnk8kIqARBykvq/2muJGifzTbZAomQTiM0sTJcQAD49q1aihJJ/HQhiPcFbR9ZWxdmIAC8S7g8zEj0WQtmUsHM6MCWI+ALioUphAa7k2DzrqaN3zNhJOKLYVTl51y0a97kl79/1dLJbUUoDwv69ZnxMWvvDkn2mIjJuNj2blY+HhsBDoTsnRZuFnG4LiaMrfenXn377bdHAQBHsA74kWxRhMWbn7j9ftqdb71NQVA05LyYzUX5dAYMzxpavjtfMlwmTM4J9T3KUwSER8eGAeSxRcWEQspeBPH+a1hHRkUjQIVAiKe1Nd+rnYaGhpNYR1xdiFmmRBIGvtMOpp42DIe8BUlnMpJvFWfOagXdLs4O9fJTcKjUmCejrUlN0cv4SYTKAg6ZjR6Dx0PmvYQf5BKeAFNxa7XaE98rGJVKVYt10LXFhbyK/DyyZCBCPF33LaGIxt6VSwQpdBrmNvbSFMHwtRlphLYVJi/habiEYFFg+5uXrqCc0z0vaExer/fp/i6yJUMEuF6Y1l3C5mAqf5VK9d/vFcynn376DQBAh3Xg7h/eSIMAFNs7bY6iatGkGqzW/lDP51CpKbeLszGzgx8szvcRrYY/abLEtI3k9RkiYzabRWgEyoGJUcTm95NZ6WGGCcPjj+YU4n039v3793/8/Yeu0WiQ2traJ7COXJiWmrRx9XJSwUQABEXh+9/9kEokL6aqYGavsEVJXP0GcRahsa1+ALxfDI/GNNnyBxkiQvcdAoDv/dFhUrlEgJ9miM00GMbsBKhWq3doNBrneR/87bff/goAoB3rhN+vraAyKBSydWMEeL+1Pfuk3hBy17uVyYKMq0Wpnee+tmvlEgsNhglZH6/09Du1TldMZwSJmAxCTuYDY8PufreTzHsJMwUsdvPPMsWYY44AABPV1dVPASzzefv27S9gnZEj4NO/2PhzKIlBJzRQjASbvUebCfli/rpEyoKmUw0q0oT6ijQhZo+fQBlzezyPnmqNud9CxAhdwdj9Pu/uoQFyiFqYSafTtX8tWiSEAcBs9tXQ0LCvvr5+yhiZoWD279+/BwDQhXXimtwc+mPyK+MhbDnneLX5eLLT6w25X8zyZL54XXrq1CTIh4rzkQBmM8/KK70D/gmvN+ZP/jG3J+TtzZfGcf+410tGjsIL8tvcotEMOgNvToxrx44d28/+nxlfnkaj8SqVyg0AAMzw6dY15azbSqVk68YwY/d4mb/99AsnkVYMd+VK0BUC/uBN2ZmE0uk9COLZ3dMf8/D0JOMeT6g+GP97o4a4+BvmEJ77snK+Xc0TLMNZR2pra+9TqVTfp05gfgH19fXDMpnMKpPJfnDhGgWGoQ2LZfT/tmicI3Z7zJ9wc4nvtIPJ961eMZzEYIQ0QkPKT4LKhSmWTCaD0CTIv7R32d/W6eMipZ5BgQc3iLOCDrUfNE043xzRky0Zwsg1KanHH5LkX4ZnHavV6v1XXXXVU+e+hqvhGxoamq+77roCkUi05MK1yauX5YjRfx4/5fchCPmUCCNcOt26tiA/JAUDQxA9g8kgVAGvdTg9ioZjDB+KxkXkpdNmpynEme2pDEZmoOc4/X7/Yz3tsMXvI+/NMCFhsDpq8ktSORQK3r156pZbbvmpTqc7r0Aa9ybS6XS+6urqnwEAjmKtr8jKpP/nx7f7z0QCScLF/qZmLoqzPY0Ge3r6/U6/P25+mB4ESbv50FHEj6IBj21RjeidOreLtK7DBAOCh15cIEPT6HQ8JT8il8uvbmxsnBEJnfUpVV9fj1ZWVm4EAGC2Fri+pIj1P1deTrZ0CCODFivvk/bOmBSYWn0+177egbhRLmfptNlXbTjcpLd4fb2zHYcA4P1YPzKybzD+/oYExveb3MLRVBp9Ac46olKpHqivrx/DWryoGaxSqU7V1dX9CM/5+Mdrr+aszM5KiF6uiQLRVg6hUtPS7jW43HHZouPdIcPylPc+hQ4YRj/BSkq0+/zjN3773fDdJ06w/QSnDZD8Hzemig5cK0yb4SY5S11dnbKysvK/eOsBhzIPHz78h/Ly8sex1sYdDk/5rn1I5/gE6VQLA1QY9p341QM9MlEaoVyWYOiw2lzST+uY/vhvJekv4LDbViYLaAIaDfUgfqbJ66N9MTzK9kEoq0TE9SUxaTEtb5grlPEF6ueKpPkAAEyHv1ar/c/69esVGo0G96YJWMFIpVKKWq3+BgBwGdb6N339roo9r5AKJkxcV1zYd+Dun2YAAKLymT50osX5fGdvQj/5c5LZdnEyi1QuYQAGkE61eIUvg87IwzlkrLKycqFKpZo1Az3gSIFGo/HLZLIbAQCY7TWvzMtlvnTLDVYoDCM1SAD4tLM774h2EHNfG26GXW7na326hHaKQgAgoiQGmVQXBjgwZXTfoiXG2ZSLUqm86mLKBcwWpsZidHTUBQA4IZfLq7DWV4uzGYMWi6t5SJ/QN2u8gAJgvnnRAkJ9UALhgWOnXEeMpoS2XoQcuiOdx0zovyFeqMqStF+VnIqXTAdUKtUvN2/e/Gkg1wo612Hbtm2H1Wp1FVaLTTDl9F1HE/N5ZFFkGFCdVqeN2OwRneR43Gh2vjEwGFLeTTyRwWOS6RJhYDE3qe3HGWK8iBFQq9Uvbd269dVArxdSMlVpaek/1Gr1Pqy1NA6b9tLNN5AFkWHA4nYzH//iKy+eMg8HL3T1xr1X92JwGVQTn0Ujh9gTZ/y3uUUUGAA8P1ZdaWlptU6nC1iZh5ytuXHjxscmH4BYazctWsBRrpNbyCQ84uw72lzUOTZOaGg+Ht02u/NN7WCiVxujBakcCtHizvkOFYKMfy+R9eYyWcU4h4xUVlbeH+x1Q1YwjY2NRplMdiUAADNpo+YqOW/rmnIyP4YgCIpSnv32MBpuZe1FEO9tDU3A6U/sUg9REsPKZVATfosXY3yP5RYNrEzir8JZ1ymVynKVStUR7IUJ1ZtoNBqbUqnciHfz/3n9NdzlmZlxMVcnkXn9+MkMq9vTGc5rvjdk8J00WeLGKVrC5YCrRUJQnpIMWJTAb8v0JCZpuRDkB0LRgetmSaZTKpUPbtu2LSRfYFi+nLfeemtDZWXlv7Bm74za7e7yXfuQ7glj3NzMich9q1e2vfyjm/LClRez5quD7kPjxphuj9IYdPCEtAQoxFkgnfl/ovhRFNSNjIG9PQPg7cEh4MfxEglYNKs0k8ch+qCcz5TxBOrniqWT9xWm30WtVj+5fv36J3Q6zHbdFyVs2r+lpeVZmUz2MNZaXU+fY+2+V+Oi/D+R6X3kwd685OR8otc5oB+xXn/wu5huK9IZDHDoqstBIXf2vLg93f3g/uZTmGsrc5LHGVRYGCER5zwwBHS1shW+TAYTM99FrVa/U1paeiuR9wjb/ru5ublh48aNVwAAZgz5yksW0IRslumTji4a+bQJHQ6dbrm6sIBQI2+Hz++58dAR2BjDTm+FHDZy8Ko1IJ/DvugDbmWKAKTS6eCA4fxR3EIO3ZzOYxJqTTGfYcOUsV0LF4/ms9h4Ien+zZs3V2o0GkKFt2H7sTc2Nlrlcvl6AMAA1vovyy8V3LNyBVl5TYD9Tc1CP4IQyot5Uzvo77E7YlrSUSMt8eWwWQFbz5uL88GNmef30Ernkb4XIvw0I3tgIZu7GGfZrlQq16pUKi3R9wlrBKG/v9/L4/HU5eXld2Ipr/IcMfiwrcM15nDEZcVuvGP3eOlcOl17eW5OSijfHQqA7+6jx6FhtydmkaMl/CTnC8sXU2EICurhxqFQwZvaoan/5jGpFkkKe9L8Ia3hELgqWXjowZyCUghnXrlKpdq8efPmL8PxXhF5CrS0tOyTyWSY5QRjdodrwfYXwITTSRZGhgAVhr3jjz86yGPg1ongsr9nwLzx2MmIlx7MRp38MktFmhCzG/1s2H0+wHvnk6lw5TKxYIRNpxBqCzpfKWCxW/4pXVY0S7DgSwiC1oXr/SLyBNi4ceNvAACnsdZSOWzmS7fcQHbCCxEfgtD2HW0OOrN31O12P3JKE9NI3uXCZFcoygWcmWAJSvlJIJlNM5PKJTToEGRQ5hezZlEuw5WVlZvC+Z4RUTCNjY1jcrn86kmDBWv99iWlnN9UrBmNxHvPB/Y3NScDAAaDOqdX6zd6vTHdmj5QmEeoLEHEYID0JNLwDRHnc8XS7kIWpxBn3VNXV3d9KMl0sxGxPWx9ff2oSqV64MzWfyZ/um5d+k0LF5BJeCGgGRkV1p5qGQ3UCnT5/a5d3X0xzdjNY7Ndt4ozCclgQX2mZDadzKcKgZ9mZGtWJPEvx1tXqVS/Xbt2LWbpDxEi6iSrrKx8u66u7k9YaxAAYO+tN9G4dDo5YykENn/wcaEXQQKqUXqytdM54HDGNKnu2aWLPCwKJWQLyoMgTi8ddUMQtmOSBJ/F3KSGX2TnLpzlkPeVSuX2SLx3xL3w1dXVj2u12vew1tK5XGb9fXfDySwm2d4hSEbtjiTVKfVFLcBum93517aumDp2lwp47tvEWYSqnZstZhOLQU0Pn1Tzg2wGs+evRYty8TJ1tVrtdzKZ7A6NRhOR94+4gtFoNOjDDz98HwDAiLW+IiuTvW3dWkek5ZiL7G06ljypa2Y75qWuPr83xjOOflGQ6yd6r31mHEv4thIxwP2HghJ7EoWKN7jOt3///iqNRhOx319U9uUajcYOAPhcLpcrAJjZ8X1VdhZDa7ZMnNAbyHKCIOg3mjjrCgvacgR8zBvI7PW67jp6nOqK4XC8VDrds3fVUohJoYScOWzwuIeeHegW+AEgOyUGjuORnIJjawQpq3HWXbW1tRs2b958MJJCRO3Jtm3btmaVSvV7rDUKDMP/uO0W4Spxlila8swFUACgX374iQQFANMX82qf1mv0+mLqs3iqdKGLT6MR8v/s1PWbPShKPnyCoFKU2fbDtIw1eOtqtXr77bff/kGk5Yiq6bx169Y9arX6Fbz11zb8iCFgMsntUhAcH9KLvurumTEYz4eg7he7+mLaBLuYy3FvLMglFPXpdjoGvzaO4bZwJJlJAYut/nmmWDLLIV+sX78eM/gSbqKqYHQ6nb+6uvoeAEAD1rpUlMZ6/+d3eiGMwVok+Lz83bHJH/F5Dt/tHd3mLps9piHdu/IkHgpEbFvz3qgBRcmSgIBJptL69y1ckiSg0tJwDumWy+U36nS6qDSDi/oXV19fDyorK3Gdvlfk5vCV69aSoesgeK+1LatrfOL7MIDW4XQoNe2Eqq7DwQ2ZIkLZ2mafV//ZxGhImb/zFOcjuYVWBgzP6GgwjXv79u331NfXRy1qG5Mng0qlaqmrq7sZbxzt41dVJK/Jy4nKTKC5gMfvpz3yyWdZZyNKL3f3e51+JNb5It7FAj4hGf6h141b/X5SwQTIL7Jyv6wQpJTirdfV1d378MMPfxNNmWJmeq5du/ZgQ0PDH7DWIADAxz//cVJpuojM9A2QdzVtkhNDBrPZ67Xu7e2PtXIBGQyGHsaIGAbKoNs19O6oIWqjcxOdtQLhyZ9mZl+Ht67VanetXbv2n9GVKsZ728rKyifVavXzWGtJDAbj3Z/eQRMwySS8QHm6/lvq//v6sGXE7Yl5Or3Z56XgWaiB8C/DoMeHojFXlInAIg732O/yiyQAJ4yvVqvfvuyyyx6KvmRxMuoBRdHPAADXYK3tONgwsfXjT1OiL1WCAlNQULoYApTYDwuw/ej6fg6Vmhv0eX5/z00nj2Z5UISsbLwI2Qxm91ulK3gQAHhO3RNyuXxlfX19TLoXxIV3frpE3IC19qvLLhX8dPnSkehLlaAgfggYJ2ItxRQf60dCyb71/13b6yaVS0DYH8kp8MyiXGxbt26tipVyAfGiYFQqVVddXd16AMCM7RAFhuHXFT8SrcjKxIw6kWAwFh/+8Vf6tEErGK3LafhkfGRRZCSaW/y/9Mz21TwB3meF1NXVKXbs2NEcZbHOIy4UDDjj9D2pUqkew1t/TfEjehKDQQ5yCwSnAwCTKea1O58YRsS7u/uPB9pWAgHA84K2z0d2Irs4hSz26Z9l4CfTNTQ0/Hnt2rUHoivVTOLCB3MWqVQK1Gr1ewCAm7HW63v7jPK9r3LxnFkk50Cno0BaCgEo5l8x+urqZeqf50lww6fgzCwk10+OHm8foLgWAgASfZxtRBHS6H1vl66g0mFYjHPIEZlMdrlGo4n5jPjYewLPYXR0dHK79P7NN9+8js/nz/jw8pIFLBRFTfW9/WRdysXw+yHAZALAinlACfpAP5w06HRpCzhsu4jJOC+vxYeirs+GR+13Hz3hHwAuhEmjpMZO1ITA8UR+8XABi12Es94qk8nWTRcYx5y4UjDgjJLx8ni8Rrlcfj/WFq6iIJ/5RVf3qNZsmX1iFwkAPj8KhMLYmzAA0I4Zzckvdffx/juo7+y1O1yHxiag94aGJ+46epy+p2cgyYz6JnJS2HgZqCRnQH8lzvv8hlQRbhGjUqm87e23326Lrlj4xPzmw+Ott976YWVl5ZtY5rLZ5XKW797nbR0ZI7M8L8YiGQqY8T9DqFjEHUzjMrJjLUc8c3Vy6sk/FJTIAABYRaw+tVr9QGlp6b4YiIZL3Dh5L+T2229/V61W78Ba4zOZrFc3/Aglksg1bxiP/0ZNNApsSOUwyCmNs8Cj0lofzS0U4SgXoFar98ebcgHxrGAmWb9+/VOTnx3W2iXibP4rG344BgHIE33JEoiJcQj441sPF6VxbBAESL8aDkIaTb97QSmFQ6Fk4hxyfOPGjbgR2FgSdz6Yc7FYLF4AwEm5XH4P1vqyzAzuhNNl/k6ri7knM25BEAhAEAKSkuJym8RlUIfyhJygs33nE1skBe2reQK8Ma8jcrn80kOHDsVHduUFxLUFA850wjukVqs3Tu4xsdaVV1ewl2ZmjEdfsgRiZBgCnvg09NJ5ZER6Fvw/Ts+uvyFVtARnHVGpVPfV19fHpXIBiaBgJiktLd0/ucfEWktmsZgH77+HlZHEtURfsgRh0ooxTsSdLwaGIKuIyyAd9Tgs5/JPbBLnXgFwZkir1eq3KisrMSd2xAsJoWDAmXG0k3vME1hrXDqdvfuHN05aOGQnPDzGxgBA40vHZPAYVgiCCI0zmauk0ei9v88vSp/lN9q5bdu2h6MsVtAkjIJpbGycmB5Hi1n4eMuihSl/vf4aXfQlSxA8bgiMj8VVFj45BhYbCIDxvxYvMmfQGXiZuma5XL5WpVIFNHgvliSMggFn2m1OqFSq+/FqW359xeX5isWy+Kj0i0f0QwD4Y549PkUal9HJolPw5vXMZ5CHcwoGilmcZXgHqFSqzfX19UHNJo8VCaVgwJnWDu/W1dVtw1vf88ObWEI2m3T6YuHzwWDCGHMrBgLAUZjGIX0vGFzGT/78R2kZeE7dSf5WWVn5RhRFIkTCKRhwZhztk1qt9j9YawIWk/PNfXdTRRxOXNRixB3jsffFpPOYRhiCyDGwF7CEy2v7c9GiS/HSR7Ra7ScymezX0ZcsdBJSwWg0GrSysvJuAMAhrHWpKI3/5h0b3DAEOaMvXZzjdMBgbDSWVowrW8AknS8XkMNkdTxZUMKHAcCbBtFcWVn5Y41GE99ZkxeQkAoGnHH6WuVy+XWTih1rfW1Bfsq/br9tONBeJPOKoUE0Vtm92QLWAINKEcbkzeMUBgwPvVhSiqbS6HiZusNyuXxdY2NjwjVdi+tM3ovR39/v5fF46vLy8juwlGVpukgwZLHom4f0SbGRME5BURjQaH7A4UT1AUODIfOC9CQmDEFkWcD/4X08r6i/lJskw1lHVCrVT5599tmTUZYrLCSsBXOWhx9++LO6uroteOsv3nxDyiJR2lB0pUoAxsaiXjqQlsR0UGCItF7O4Za0jAPXpKQtxVuvq6v7XWVl5fvRlSp8JLyCAWfabb6o1Wpfx1qjUyjMT+/+CSuHz0848zKiuJwwMEY1ouRJ5zHIToTncBk/ueV/cgrW4a1rtdq3qqurn4muVOFlTigYcKby+pcAAMxEOwmfn7zvtpvJcbQXotOi0YooZfCYfSyyW933UADU/0hOweTWHa9Qd3j9+vUPaDSaKEsWXhLaB3Muo6OjbgDAh3K5fAMAYIbPpTAlhc+mUTu+6OrhzaW/mxAIAgMGEwEsVkS3SxQYsi5KT6LBMER2IZy8OSnU0d0LFxtzmKxinENGlErlVW+//TZmACORmFM/tOmq0iG5XH4b1vr/Z+/cY5vIrj9+Zvy2Y8exYycmHhIT5+UbFtj9/bZh2WLz0MarLoiXYyo1iFKkPuSqgnYl1G5F/uhDLaWvVdltRaS2Yllqt6W7qLTsrpSkXZEAKktK7PAOyZgCedIEEtuZeCoTR03ZGW8S7LEzMx8JCelYo+PJ9XfOPXPuOWtKlxp7Rh70dd69JzY3mmGKioOxMKORbJFOOWzUKMS6lyR7lxBXXAVG1rxLIBD4is/n+4BbrzIDrwQmwc2bN4P19fVqs9m8hsm+mrBK3u68/Ggslv3xqjlBLIaBVhsHuSJTIjNlN+VFZBJcjF4en5DWdR8os9tTjHn9eWNj46HR0dHcOpm6QHKyCVE6oGn6NAC8zGT7Q1fo5o7j/nLuvcpRlEoKqh3STIw4MeUprlWY88Qh9tP0n0Crxgilim3tvY9h2Esc+5RReJPkfZKGhgZfYrvEZNte67B9e73zstjTN0kkIoXR0bS/UcIx7FGpQS2eOQIAOY4Pv1G1/E4KcbmXHKHMK3i3RZohFAqNAMCZZLvNJxslY+uW2You3b13/erAoPhmAx7PUYqDwZDWB45Zqxw0aRVs1amC4vMW6xW30bSKxRxtampyHjlypJtjtzIObwUGppO+AwihMYQQ41bpxdKl2DvdV4ZHJiLiUzYWA8jXx0EmS5fIxO0mzbhcigu+odRqnb79G6Xl1ThgjP1BA4HAqz6fL6c70y0U3uZgZkiOow0AwA4m++2RBz3VP3ldG6WmxEgmT0tBRSXjWIz5YtDIr1YXaavSca3FjE2p6j6GVhGJu8vykT8ihLYv9noXNnibg5kh8YdDCDWSJNnOZC8r0Nt+tXXzsJiPAYCHY1J49PCpczEYBuNlBrHfiwSw/tfKKqRs4pJYkwihz/FVXEAIAgPTIhNpbm7+AlvP3l2rVlTufm7V37j3LAcZfPpBbYV5igdKGS703Ev0cIWju1qTx1ZMN5lYk6FQiNctRXidg5lNW1vboMPhuIgQ2spUg7DFUV18jgz33BgaFvZhvGgUwGCkQSJZ8Pa5vFAzppBKBH2CvcFs6dxmLl7NYp7w+/3bfD4fY1TNJwQRwczg9Xr/HAwGD7OYVW9ueUUlxfFF0es0Y8TjONy9s+Btkl4lu6ZVygTda9ehzjv/NcLGWvsTDAZ/5PV6T3PrVXbgfZL3SaxWq5okyQ4AYJyUd/Ffd7vXH/216d+RqJCTvnGodgCoVPN6AGEAkZVW/ZBKLhHsEHuLXHH7aM0zUr1UxjYRoJMgiBfC4fA4x65lBcFskWZIjqO96HK59jLZLVqtCQP86gc3bwk5h4ABhk2BLn9eAmPUyPuL85WCFRcAmPxxheNOikOMdFNT0+ZTp071cuxX1hCcwMB0PuaOx+PpMZvNm5i2iWvKlub3jIyc67x7f2l2PMwBYlEaCk044HPXmGWFmlGlTCLUt0cT+5YuO+/SG59nsU/6/f5dPp/vDMd+ZRVB5WBmU1tb+9tAIHCAyYYBqH+zY2tdw3L0Efee5QgUJYG+3jkPtDZq5LfyVTLBRn1fKikN7TAVf5rNHggEXvV6vce59Sr7CC4HM5tkEd67ALCJyT4Wjd6xHfrZyND4eC333uUI1TUUqNSfVHwX+VSZYViCY4JM7j6rzW99vRKtBgC2Sf6/Rwh5+FzvwoZgIxj4bxHeTpIkzzPZtQpFyd+/uEdi0WqFO5J2Dr17i7SKIaGKS7lKff2wvcbBJi4kSZ5FCDUKUVxA6AID0yIz3tzcvJetkrfGVFjz/fqNfdx7liMMD9EQT/3WukinFOo6enjQVknJcdzMYp8ppotw7FfOIMgk75O0tbX1OxyOywihLQwnr2GlpbgoRlHvfdjbZxOcKNM0DvF4FHT5jNukArWst0SvsgjtvmAAo98trwo+q81nOyE94ff7t/p8vg6OXcspBLUoUuH1ek8Gg8Gfspjl36vfWP9Shf1Djt3KDQb6ZRCLMUV4k3bT42M2gntQ7bJYb7j0xjo2ezAY/KHX6/0Lt17lHqLAzMLtdn8nEdCwmPFjDdsqd65Y3gIAc367whNwGPr4GSVTnqJfJsFLs+NS9ngmT9uyq7gk1fc+43a7f8ChSzmLKDCzCIfDD10u18sAcJvJbtKol7zt3e56bd3a9xObB+49zCKDgx8bcVKky1gf35zFrtK890bV8pVKnHX87TWXy7U5HA7z+hDjXBFcaPtJ9Pb2Ujqdris5jpbp/mDry222/ytZcqmjLxx7EImwDSvnF/G4BFRqCpTTCd18pZQkCtRmAa2hh26D+Z1v2uw1GgnrUYjI/v37t584cYLxASVEBF0Hk4qWlpYvu1yuI6k+Q8Xjg9vf8l96t/vKekFEgzrdJJTapCCVxp8j9L0KmWRZtl3iiN4DpeUnNxUWfTWVoLa2tu5ct27d77h1LbcRytNn3ly4cOEfZrM5ghDawCbEOIapP7ui1vqZqoqgWi4fuDE0NDQxSRl5K9zRKIBMRhnMhv5inZL3uRcFjl/0mCwt3yqzTzyv07NFtI9pb28/tHbtWraXBIKFnz+ENNLS0rLb5XIdnaMYT5y+ev3sW5f+SR/vvFwFAAQHLnKLQkE5NrwwoOffsQAaAEgACK43FJ6zKTQTe5aUvAIArOX/s2hFCG0MhUJiV8QnEAVmDvj9/i0ej+eXAMBWUMXEwOV79+/fGB7Jo6amaP4khbF4gaXwI4kE70827lrka+jxMChMplLhLyrViegzEZlVppgZ/T+QJHnC7XbvDoVC0cz7uvhY5IuDO5xOp6G1tfWvAPD/2fYly0zO6gg4lfxHpziHw2eOIYR2i5ELO/xPTKaJtra2YYIgXIFA4OsAcC/b/uQIiW2jPCkucQCgkjVCU8n/85WRQCCwB8OwRlFcRNKOx+Mx0DT9Jk3TFC08YvP4bCR5j6IZ9Idr/uR0OguyvQZFBMC+ffscZ8+e/QVN0wPZXvUcMh+Bmc2M2FBPcY1s8aivr+/4wYMHN1itVjGtIMItTqcT9/v9m2iaPknT9ES2fw0ZJl3iMCM0kTRdLxOQXV1dB5xOp+CnUy4UUY3TTF1dnYogiOq6ujoHQRAEAFgAgE/VvlMZqJ+iEtd0OBwShBDBcX1W4vuMB4PBR8l55j0kSd7q6Ojoam9v7w6Hw089iE7I/CcAAP//LazR1LfsgEMAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - hco.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - v2v.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - machineremediation.kubevirt.io
+          resources:
+          - machineremediationoperators
+          - machineremediationoperators/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - daemonsets
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consoleclidownloads
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        serviceAccountName: hyperconverged-cluster-operator
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - networkaddonsconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          - endpoints
+          - pods/exec
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - patch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - kubevirt-handler
+          - kubevirt-controller
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - put
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - delete
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines/status
+          verbs:
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancemigrations
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancepresets
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - limitranges
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinerestores
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - update
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstances
+          verbs:
+          - update
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - version
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - kubevirt.io
+          - ssp.kubevirt.io
+          - template.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes
+          - datavolumes/source
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+          - delete
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - daemonsets
+          verbs:
+          - create
+          - update
+          - get
+          - list
+          - patch
+          - watch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - persistentvolumeclaims
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - update
+          - get
+          - patch
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - persistentvolumeclaims/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - create
+          - watch
+          - patch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: kubevirt-ssp-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          - upload.cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - '*'
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes
+          verbs:
+          - list
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims/finalizers
+          - pods/finalizers
+          - volumesnapshots/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - events
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+          - create
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - nodemaintenance.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: node-maintenance-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - list
+          - watch
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - clusterrolebindings
+          verbs:
+          - update
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - clusterroles
+          verbs:
+          - update
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - hostpath-provisioner-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - hostpathprovisioner.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - delete
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+        serviceAccountName: hostpath-provisioner-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - v2v.kubevirt.io
+          resources:
+          - vmimportconfigs
+          - vmimportconfigs/finalizers
+          - vmimportconfigs/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - '*'
+        serviceAccountName: vm-import-operator
+      deployments:
+      - name: hco-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-operator
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                - name: WEBHOOK_MODE
+                  value: "false"
+                - name: KVM_EMULATION
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-operator
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                - name: CONVERSION_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-v2v-conversion@sha256:c620233c71b805004c2cd38927c421b69d99b27cb40af521967e655882b2f815
+                - name: VMWARE_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-vmware@sha256:ae5ccd98a49ab9e154ce482d2fa73f044b00211f273210a9cd371b40746d3c92
+                - name: SMBIOS
+                  value: |-
+                    Family: KubeVirt
+                    Manufacturer: KubeVirt
+                    Product: None
+                - name: MACHINETYPE
+                - name: HCO_KV_IO_VERSION
+                  value: 1.2.0
+                - name: KUBEVIRT_VERSION
+                  value: v0.34.0
+                - name: CDI_VERSION
+                  value: v1.23.5
+                - name: NETWORK_ADDONS_VERSION
+                  value: v0.42.2
+                - name: SSP_VERSION
+                  value: v1.2.1
+                - name: NMO_VERSION
+                  value: v0.7.0
+                - name: HPPO_VERSION
+                  value: v0.5.2
+                - name: VM_IMPORT_VERSION
+                  value: v0.2.4
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+                imagePullPolicy: IfNotPresent
+                name: hyperconverged-cluster-operator
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: hco-webhook
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-webhook
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-webhook
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                - name: WEBHOOK_MODE
+                  value: "true"
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-webhook
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+                imagePullPolicy: IfNotPresent
+                name: hyperconverged-cluster-webhook
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: cluster-network-addons-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cluster-network-addons-operator
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                name: cluster-network-addons-operator
+            spec:
+              containers:
+              - env:
+                - name: MULTUS_IMAGE
+                  value: nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba
+                - name: LINUX_BRIDGE_IMAGE
+                  value: quay.io/kubevirt/cni-default-plugins@sha256:3dd438117076016d6d2acd508b93f106ca80a28c0af6e2e914d812f9a1d55142
+                - name: LINUX_BRIDGE_MARKER_IMAGE
+                  value: quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a
+                - name: NMSTATE_HANDLER_IMAGE
+                  value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150
+                - name: OVS_CNI_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53
+                - name: OVS_MARKER_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620
+                - name: KUBEMACPOOL_IMAGE
+                  value: quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e
+                - name: MACVTAP_CNI_IMAGE
+                  value: quay.io/kubevirt/macvtap-cni@sha256:407f75760fc096666becfa45d94f51757ebbe8f382e9e7b57ceeded0b8cfb6b8
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/cluster-network-addons-operator@sha256:f31ea1cc004fc3b9993ed43c5f23c9e237a368a385daf8730ec9366e8f0ee238
+                - name: OPERATOR_NAME
+                  value: cluster-network-addons-operator
+                - name: OPERATOR_VERSION
+                  value: v0.42.2
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERAND_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/cluster-network-addons-operator@sha256:f31ea1cc004fc3b9993ed43c5f23c9e237a368a385daf8730ec9366e8f0ee238
+                imagePullPolicy: IfNotPresent
+                name: cluster-network-addons-operator
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cluster-network-addons-operator
+      - name: virt-operator
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              kubevirt.io: virt-operator
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              annotations:
+                scheduler.alpha.kubernetes.io/critical-pod: ""
+              labels:
+                kubevirt.io: virt-operator
+                prometheus.kubevirt.io: ""
+              name: virt-operator
+            spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: kubevirt.io
+                          operator: In
+                          values:
+                          - virt-operator
+                      topologyKey: kubernetes.io/hostname
+                    weight: 1
+              containers:
+              - command:
+                - virt-operator
+                - --port
+                - "8443"
+                - -v
+                - "2"
+                env:
+                - name: OPERATOR_IMAGE
+                  value: docker.io/kubevirt/virt-operator@sha256:fec75f1d53426826a6e7b3e78f89730970dc3f7cfac7f44de7079247e4891492
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: KUBEVIRT_VERSION
+                  value: v0.34.0
+                - name: VIRT_API_SHASUM
+                  value: sha256:b02ec9d1c1a6a18626490ab6ac8be34155d9da32718036866b341feff41e5633
+                - name: VIRT_CONTROLLER_SHASUM
+                  value: sha256:852b81c8d72db1236d8cdc70263e7499819fad2470f3a6e154de08d256393ad3
+                - name: VIRT_HANDLER_SHASUM
+                  value: sha256:ec614bb569363ad646ddab232f4e6d9cc696711d271cafd56245a08f9d1c0f68
+                - name: VIRT_LAUNCHER_SHASUM
+                  value: sha256:15280b86aa3dbb5ab9648eb8fefc57fa4e6a0f5d521318478ad5c89edd31479b
+                image: docker.io/kubevirt/virt-operator@sha256:fec75f1d53426826a6e7b3e78f89730970dc3f7cfac7f44de7079247e4891492
+                imagePullPolicy: IfNotPresent
+                name: virt-operator
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8444
+                  name: webhooks
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /metrics
+                    port: 8443
+                    scheme: HTTPS
+                  initialDelaySeconds: 5
+                  timeoutSeconds: 10
+                resources: {}
+                volumeMounts:
+                - mountPath: /etc/virt-operator/certificates
+                  name: kubevirt-operator-certs
+                  readOnly: true
+              priorityClassName: kubevirt-cluster-critical
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: kubevirt-operator
+              tolerations:
+              - key: CriticalAddonsOnly
+                operator: Exists
+              volumes:
+              - name: kubevirt-operator-certs
+                secret:
+                  optional: true
+                  secretName: kubevirt-operator-certs
+      - name: kubevirt-ssp-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kubevirt-ssp-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: kubevirt-ssp-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: IMAGE_REFERENCE
+                  value: quay.io/fromani/kubevirt-ssp-operator-container@sha256:13ecfd8bc5779721378cfed69109bcc99392b0dcd589ddd600eb2648de9fce8c
+                - name: WATCH_NAMESPACE
+                - name: KVM_INFO_TAG
+                - name: VALIDATOR_TAG
+                - name: VIRT_LAUNCHER_TAG
+                - name: NODE_LABELLER_TAG
+                - name: CPU_PLUGIN_TAG
+                - name: IMAGE_NAME_PREFIX
+                - name: OPERATOR_NAME
+                  value: kubevirt-ssp-operator
+                - name: OPERATOR_VERSION
+                  value: v1.2.1
+                image: quay.io/fromani/kubevirt-ssp-operator-container@sha256:13ecfd8bc5779721378cfed69109bcc99392b0dcd589ddd600eb2648de9fce8c
+                imagePullPolicy: IfNotPresent
+                name: kubevirt-ssp-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              serviceAccountName: kubevirt-ssp-operator
+      - name: cdi-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cdi-operator
+              operator.cdi.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: cdi-operator
+                operator.cdi.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                  value: v1.23.5
+                - name: CONTROLLER_IMAGE
+                  value: docker.io/kubevirt/cdi-controller@sha256:659e241627c35b40650aa8d64cab77fb4962d326a7c152406068158487670ef5
+                - name: IMPORTER_IMAGE
+                  value: docker.io/kubevirt/cdi-importer@sha256:e501151f3ee205079488745520edabaef2e8b5911f504d79fd1048069d3b8866
+                - name: CLONER_IMAGE
+                  value: docker.io/kubevirt/cdi-cloner@sha256:cebde10682870ff307b51f6c57a90eca66b3b6cb569641d5e60660ae41e844c4
+                - name: APISERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-apiserver@sha256:513764f696b195ef7b9efef818634c9931ef96ccd8402fc8bc0a4d8a00a421f3
+                - name: UPLOAD_SERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadserver@sha256:9c89fdf6d8097b0258620584bc3d6028bcb27c0c053a5c81344d969c4aeb2943
+                - name: UPLOAD_PROXY_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadproxy@sha256:4b29d0592bbf45b32ae67efda633a47cfa8809ff87b6ea16849e2eb6df722921
+                - name: VERBOSITY
+                  value: "1"
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: docker.io/kubevirt/cdi-operator@sha256:55b71a6bf89ca32022f26cbba117e5bbaf2eac0a150aada326bb393960c7acea
+                imagePullPolicy: IfNotPresent
+                name: cdi-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                  protocol: TCP
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cdi-operator
+      - name: node-maintenance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: node-maintenance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: node-maintenance-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: node-maintenance-operator
+                image: quay.io/kubevirt/node-maintenance-operator:v0.7.0
+                imagePullPolicy: Always
+                name: node-maintenance-operator
+                resources: {}
+              serviceAccountName: node-maintenance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+      - name: hostpath-provisioner-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hostpath-provisioner-operator
+              operator.hostpath-provisioner.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hostpath-provisioner-operator
+                operator.hostpath-provisioner.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: hostpath-provisioner-operator
+                - name: PROVISIONER_IMAGE
+                  value: quay.io/kubevirt/hostpath-provisioner@sha256:9d92c216bc50d7fbfc787f315ad77dabd2ac26d981702efd545a1dd1f2b37c6c
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:074aae9b1fbc727975934e86eea31e699e4504c24e1a7aea6d0b2d69f0e07673
+                imagePullPolicy: IfNotPresent
+                name: hostpath-provisioner-operator
+                resources: {}
+              serviceAccountName: hostpath-provisioner-operator
+      - name: vm-import-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: vm-import-operator
+              operator.v2v.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: vm-import-operator
+                operator.v2v.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                  value: v0.2.4
+                - name: CONTROLLER_IMAGE
+                  value: quay.io/kubevirt/vm-import-controller@sha256:8ee55747671cd78b02a05a4b6a18737c8241c6ad7e6456d1d4a92e52f6c10dad
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: MONITORING_NAMESPACE
+                  value: openshift-monitoring
+                - name: VIRTV2V_IMAGE
+                  value: quay.io/kubevirt/vm-import-virtv2v@sha256:fe0f897bb1af295c228ae9060a8ee510a44e14d4973cc912e1c1b2394dd26740
+                image: quay.io/kubevirt/vm-import-operator@sha256:1f90a44eb9a567c2e3ca6b50ca8643d850a2d04b7f9a82992ad7e6777f84ec30
+                imagePullPolicy: IfNotPresent
+                name: vm-import-operator
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: vm-import-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - events
+          - secrets
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - daemonsets
+          verbs:
+          - delete
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - ""
+          resourceNames:
+          - hostpath-provisioner-admin
+          resources:
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        serviceAccountName: hostpath-provisioner-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  labels:
+    alm-owner-kubevirt: kubevirt-hyperconverged
+    operated-by: kubevirt-hyperconverged
+  links:
+  - name: KubeVirt project
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/hyperconverged-cluster-operator
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  relatedImages:
+  - image: quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a
+    name: bridge-marker
+  - image: docker.io/kubevirt/cdi-apiserver@sha256:513764f696b195ef7b9efef818634c9931ef96ccd8402fc8bc0a4d8a00a421f3
+    name: cdi-apiserver
+  - image: docker.io/kubevirt/cdi-cloner@sha256:cebde10682870ff307b51f6c57a90eca66b3b6cb569641d5e60660ae41e844c4
+    name: cdi-cloner
+  - image: docker.io/kubevirt/cdi-controller@sha256:659e241627c35b40650aa8d64cab77fb4962d326a7c152406068158487670ef5
+    name: cdi-controller
+  - image: docker.io/kubevirt/cdi-importer@sha256:e501151f3ee205079488745520edabaef2e8b5911f504d79fd1048069d3b8866
+    name: cdi-importer
+  - image: docker.io/kubevirt/cdi-operator@sha256:55b71a6bf89ca32022f26cbba117e5bbaf2eac0a150aada326bb393960c7acea
+    name: cdi-operator
+  - image: docker.io/kubevirt/cdi-uploadproxy@sha256:4b29d0592bbf45b32ae67efda633a47cfa8809ff87b6ea16849e2eb6df722921
+    name: cdi-uploadproxy
+  - image: docker.io/kubevirt/cdi-uploadserver@sha256:9c89fdf6d8097b0258620584bc3d6028bcb27c0c053a5c81344d969c4aeb2943
+    name: cdi-uploadserver
+  - image: quay.io/kubevirt/cluster-network-addons-operator@sha256:f31ea1cc004fc3b9993ed43c5f23c9e237a368a385daf8730ec9366e8f0ee238
+    name: cluster-network-addons-operator
+  - image: quay.io/kubevirt/cni-default-plugins@sha256:3dd438117076016d6d2acd508b93f106ca80a28c0af6e2e914d812f9a1d55142
+    name: cni-default-plugins
+  - image: quay.io/kubevirt/hostpath-provisioner@sha256:9d92c216bc50d7fbfc787f315ad77dabd2ac26d981702efd545a1dd1f2b37c6c
+    name: hostpath-provisioner
+  - image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:074aae9b1fbc727975934e86eea31e699e4504c24e1a7aea6d0b2d69f0e07673
+    name: hostpath-provisioner-operator
+  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:b827d847bf46643f7aa643cfad5d46cefff8b8b090d65f2162e9481fd268bdac
+    name: hyperconverged-cluster-operator
+  - image: quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e
+    name: kubemacpool
+  - image: quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150
+    name: kubernetes-nmstate-handler
+  - image: quay.io/fromani/kubevirt-ssp-operator-container@sha256:13ecfd8bc5779721378cfed69109bcc99392b0dcd589ddd600eb2648de9fce8c
+    name: kubevirt-ssp-operator-container
+  - image: quay.io/kubevirt/kubevirt-v2v-conversion@sha256:c620233c71b805004c2cd38927c421b69d99b27cb40af521967e655882b2f815
+    name: kubevirt-v2v-conversion
+  - image: quay.io/kubevirt/kubevirt-vmware@sha256:ae5ccd98a49ab9e154ce482d2fa73f044b00211f273210a9cd371b40746d3c92
+    name: kubevirt-vmware
+  - image: quay.io/kubevirt/macvtap-cni@sha256:407f75760fc096666becfa45d94f51757ebbe8f382e9e7b57ceeded0b8cfb6b8
+    name: macvtap-cni
+  - image: nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba
+    name: multus
+  - image: quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620
+    name: ovs-cni-marker
+  - image: quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53
+    name: ovs-cni-plugin
+  - image: docker.io/kubevirt/virt-api@sha256:b02ec9d1c1a6a18626490ab6ac8be34155d9da32718036866b341feff41e5633
+    name: virt-api
+  - image: docker.io/kubevirt/virt-controller@sha256:852b81c8d72db1236d8cdc70263e7499819fad2470f3a6e154de08d256393ad3
+    name: virt-controller
+  - image: docker.io/kubevirt/virt-handler@sha256:ec614bb569363ad646ddab232f4e6d9cc696711d271cafd56245a08f9d1c0f68
+    name: virt-handler
+  - image: docker.io/kubevirt/virt-launcher@sha256:15280b86aa3dbb5ab9648eb8fefc57fa4e6a0f5d521318478ad5c89edd31479b
+    name: virt-launcher
+  - image: docker.io/kubevirt/virt-operator@sha256:fec75f1d53426826a6e7b3e78f89730970dc3f7cfac7f44de7079247e4891492
+    name: virt-operator
+  - image: quay.io/kubevirt/vm-import-controller@sha256:8ee55747671cd78b02a05a4b6a18737c8241c6ad7e6456d1d4a92e52f6c10dad
+    name: vm-import-controller
+  - image: quay.io/kubevirt/vm-import-operator@sha256:1f90a44eb9a567c2e3ca6b50ca8643d850a2d04b7f9a82992ad7e6777f84ec30
+    name: vm-import-operator
+  - image: quay.io/kubevirt/vm-import-virtv2v@sha256:fe0f897bb1af295c228ae9060a8ee510a44e14d4973cc912e1c1b2394dd26740
+    name: vm-import-virtv2v
+  replaces: kubevirt-hyperconverged-operator.v1.1.0
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-hyperconverged
+      operated-by: kubevirt-hyperconverged
+  version: 1.2.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1beta1
+    - v1
+    containerPort: 4343
+    deploymentName: hco-webhook
+    failurePolicy: Fail
+    generateName: validate-hco.kubevirt.io
+    rules:
+    - apiGroups:
+      - hco.kubevirt.io
+      apiVersions:
+      - v1alpha1
+      - v1beta1
+      operations:
+      - CREATE
+      - DELETE
+      - UPDATE
+      resources:
+      - hyperconvergeds
+    sideEffects: None
+    timeoutSeconds: 30
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-hco-kubevirt-io-v1beta1-hyperconverged
+  - admissionReviewVersions:
+    - v1beta1
+    containerPort: 8443
+    deploymentName: node-maintenance-operator
+    failurePolicy: Fail
+    generateName: nodemaintenance-validation.kubevirt.io
+    rules:
+    - apiGroups:
+      - nodemaintenance.kubevirt.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - nodemaintenances
+      scope: Cluster
+    sideEffects: None
+    timeoutSeconds: 15
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/kubevirt00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/kubevirt00.crd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    categories:
+    - all
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/node-maintenance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/node-maintenance00.crd.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nodemaintenances.nodemaintenance.kubevirt.io
+spec:
+  group: nodemaintenance.kubevirt.io
+  names:
+    kind: NodeMaintenance
+    listKind: NodeMaintenanceList
+    plural: nodemaintenances
+    singular: nodemaintenance
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: NodeMaintenance is the Schema for the nodemaintenances API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: NodeMaintenanceSpec defines the desired state of NodeMaintenance
+          properties:
+            nodeName:
+              description: Node name to apply maintanance on/off
+              type: string
+            reason:
+              description: Reason for maintanance
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          description: NodeMaintenanceStatus defines the observed state of NodeMaintenance
+          properties:
+            errorOnLeaseCount:
+              description: Consecutive number of errors upon obtaining a lease
+              type: integer
+            evictionPods:
+              description: EvictionPods is the total number of pods up for eviction
+                from the start
+              type: integer
+            lastError:
+              description: LastError represents the latest error if any in the latest
+                reconciliation
+              type: string
+            pendingPods:
+              description: PendingPods is a list of pending pods for eviction
+              items:
+                type: string
+              type: array
+            phase:
+              description: Phase is the represtation of the maintenance progress (Running,Succeeded,Failed)
+              type: string
+            totalpods:
+              description: TotalPods is the total number of all pods on the node from
+                the start
+              type: integer
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/scheduling-scale-performance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/scheduling-scale-performance00.crd.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtcommontemplatesbundles.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: KubevirtCommonTemplatesBundle
+    listKind: KubevirtCommonTemplatesBundleList
+    plural: kubevirtcommontemplatesbundles
+    shortNames:
+    - kvct
+    singular: kubevirtcommontemplatesbundle
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KubevirtCommonTemplatesBundle defines the CommonTemplates CR
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the configuration of Common Templates
+            properties:
+              version:
+                description: Defines the version of the operand
+                type: string
+            type: object
+          status:
+            description: Status holds the current status of Common Templates
+            properties:
+              conditions:
+                description: Reported states of the controller
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              containers:
+                description: Containers used in the current deployment
+                items:
+                  description: Defines a container
+                  properties:
+                    image:
+                      description: Image path
+                      type: string
+                    name:
+                      description: Container name
+                      type: string
+                    namespace:
+                      description: Container namespace
+                      type: string
+                    parentKind:
+                      description: Parent kind
+                      type: string
+                    parentName:
+                      description: Parent image
+                      type: string
+                  required:
+                  - image
+                  - name
+                  - namespace
+                  - parentKind
+                  - parentName
+                  type: object
+                type: array
+              observedVersion:
+                description: The version of the deployed operands
+                type: string
+              operatorVersion:
+                description: The version of the deployed operator
+                type: string
+              targetVersion:
+                description: The desired version of the deployed operands
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  preserveUnknownFields: false

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/scheduling-scale-performance01.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/scheduling-scale-performance01.crd.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtmetricsaggregations.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: KubevirtMetricsAggregation
+    listKind: KubevirtMetricsAggregationList
+    plural: kubevirtmetricsaggregations
+    shortNames:
+    - kvma
+    singular: kubevirtmetricsaggregation
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KubevirtMetricsAggregation defines the MetricsAggregation CR
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the configuration of MetricsAggregation
+            properties:
+              version:
+                description: Defines the version of the operand
+                type: string
+            type: object
+          status:
+            description: Status holds the current status of MetricsAggregation
+            properties:
+              conditions:
+                description: Reported states of the controller
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              containers:
+                description: Containers used in the current deployment
+                items:
+                  description: Defines a container
+                  properties:
+                    image:
+                      description: Image path
+                      type: string
+                    name:
+                      description: Container name
+                      type: string
+                    namespace:
+                      description: Container namespace
+                      type: string
+                    parentKind:
+                      description: Parent kind
+                      type: string
+                    parentName:
+                      description: Parent image
+                      type: string
+                  required:
+                  - image
+                  - name
+                  - namespace
+                  - parentKind
+                  - parentName
+                  type: object
+                type: array
+              observedVersion:
+                description: The version of the deployed operands
+                type: string
+              operatorVersion:
+                description: The version of the deployed operator
+                type: string
+              targetVersion:
+                description: The desired version of the deployed operands
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  preserveUnknownFields: false

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/scheduling-scale-performance02.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/scheduling-scale-performance02.crd.yaml
@@ -1,0 +1,750 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtnodelabellerbundles.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: KubevirtNodeLabellerBundle
+    listKind: KubevirtNodeLabellerBundleList
+    plural: kubevirtnodelabellerbundles
+    shortNames:
+    - kvnl
+    singular: kubevirtnodelabellerbundle
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KubevirtNodeLabellerBundle defines the NodeLabeller CR
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the configuration of NodeLabeller
+            properties:
+              affinity:
+                description: Define the node affinity for NodeLabeller pods
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: Define node selector labels for NodeLabeller pods
+                type: object
+              tolerations:
+                description: Define tolerations for NodeLabeller pods
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              version:
+                description: Defines the version of the NodeLabeller
+                type: string
+            type: object
+          status:
+            description: Status holds the current status of NodeLabeller
+            properties:
+              conditions:
+                description: Reported states of the controller
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              containers:
+                description: Containers used in the current deployment
+                items:
+                  description: Defines a container
+                  properties:
+                    image:
+                      description: Image path
+                      type: string
+                    name:
+                      description: Container name
+                      type: string
+                    namespace:
+                      description: Container namespace
+                      type: string
+                    parentKind:
+                      description: Parent kind
+                      type: string
+                    parentName:
+                      description: Parent image
+                      type: string
+                  required:
+                  - image
+                  - name
+                  - namespace
+                  - parentKind
+                  - parentName
+                  type: object
+                type: array
+              observedVersion:
+                description: The version of the deployed operands
+                type: string
+              operatorVersion:
+                description: The version of the deployed operator
+                type: string
+              targetVersion:
+                description: The desired version of the deployed operands
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  preserveUnknownFields: false

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/scheduling-scale-performance03.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/scheduling-scale-performance03.crd.yaml
@@ -1,0 +1,753 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirttemplatevalidators.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: KubevirtTemplateValidator
+    listKind: KubevirtTemplateValidatorList
+    plural: kubevirttemplatevalidators
+    shortNames:
+    - kvtv
+    singular: kubevirttemplatevalidator
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KubevirtTemplateValidator defines the TemplateValidator CR
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the configuration of TemplateValidator
+            properties:
+              affinity:
+                description: Define the node affinity for TemplateValidator pods
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: Define node selector labels for TemplateValidator
+                type: object
+              templateValidatorReplicas:
+                description: Defines the desired number of replicas for TemplateValidator
+                type: integer
+              tolerations:
+                description: Define tolerations for TemplateValidator
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              version:
+                description: Defines the version of TemplateValidaotr
+                type: string
+            type: object
+          status:
+            description: Status holds the current status of TemplateValidator
+            properties:
+              conditions:
+                description: Reported states of the controller
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              containers:
+                description: Containers used in the current deployment
+                items:
+                  description: Defines a container
+                  properties:
+                    image:
+                      description: Image path
+                      type: string
+                    name:
+                      description: Container name
+                      type: string
+                    namespace:
+                      description: Container namespace
+                      type: string
+                    parentKind:
+                      description: Parent kind
+                      type: string
+                    parentName:
+                      description: Parent image
+                      type: string
+                  required:
+                  - image
+                  - name
+                  - namespace
+                  - parentKind
+                  - parentName
+                  type: object
+                type: array
+              observedVersion:
+                description: The version of the deployed operands
+                type: string
+              operatorVersion:
+                description: The version of the deployed operator
+                type: string
+              targetVersion:
+                description: The desired version of the deployed operands
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  preserveUnknownFields: false

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/vm-import-operator00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/manifests/vm-import-operator00.crd.yaml
@@ -1,0 +1,903 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.v2v.kubevirt.io: ""
+  name: vmimportconfigs.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: VMImportConfig
+    listKind: VMImportConfigList
+    plural: vmimportconfigs
+    singular: vmimportconfig
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VMImportConfig is the Schema for the vmimportconfigs API
+        properties:
+          apiVersion:
+            description: APIVersion defines the versioned schema of this representation of an object
+            type: string
+          kind:
+            description: Kind is a string value representing the REST resource this object represents
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VMImportConfigSpec defines the desired state of VMImportConfig
+            properties:
+              imagePullPolicy:
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes vm import infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: VMImportConfigStatus defines the observed state of VMImportConfig
+            properties:
+              conditions:
+                description: A list of current conditions of the VMImportConfig resource
+                items:
+                  properties:
+                    lastHeartbeatTime:
+                      description: Last time the state of the condition was checked
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the state of the condition changed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message related to the last condition change
+                      type: string
+                    reason:
+                      description: Reason the last condition changed
+                      type: string
+                    status:
+                      description: Current status of the condition, True, False, Unknown
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the VMImportConfig resource
+                type: string
+              operatorVersion:
+                description: The version of the VMImportConfig resource as defined by the operator
+                type: string
+              phase:
+                description: VMImportPhase is the current phase of the VMImport deployment
+                type: string
+              targetVersion:
+                description: The desired version of the VMImportConfig resource
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VMImportConfig is the Schema for the vmimportconfigs API
+        properties:
+          apiVersion:
+            description: APIVersion defines the versioned schema of this representation of an object
+            type: string
+          kind:
+            description: Kind is a string value representing the REST resource this object represents
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VMImportConfigSpec defines the desired state of VMImportConfig
+            properties:
+              imagePullPolicy:
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes vm import infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: ' defines the status of the VMImportConfig installation'
+            properties:
+              conditions:
+                description: A list of current conditions of the VMImportConfigresource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the VMImportConfig resource
+                type: string
+              operatorVersion:
+                description: The version of the VMImportConfig resource as defined by the operator
+                type: string
+              phase:
+                description: Phase is the current phase of the VMImportConfig deployment
+                type: string
+              targetVersion:
+                description: The desired version of the VMImportConfig resource
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.2.0/metadata/annotations.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.2.0/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: community-kubevirt-hyperconverged
+  com.redhat.openshift.versions: "=v4.6"

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/cluster-network-addons00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/cluster-network-addons00.crd.yaml
@@ -1,0 +1,3049 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NetworkAddonsConfig is the Schema for the networkaddonsconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkAddonsConfigSpec defines the desired state of NetworkAddonsConfig
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
+                type: string
+              kubeMacPool:
+                description: KubeMacPool plugin manages MAC allocation to Pods and
+                  VMs in Kubernetes
+                properties:
+                  rangeEnd:
+                    description: RangeEnd defines the first mac in range
+                    type: string
+                  rangeStart:
+                    description: RangeStart defines the first mac in range
+                    type: string
+                type: object
+              linuxBridge:
+                description: LinuxBridge plugin allows users to create a bridge and
+                  add the host and the container to it
+                type: object
+              macvtap:
+                description: MacvtapCni plugin allows users to define Kubernetes networks
+                  on top of existing host interfaces
+                type: object
+              multus:
+                description: Multus plugin enables attaching multiple network interfaces
+                  to Pods in Kubernetes
+                type: object
+              nmstate:
+                description: NMState is a declarative node network configuration driven
+                  through Kubernetes API
+                type: object
+              ovs:
+                description: Ovs plugin allows users to define Kubernetes networks
+                  on top of Open vSwitch bridges available on nodes
+                type: object
+              placementConfiguration:
+                description: PlacementConfiguration defines node placement configuration
+                properties:
+                  infra:
+                    description: Infra defines placement configuration for master
+                      nodes
+                    properties:
+                      affinity:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  workloads:
+                    properties:
+                      affinity:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              selfSignConfiguration:
+                description: SelfSignConfiguration defines self sign configuration
+                properties:
+                  caOverlapInterval:
+                    description: CAOverlapInterval defines the duration of CA Certificates
+                      at CABundle if not set it will default to CARotateInterval
+                    type: string
+                  caRotateInterval:
+                    description: CARotateInterval defines duration for CA and certificate
+                    type: string
+                  certRotateInterval:
+                    description: CertRotateInterval defines duration for of service
+                      certificate
+                    type: string
+                type: object
+            type: object
+          status:
+            description: NetworkAddonsConfigStatus defines the observed state of NetworkAddonsConfig
+            properties:
+              conditions:
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              containers:
+                items:
+                  properties:
+                    image:
+                      type: string
+                    name:
+                      type: string
+                    parentKind:
+                      type: string
+                    parentName:
+                      type: string
+                  required:
+                  - image
+                  - name
+                  - parentKind
+                  - parentName
+                  type: object
+                type: array
+              observedVersion:
+                type: string
+              operatorVersion:
+                type: string
+              targetVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetworkAddonsConfig is the Schema for the networkaddonsconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkAddonsConfigSpec defines the desired state of NetworkAddonsConfig
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
+                type: string
+              kubeMacPool:
+                description: KubeMacPool plugin manages MAC allocation to Pods and
+                  VMs in Kubernetes
+                properties:
+                  rangeEnd:
+                    description: RangeEnd defines the first mac in range
+                    type: string
+                  rangeStart:
+                    description: RangeStart defines the first mac in range
+                    type: string
+                type: object
+              linuxBridge:
+                description: LinuxBridge plugin allows users to create a bridge and
+                  add the host and the container to it
+                type: object
+              macvtap:
+                description: MacvtapCni plugin allows users to define Kubernetes networks
+                  on top of existing host interfaces
+                type: object
+              multus:
+                description: Multus plugin enables attaching multiple network interfaces
+                  to Pods in Kubernetes
+                type: object
+              nmstate:
+                description: NMState is a declarative node network configuration driven
+                  through Kubernetes API
+                type: object
+              ovs:
+                description: Ovs plugin allows users to define Kubernetes networks
+                  on top of Open vSwitch bridges available on nodes
+                type: object
+              placementConfiguration:
+                description: PlacementConfiguration defines node placement configuration
+                properties:
+                  infra:
+                    description: Infra defines placement configuration for master
+                      nodes
+                    properties:
+                      affinity:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  workloads:
+                    properties:
+                      affinity:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              selfSignConfiguration:
+                description: SelfSignConfiguration defines self sign configuration
+                properties:
+                  caOverlapInterval:
+                    description: CAOverlapInterval defines the duration of CA Certificates
+                      at CABundle if not set it will default to CARotateInterval
+                    type: string
+                  caRotateInterval:
+                    description: CARotateInterval defines duration for CA and certificate
+                    type: string
+                  certRotateInterval:
+                    description: CertRotateInterval defines duration for of service
+                      certificate
+                    type: string
+                type: object
+            type: object
+          status:
+            description: NetworkAddonsConfigStatus defines the observed state of NetworkAddonsConfig
+            properties:
+              conditions:
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              containers:
+                items:
+                  properties:
+                    image:
+                      type: string
+                    name:
+                      type: string
+                    parentKind:
+                      type: string
+                    parentName:
+                      type: string
+                  required:
+                  - image
+                  - name
+                  - parentKind
+                  - parentName
+                  type: object
+                type: array
+              observedVersion:
+                type: string
+              operatorVersion:
+                type: string
+              targetVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  preserveUnknownFields: false

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/containerized-data-importer00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/containerized-data-importer00.crd.yaml
@@ -1,0 +1,1795 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.cdi.kubevirt.io: ""
+  name: cdis.cdi.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: cdi.kubevirt.io
+  names:
+    kind: CDI
+    listKind: CDIList
+    plural: cdis
+    shortNames:
+    - cdi
+    - cdis
+    singular: cdi
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CDI is the CDI Operator CRD
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CDISpec defines our specification for the CDI installation
+            properties:
+              cloneStrategyOverride:
+                description: 'Clone strategy override: should we use a host-assisted copy even if snapshots are available?'
+                enum:
+                - copy
+                - snapshot
+                type: string
+              config:
+                description: CDIConfig at CDI level
+                properties:
+                  filesystemOverhead:
+                    description: FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)
+                    properties:
+                      global:
+                        description: Global is how much space of a Filesystem volume should be reserved for overhead. This value is used unless overridden by a more specific value (per storageClass)
+                        pattern: ^(0(?:\.\d{1,3})?|1)$
+                        type: string
+                      storageClass:
+                        additionalProperties:
+                          description: 'Percent is a string that can only be a value between [0,1) (Note: we actually rely on reconcile to reject invalid values)'
+                          pattern: ^(0(?:\.\d{1,3})?|1)$
+                          type: string
+                        description: StorageClass specifies how much space of a Filesystem volume should be reserved for safety. The keys are the storageClass and the values are the overhead. This value overrides the global value
+                        type: object
+                    type: object
+                  podResourceRequirements:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  scratchSpaceStorageClass:
+                    description: 'Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn''t exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space'
+                    type: string
+                  uploadProxyURLOverride:
+                    description: Override the URL used when uploading to a DataVolume
+                    type: string
+                type: object
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes CDI infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              uninstallStrategy:
+                description: CDIUninstallStrategy defines the state to leave CDI on uninstall
+                enum:
+                - RemoveWorkloads
+                - BlockUninstallIfWorkloadsExist
+                type: string
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: CDIStatus defines the status of the installation
+            properties:
+              conditions:
+                description: A list of current conditions of the resource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the resource
+                type: string
+              operatorVersion:
+                description: The version of the resource as defined by the operator
+                type: string
+              phase:
+                description: Phase is the current phase of the deployment
+                type: string
+              targetVersion:
+                description: The desired version of the resource
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CDI is the CDI Operator CRD
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CDISpec defines our specification for the CDI installation
+            properties:
+              cloneStrategyOverride:
+                description: 'Clone strategy override: should we use a host-assisted copy even if snapshots are available?'
+                enum:
+                - copy
+                - snapshot
+                type: string
+              config:
+                description: CDIConfig at CDI level
+                properties:
+                  featureGates:
+                    description: FeatureGates are a list of specific enabled feature gates
+                    items:
+                      type: string
+                    type: array
+                  filesystemOverhead:
+                    description: FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)
+                    properties:
+                      global:
+                        description: Global is how much space of a Filesystem volume should be reserved for overhead. This value is used unless overridden by a more specific value (per storageClass)
+                        pattern: ^(0(?:\.\d{1,3})?|1)$
+                        type: string
+                      storageClass:
+                        additionalProperties:
+                          description: 'Percent is a string that can only be a value between [0,1) (Note: we actually rely on reconcile to reject invalid values)'
+                          pattern: ^(0(?:\.\d{1,3})?|1)$
+                          type: string
+                        description: StorageClass specifies how much space of a Filesystem volume should be reserved for safety. The keys are the storageClass and the values are the overhead. This value overrides the global value
+                        type: object
+                    type: object
+                  podResourceRequirements:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  preallocation:
+                    description: Preallocation controls whether storage for DataVolumes should be allocated in advance.
+                    type: boolean
+                  scratchSpaceStorageClass:
+                    description: 'Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn''t exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space'
+                    type: string
+                  uploadProxyURLOverride:
+                    description: Override the URL used when uploading to a DataVolume
+                    type: string
+                type: object
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes CDI infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              uninstallStrategy:
+                description: CDIUninstallStrategy defines the state to leave CDI on uninstall
+                enum:
+                - RemoveWorkloads
+                - BlockUninstallIfWorkloadsExist
+                type: string
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: CDIStatus defines the status of the installation
+            properties:
+              conditions:
+                description: A list of current conditions of the resource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the resource
+                type: string
+              operatorVersion:
+                description: The version of the resource as defined by the operator
+                type: string
+              phase:
+                description: Phase is the current phase of the deployment
+                type: string
+              targetVersion:
+                description: The desired version of the resource
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/hco00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/hco00.crd.yaml
@@ -1,0 +1,992 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hyperconvergeds.hco.kubevirt.io
+spec:
+  group: hco.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: HyperConverged
+    listKind: HyperConvergedList
+    plural: hyperconvergeds
+    shortNames:
+    - hco
+    - hcos
+    singular: hyperconverged
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HyperConverged is the Schema for the hyperconvergeds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                pattern: kubevirt-hyperconverged
+                type: string
+            type: object
+          spec:
+            description: HyperConvergedSpec defines the desired state of HyperConverged
+            properties:
+              BareMetalPlatform:
+                description: BareMetalPlatform indicates whether the infrastructure is baremetal.
+                type: boolean
+              LocalStorageClassName:
+                description: LocalStorageClassName the name of the local storage class.
+                type: string
+              version:
+                description: operator version
+                type: string
+            type: object
+          status:
+            description: HyperConvergedStatus defines the observed state of HyperConverged
+            properties:
+              conditions:
+                description: Conditions describes the state of the HyperConverged resource.
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              relatedObjects:
+                description: RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster.
+                items:
+                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              versions:
+                description: 'Versions is a list of HCO component versions, as name/version pairs. The version with a name of "operator" is the HCO version itself, as described here: https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version'
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HyperConverged is the Schema for the hyperconvergeds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                pattern: kubevirt-hyperconverged
+                type: string
+            type: object
+          spec:
+            description: HyperConvergedSpec defines the desired state of HyperConverged
+            properties:
+              bareMetalPlatform:
+                description: BareMetalPlatform indicates whether the infrastructure is baremetal.
+                type: boolean
+              featureGates:
+                description: featureGates is a map of feature gate flags. Setting a flag to `true` will enable the feature. Setting `false` or removing the feature gate, disables the feature.
+                properties:
+                  hotplugVolumes:
+                    description: Allow attaching a data volume to a running VMI
+                    type: boolean
+                type: object
+              infra:
+                description: infra HyperConvergedConfig influences the pod configuration (currently only placement) for all the infra components needed on the virtualization enabled cluster but not necessarely directly on each node running VMs/VMIs.
+                properties:
+                  nodePlacement:
+                    description: NodePlacement describes node scheduling configuration.
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              localStorageClassName:
+                description: LocalStorageClassName the name of the local storage class.
+                type: string
+              version:
+                description: operator version
+                type: string
+              workloads:
+                description: workloads HyperConvergedConfig influences the pod configuration (currently only placement) of components which need to be running on a node where virtualization workloads should be able to run. Changes to Workloads HyperConvergedConfig can be applied only without existing workload.
+                properties:
+                  nodePlacement:
+                    description: NodePlacement describes node scheduling configuration.
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            type: object
+          status:
+            description: HyperConvergedStatus defines the observed state of HyperConverged
+            properties:
+              conditions:
+                description: Conditions describes the state of the HyperConverged resource.
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              relatedObjects:
+                description: RelatedObjects is a list of objects created and maintained by this operator. Object references will be added to this list after they have been created AND found in the cluster.
+                items:
+                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              versions:
+                description: 'Versions is a list of HCO component versions, as name/version pairs. The version with a name of "operator" is the HCO version itself, as described here: https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version'
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/hco01.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/hco01.crd.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: v2vvmwares.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    kind: V2VVmware
+    listKind: V2VVmwareList
+    plural: v2vvmwares
+    singular: v2vvmware
+  scope: Namespaced
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/hco02.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/hco02.crd.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ovirtproviders.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    kind: OVirtProvider
+    listKind: OVirtProviderList
+    plural: ovirtproviders
+    singular: ovirtprovider
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: OVirtProvider is the Schema for the ovirtproviders API
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation
+                                    of an object. Servers should convert recognized schemas to the latest
+                                    internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this
+                                    object represents. Servers may infer this from the endpoint the client
+                                    submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: OVirtProviderSpec defines the desired state of OVirtProvider
+          properties:
+            connection:
+              type: string
+            timeToLive:
+              type: string
+            vms:
+              items:
+                description: OVirtVM aligns with maintained UI interface
+                properties:
+                  cluster:
+                    type: string
+                  detail:
+                    description: OVirtVMDetail contains ovirt vm details as json string
+                    properties:
+                      raw:
+                        type: string
+                    type: object
+                  detailRequest:
+                    type: boolean
+                  id:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - cluster
+                - id
+                - name
+                type: object
+              type: array
+          type: object
+        status:
+          description: OVirtProviderStatus defines the observed state of OVirtProvider
+          properties:
+            phase:
+              description: VirtualMachineProviderPhase defines provider phase
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/hostpath-provisioner00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/hostpath-provisioner00.crd.yaml
@@ -1,0 +1,925 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.hostpathprovisioner.kubevirt.io: ""
+  name: hostpathprovisioners.hostpathprovisioner.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: hostpathprovisioner.kubevirt.io
+  names:
+    kind: HostPathProvisioner
+    listKind: HostPathProvisionerList
+    plural: hostpathprovisioners
+    shortNames:
+    - hpp
+    - hpps
+    singular: hostpathprovisioner
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HostPathProvisioner is the Schema for the hostpathprovisioners API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostPathProvisionerSpec defines the desired state of HostPathProvisioner
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              imageRegistry:
+                type: string
+              imageTag:
+                type: string
+              pathConfig:
+                description: PathConfig describes the location and layout of PV storage on nodes
+                properties:
+                  path:
+                    description: Path The path the directories for the PVs are created under
+                    type: string
+                  useNamingPrefix:
+                    description: UseNamingPrefix Use the name of the PVC requesting the PV as part of the directory created
+                    type: string
+                type: object
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - pathConfig
+            type: object
+          status:
+            description: HostPathProvisionerStatus defines the observed state of HostPathProvisioner
+            properties:
+              conditions:
+                description: Conditions contains the current conditions observed by the operator
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: ObservedVersion The observed version of the HostPathProvisioner deployment
+                type: string
+              operatorVersion:
+                description: OperatorVersion The version of the HostPathProvisioner Operator
+                type: string
+              targetVersion:
+                description: TargetVersion The targeted version of the HostPathProvisioner deployment
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HostPathProvisioner is the Schema for the hostpathprovisioners API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostPathProvisionerSpec defines the desired state of HostPathProvisioner
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              imageRegistry:
+                type: string
+              imageTag:
+                type: string
+              pathConfig:
+                description: PathConfig describes the location and layout of PV storage on nodes
+                properties:
+                  path:
+                    description: Path The path the directories for the PVs are created under
+                    type: string
+                  useNamingPrefix:
+                    description: UseNamingPrefix Use the name of the PVC requesting the PV as part of the directory created
+                    type: boolean
+                type: object
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - pathConfig
+            type: object
+          status:
+            description: HostPathProvisionerStatus defines the observed state of HostPathProvisioner
+            properties:
+              conditions:
+                description: Conditions contains the current conditions observed by the operator
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: ObservedVersion The observed version of the HostPathProvisioner deployment
+                type: string
+              operatorVersion:
+                description: OperatorVersion The version of the HostPathProvisioner Operator
+                type: string
+              targetVersion:
+                description: TargetVersion The targeted version of the HostPathProvisioner deployment
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt-hyperconverged-operator.v1.3.0.clusterserviceversion.yaml
@@ -1,0 +1,2608 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{"BareMetalPlatform":false}},{"apiVersion":"networkaddonsoperator.network.kubevirt.io/v1","kind":"NetworkAddonsConfig","metadata":{"name":"cluster"},"spec":{"imagePullPolicy":"IfNotPresent","kubeMacPool":{"rangeEnd":"FD:FF:FF:FF:FF:FF","rangeStart":"02:00:00:00:00:00"},"linuxBridge":{},"macvtap":{},"multus":{},"nmstate":{},"ovs":{}}},{"apiVersion":"kubevirt.io/v1alpha3","kind":"KubeVirt","metadata":{"name":"kubevirt","namespace":"kubevirt"},"spec":{"imagePullPolicy":"Always"}},{"apiVersion":"ssp.kubevirt.io/v1beta1","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"templateValidator":{"replicas":2}}},{"apiVersion":"cdi.kubevirt.io/v1beta1","kind":"CDI","metadata":{"name":"cdi","namespace":"cdi"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"nodemaintenance.kubevirt.io/v1beta1","kind":"NodeMaintenance","metadata":{"name":"nodemaintenance-example"},"spec":{"nodeName":"node02","reason":"Test node maintenance"}},{"apiVersion":"hostpathprovisioner.kubevirt.io/v1beta1","kind":"HostPathProvisioner","metadata":{"name":"hostpath-provisioner"},"spec":{"imagePullPolicy":"IfNotPresent","pathConfig":{"path":"/var/hpvolumes","useNamingPrefix":false}}},{"apiVersion":"v2v.kubevirt.io/v1beta1","kind":"VMImportConfig","metadata":{"name":"vm-import-operator-config"},"spec":{"imagePullPolicy":"IfNotPresent"}}]'
+    capabilities: Full Lifecycle
+    categories: OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:914c75180c2c1aa6bfabc033ee3bd9d1a0169999e0958aab8c44bad9aa262719
+    createdAt: "2021-01-18 15:57:46"
+    description: |-
+      **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+      Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+      Containerized Data Importer (CDI), Virtual Machine import operator and Cluster Network Addons (CNA) operators.
+
+      **KubeVirt** is a virtual machine management add-on for Kubernetes.
+      The aim is to provide a common ground for virtualization solutions on top of
+      Kubernetes.
+
+      # Virtualization extension for Kubernetes
+
+      At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+      additional virtualization resource types (especially the `VirtualMachine` type) through
+      [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+      By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+      resources alongside all other resources Kubernetes provides.
+
+      The resources themselves are not enough to launch virtual machines.
+      For this to happen the _functionality and business logic_ needs to be added to
+      the cluster. The functionality is not added to Kubernetes itself, but rather
+      added to a Kubernetes cluster by _running_ additional controllers and agents
+      on an existing cluster.
+
+      The necessary controllers and agents are provided by KubeVirt.
+
+      As of today KubeVirt can be used to declaratively
+
+        * Create a predefined VM
+        * Schedule a VM on a Kubernetes cluster
+        * Launch a VM
+        * Migrate a VM
+        * Stop a VM
+        * Delete a VM
+
+      # Start using KubeVirt
+
+        * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+        * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+      # Start developing KubeVirt
+
+      To set up a development environment please read our
+      [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+      To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+      You can learn more about how KubeVirt is designed (and why it is that way),
+      and learn more about the major components by taking a look at our developer documentation:
+
+        * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+        * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+        * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+      # Community
+
+      If you got enough of code and want to speak to people, then you got a couple of options:
+
+        * Follow us on [Twitter](https://twitter.com/kubevirt)
+        * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+        * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+        * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+      # License
+
+      KubeVirt is distributed under the
+      [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+    operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{"BareMetalPlatform":false}}'
+    operatorframework.io/suggested-namespace: kubevirt-hyperconverged
+    operators.operatorframework.io/internal-objects: '["v2vvmwares.v2v.kubevirt.io","ovirtproviders.v2v.kubevirt.io","networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","ssps.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.nodemaintenance.kubevirt.io","vmimportconfigs.v2v.kubevirt.io"]'
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    support: "false"
+  name: kubevirt-hyperconverged-operator.v1.3.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents the deployment of HyperConverged Cluster Operator
+      displayName: HyperConverged Cluster Operator Deployment
+      kind: HyperConverged
+      name: hyperconvergeds.hco.kubevirt.io
+      specDescriptors:
+      - description: nodeAffinity describes node affinity scheduling rules for the infra pods.
+        displayName: Infra components node affinity
+        path: infra.nodePlacement.affinity.nodeAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+      - description: podAffinity describes pod affinity scheduling rules for the infra pods.
+        displayName: Infra components pod affinity
+        path: infra.nodePlacement.affinity.podAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAffinity
+      - description: podAntiAffinity describes pod anti affinity scheduling rules for the infra pods.
+        displayName: Infra components pod anti-affinity
+        path: infra.nodePlacement.affinity.podAntiAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
+      - description: nodeAffinity describes node affinity scheduling rules for the workloads pods.
+        displayName: Workloads components node affinity
+        path: workloads.nodePlacement.affinity.nodeAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+      - description: podAffinity describes pod affinity scheduling rules for the workloads pods.
+        displayName: Workloads components pod affinity
+        path: workloads.nodePlacement.affinity.podAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAffinity
+      - description: podAntiAffinity describes pod anti affinity scheduling rules for the workloads pods.
+        displayName: Workloads components pod anti-affinity
+        path: workloads.nodePlacement.affinity.podAntiAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
+      - description: HIDDEN FIELDS - operator version.
+        displayName: HIDDEN FIELDS - operator version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      version: v1beta1
+    - description: V2V Vmware
+      displayName: V2V Vmware
+      kind: V2VVmware
+      name: v2vvmwares.v2v.kubevirt.io
+      version: v1alpha1
+    - description: V2V oVirt
+      displayName: V2V oVirt
+      kind: OVirtProvider
+      name: ovirtproviders.v2v.kubevirt.io
+      version: v1alpha1
+    - description: Cluster Network Addons
+      displayName: Cluster Network Addons
+      kind: NetworkAddonsConfig
+      name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+      version: v1
+    - description: Represents a KubeVirt deployment
+      displayName: KubeVirt deployment
+      kind: KubeVirt
+      name: kubevirts.kubevirt.io
+      version: v1alpha3
+    - description: SSP is the Schema for the ssps API
+      displayName: SSP
+      kind: SSP
+      name: ssps.ssp.kubevirt.io
+      version: v1beta1
+    - description: Represents a CDI deployment
+      displayName: CDI deployment
+      kind: CDI
+      name: cdis.cdi.kubevirt.io
+      version: v1beta1
+    - description: NodeMaintenance is the Schema for the nodemaintenances API
+      kind: NodeMaintenance
+      name: nodemaintenances.nodemaintenance.kubevirt.io
+      version: v1beta1
+    - description: Represents a HostPathProvisioner deployment
+      displayName: HostPathProvisioner deployment
+      kind: HostPathProvisioner
+      name: hostpathprovisioners.hostpathprovisioner.kubevirt.io
+      version: v1beta1
+    - description: Represents a virtual machine import config
+      displayName: Virtual Machine import config
+      kind: VMImportConfig
+      name: vmimportconfigs.v2v.kubevirt.io
+      version: v1beta1
+  description: |-
+    **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+    Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+    Containerized Data Importer (CDI), Virtual Machine import operator and Cluster Network Addons (CNA) operators.
+
+    **KubeVirt** is a virtual machine management add-on for Kubernetes.
+    The aim is to provide a common ground for virtualization solutions on top of
+    Kubernetes.
+
+    # Virtualization extension for Kubernetes
+
+    At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+    additional virtualization resource types (especially the `VirtualMachine` type) through
+    [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+    By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+    resources alongside all other resources Kubernetes provides.
+
+    The resources themselves are not enough to launch virtual machines.
+    For this to happen the _functionality and business logic_ needs to be added to
+    the cluster. The functionality is not added to Kubernetes itself, but rather
+    added to a Kubernetes cluster by _running_ additional controllers and agents
+    on an existing cluster.
+
+    The necessary controllers and agents are provided by KubeVirt.
+
+    As of today KubeVirt can be used to declaratively
+
+      * Create a predefined VM
+      * Schedule a VM on a Kubernetes cluster
+      * Launch a VM
+      * Migrate a VM
+      * Stop a VM
+      * Delete a VM
+
+    # Start using KubeVirt
+
+      * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+      * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+    # Start developing KubeVirt
+
+    To set up a development environment please read our
+    [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+    To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+    You can learn more about how KubeVirt is designed (and why it is that way),
+    and learn more about the major components by taking a look at our developer documentation:
+
+      * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+      * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+      * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+    # Community
+
+    If you got enough of code and want to speak to people, then you got a couple of options:
+
+      * Follow us on [Twitter](https://twitter.com/kubevirt)
+      * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+      * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+      * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+    # License
+
+    KubeVirt is distributed under the
+    [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+  displayName: KubeVirt HyperConverged Cluster Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAARgAAAEYCAYAAACHjumMAABam0lEQVR4nOydB3gb9fn4v3faw5Js2fKSvO0kkrMTsCFgBQKEslqIzB+6AAcocVpIKD9aWrBSaKEtJKUQEjLKKO0PLFo2hG1DEpvEcZYl7ynZkqf2lu7+jx2HXxLfOZJO077P8+Qp1ffu9Fo6vfd+30kFJCTTKBQKLgBgoUKhKAEA5AIAssRicVp5efnk62wAADL9zzv5r6GhwarT6QYAAL0qleqEVqs92djY6I3130FCQhJHVFRUcFpaWl5CUdSPEmMMRdFdCoUiP9Z/EwkJSYxRKBRFhw8f3o6iqImgYrkQF4qiHz/33HO3SqVSONZ/JwkJSRSpqKjgTlss0aCttrZ2baz/ZhISkgijUChKDh8+/DcURc1RUi5nmdx6ff3cc88ppFIpJdafAwkJSRipqKjgtbS0vBxlpYJHV21t7bWx/kxIogMUawFIIkdZWZl4+/bt/1NeXn4XACAp0PMQAGxDTqel3Wpnj7s9DA+CuLwIgkyaIQgAKAwgiEWBqRwqlV3M5TiKkzhUOgxzgxANBQAc2r59++4dO3a8qdPp/KH9hSTxDqlg5iBSqZS1c+fOR+Ry+f8AADiBnudDENsjp1qtz3f2pKEABJzCQIEgz63ZmdpfLyhkXJIiEAcp7mGlUnn/tm3bWoI8jyQBIBXMHGLSYtm6dWuVQqHYCAAI+Ifeb3eYdnX3gZd7+hkmr48V6vtDAHivzxCNVhfloT/ITBcBAGgBnopqtdoP9u/fv2v//v2fkxbN3IFUMHMAqVTK2blz5//I5fJfTyfEBcSkxbL1pNr2QldfRrhlKuUl9e9ZtRSUC5Nzgzz1u2mL5mS4ZSKJPqSCSWDKyspypi2We4KxWHpsdtPunn6wu7ufafX5mBEU0XdNetrIpsJc9IfZmWkAAHqgJ2q12o+mLZpPdTqdL4IykkQQUsEkIFKplLtz587fyOXyrQCAgLc0XgSxPXi8xbarpz/sFsvFKOZytPtWLfVfmSbMC/LUY0ql8hfbtm1ripBoJBGEVDAJhEKhyFUoFBunLZasQM/rstlNL3f3o7u6+1h2vz+SFsvF8MvThCObCvMQhSRLCAAIWBatVvvptEXzsU6nI+udEgRSwSQACoUiqba29jEAwEPB/Ch9COLc1Hzasrd3ID2yEgZPDps1tH/VMte69NSCIE89qVQqN23btu1whEQjCSOkgoljtmzZkl9VVXWvTCa7CwCQGeh5Q06X/ZU+rXdfTz+tz+EMOEwdA5AfZmXoHyjMg67NSJu0aBiBnqjVar+ctmg+0Ol0nsiKSRIqpIKJQxQKBa+2tvZxAMAvg/nReRHE8df2bstTrZ3JTr8/4PPigbKU5MG9q5Y4Svm84iBPbVEqlZu3bdtWHyHRSAhAKpg4QqFQ8Lds2bKxvLz8EQBAwNuaQafL/o/eAe++3gHaQHxbLBcDvT5DpK8uygPXZ6anwMH5aOp37NixTaVSHdbpdO7IikkSKKSCiQMqKiqgnTt3/lImkz0TTFTIgyCOP7d1Wf7U2pniQpCAQ8CJwMpkwdDuFUtsq1L4JUGe2lZZWXm7SqU6FSHRSIKAVDAxRKFQJE9bLA8AAAJu0qR1OKcslv29AzSt05XIFstFuVqUOrS5KB+6KStdQIGgQJWvBwDw0fbt26cygzUaTYSlJMGDVDAxYNpieUgmk/0pmKiQy++3P9PWZX26rSvFM8cslouxhM/Tv7RisfXy1JTiIO/b71Qq1QOVlZXHIygeCQ6kgokiCoUiZcuWLfeVl5f/YrrnbUAMOJz2/T393v19Wvqg0xVwKcBc5MrUFP3monz0h9kZAhoMB/pZeAEAB7Zv3/7S/v37D5AWTfQgFUyEEYvFUFVVVVlVVdUmiURyezAFgF+PjBlf7OqD3xsycP0oSjZoP4dsFtN4T36OsypPwsjlsIVBnNrb0NCwa8eOHftUKpUxgiKSkAomstTU1OQolcpdAIAfBHPeSZNlYlPzKd/hcaMoctLNDagQ5Pz1gkLtE9KSNBaFkhzEqS61Wv276urqHfX19WgERZzXkAomzExbLJdNWyyVIPC+KugJk9m8u7sf2dc7wPejKNlaMggymAzT1pIC123ZmbQCLicYi2agoaFh944dO/aoVKrxCIo4LyEVTBipqanJUyqVuwEA1wVznsnjndjYdBL5z6A+NXLSzQ9gANx/X764p7oorzCY6m0AgEetVtdUV1f/pb6+HomgiPMKUsEQZNpiuaKqquoBiUSyIQiLBWk2mi27u/uQV/q0PB/pYwkruWzWyP2Fucimwjwqn0YLRnEPNjQ0vLxjx46XVSrVSARFnBeQCoYACoUivba29g0AwLpgzpvweMarjp5E3x0ykBZLhIEBcP1lyaLehxcU5QeTEgAA8KrV6icrKyv/qNFoSIsmREgFEwJbtmwpnbRYZDLZnQAAQYCnIUcnTJaXe/qRV/u0pI8lymSxmGO/KMj1bSrKg4V0ejDO89Mqlerl7du3/6uxsdEUQRHnJKSCCQKFQpFZW1v7DADgxwCAgBXEmNszds/RE9AH+uFgnI8kkcHzpGxh9++lxTnBNEQHAAzX1dX9rrq6+lWNRkP2DA4QUsEEwJYtW5ZMWyx3AAD4AZ6GfDdhtOzu6kde79fxEUBaLPGEiEEff6Awz/tAYR6UzmQE0y+nddqi+WdjY+NEBEWcE5AKZhYUCkVWbW3tXwAAd5zZzgfGsMs9es/RE/DHhhHSYol/fI8tKup8snSRGA5idtSkYVpXV/dEdXX1Xo1GQ/YMxoFUMBhs2bJl2bTF8v8AALwAT/M3jButu7v7kDf6dQIkCIVEEnuS6TTjpsI89y8KcoGYzQqmZ3HHtEXzemNj41gERUxISAVzDgqFQlxbW/vs5H8GY7Hona6Re5pOUg8YRlIiKyFJFEAeKi7oeHapNIMCQYE68CeZqKur+0N1dfUujUZDdtibhlQwZyyWFdMWy+3BjFhts9gsT7V2+P49MChASYtlTpFEpZo3FeY5tpQUMNOZjGBKELpVKtWe7du3v9rY2Djv82jmtYJRKBQ5tbW1zwEAbgvmsxh3e8yPnW517u0dEJGKZW7DoVAsNbIFhq0lBZkUCArGR2Ouq6t7qrq6+gWNRjNvO+zNSwWzZcuWVVVVVZtkMtnkVijgoe2tFqtlV3c/8s9+HdPk9cZy/AdJlMnjsIwb83Ncd+flMLJYzGC2wr0qlWrf9u3bX2lsbNRHUMS4ZF4pmIqKCtbOnTv/JJPJHgzmbx91u82/OdXqfKVPm47Os8+M5HyYMGz73aLioUcXFqXTYDjQlIVJrHV1dc9UV1fv0Gg0zgiKGFfMix+LQqHI37Jly6by8vIqAEDA+2n1pMXS1Ye8MaBjmr0RHbFKkmBIWCzjPfkSZ1V+DlPCZgVj0Qxs37796f3797+u0WgcERQxLpjTCqaiooK9c+fOZ2Qy2S+DOW/Y5TY9ekrjeq1flz7XPyMSYtAgyPHowiLd7xYVi5gUSjBRJ5NKpXqosrLytQiKF3Pm5I9HoVAUnmOxBGzGnjZbzbu6e9F/9Q+yLD5fQs0VIoktWUyG6a78HOfG/Bx6fnAd9jTTzclf0Wg09giKGBPmjIIRi8W0qqqqH0y3TQi4HwsCgOetgUHbru4++NuxiWCeQCQkM4AB8NyQlT6+uTAfuTYjLT2I9h3OhoaG13fs2LGroaHhpE6ni7Ck0WFOKJiamppypVL5EgBgWTDnfTY8Olx19ART53QF46wjIQmI5QJ+7+6VS6iXpAgkQZ76plKp/NW2bdtGIyRa1EhYBSMWi+lVVVU3TLemDLgfCwKA93/7dZMWC3Ro3EhaLCQRBQLAtz4jbXRTYT5yY1a6KIim7y6tVvuv6fnbxxLVoklIBVNTU7NGqVTuBAAsCeY8jcVquLfpJOPwuDGYzEwSkrAg5SX17125BFyWmhLwyJpp/jM9f9sQIdEiRsIomGmL5aZpi+WqQM+btFg+04/YX+ruQz/QD5OKhSTW+O+UZBt+UZgLX5EmTA3CovFotdp/T1s0RxLFokkIBVNTU1OhVCpfBACUBnPeabNFf2/TKeZ3E6TFQhJ/rE1L1f5j9VJfHocd8NjgaT5QKpWbtm3bFvdaJq4VzJYtW+RbtmypkUgk8kDPQQDwHNAPO3Z29aEfG0ZIxUIS7/g3iDMNDxTmQVeJUlODmITg1Wq1b+3YseOpHTt2tEdYxpCJSwWjUChKa2trdwIArgzmvOMms+H+plOMo0YTqVhIEo41qSm6fauWuhckcQuDOM0HAPhHZWXl71UqVdxFneJKwWzZskVWVVX1qEwmqwQABJTo5keB5xP9sP3Frl7o0+FRMipEkuggN2Wl6zcV5sHXZYhSoAB/BwCACbVa/a/9+/dPWjWHIixjwMSFgpFKpWDnzp33yeXyvwEAWIGe1zRhMtzffIrZbDSTioVkznFpSvLgnpVLHEsEvOIgTz1QWVl5l0qlGo6QaAETcwUjlUqFBw4c2C6RSH4WyPF+FPV8ODTs2NnVCz4fGSMVC8lcB12fkaavLsoHP8hMT4EDn+00qFKpfrd169Z/6nS6mM11iqmCqampKVEqlQcBAGkAAD0AIHO24xsnjIYHmk4xT5gtpGIhmXesEPCHdq1cbL8kJTlgi0atVu8sLS3dHFnJ8ImZgqmpqVmiVCr/AwAomn7JON2u8rzaDR+CuD/QDztf7OoDX5EWCwkJuEqUqt9cmIfenJ0hoEAQO4BTnpBIJE/pdDo0CuKdR0wUTE1NTb5SqTyF0U3OdO6kxA6rzaJoOIacIi0WEpIZLOYn6d8qW4ks4iVlz3LY5IM7Wa1W/7a0tPSZKIo3RdQVjFQqZR04cOBriURyKcbyBAAgxeByef7c1u3b29NPt/v95FB4EhIcqBDkvk2cOfr4ohKajJ+ENUDOON1kzadWq59Yv379M9G0ZKI+bXBkZOQ1Pp9/Pc4y47jR3Hd1fQP3s+FRlhdFyYbaJCSzgABAVVusvN3dfdQsFuvEymR++jkjd2zTiXu0yddEItHVEolEq1KpjkdLvqgqmOeee+628vLyJ/HW//T1N947PzwwYOJOmXwxj3CRkCQKKADUD/TDWV02u3Z9hgihwTALADA2uSM49ziZTLYGAPBpfX19VELYUf0Royh6anLriLX2dN233sc++5I2pZQXLuoBLHZRNGUjIZkr5HJY2kNr1ziyWcwFOIfoZTLZQo1GY4m0LFHbgrz11lv34SmXN0+1+B777Evq9zKNj0fd201CMlfotzslD7dqPFYf7sjszH379v0mGrJEZYsklUpZL7300gGAkSTk9vnA9a++gdg8nv+TxelAQHqGDUBQwDOLSEhIzgBBoI3HpwsbLSbWDUIRTIFmblQkEskqAMCe+vr6iE42iIoFU1VVddO54edz+WntOy6D1XZ+pAhF04B2oDcaspGQzDGQElFSH4BARpfTTtk12I+XxctSKpUvicXiiAoTFQWjUCh+gvX6p51dPlWLGjv1eXxsJXA4SCVDQhIESQzqKSGH/n0L2doRPfzB2DCektmgUCiC6lgQLBFXMBUVFZBEIsH8I145Nmu0jAbGRvwRE4yEZA6SKWCiF2bD/6W/G4x43Jh+zaqqqjsiKU/EFYxcLr8SazaRD0HQzzq7cb1QUxiNycDvH4+kfCQkcwUWjXJKyGHkXPg6AgD87ugwpoKRyWTXS6XSiEWTI65glErlLVivv6tpMxmdrtkrQxFECIwTxkjJRkIyh0DyUzl6CADMoW+fG8fwtkm5CoVihlIKF9HwwWAOQfv3ydOBRYjGRqnTXbtISEhw4DKoGgGLthZvfcjtonY47Ji/I6lUuiZSckVUwSgUikltKr3w9UlV+kl7Z2A9KpzOPGAyRS21mYQkEcnkM30X6+f7tXEccytUWVm5PlJyRVTBiMXipVivtw6PeF3BzH4e1AkBikY865CEJBFhUuFWIYc+W0X1FA1mI17Q5BqxWBwRXRBRBVNeXo45yvXU8HBw7+txFwCTcSRccpGQzCXyhBwtDEFpFzuu02mnO/yYOia9vLw8LxKyRdqCwZy8eHzIEHz4eXSULH4kIbkADp3SmsKhXxHo8W0OG6YfpqysLKi57oESEwtGPTwS6DS7/8NuywN2O+mLISE5hww+yxNMo/xupwOzv5JEIlkeVsGmiZiC2bBhAxsAsBBr7dig3hvCJSlA288CKOoiLh0JSeJDhSFDKoeO1WQKl3Z8CwbTX0qUiCkYmUx2BdZso0GLBQzbbIFOrzsfp3MhsFgGwyEfCUmik8pljFBgKCOYc7qdDszffMJZMAqF4lqs199vbSdWvTk2SrZyICEBwJnBYwY6wuR7epwO1I1gZoiIa2pqcsMi2TlE0oLBjK1/3dMXeHgaC4tZDNzuNkLXICFJcNK4jMNsOqUk2PN8KEo5YbXgJa5iJsUSISIKZjrBbob/BUFR8GlHVyj+l3NhgoF+L5ndSzJfgSFoNDeFHXJ6/3cWI2ZEVqlUhj3hLlIWzBKsa3eOT/gsbnfQZt0MbNbFwGYdIHwdEpIEJJVLN9CpcLDjZL/nsNmE93C+RiqVhlUnRMqCwQxPn9Qbwvcm4+MxG4dJQhJDPJk8ZmhBkmm0bifD5MPcSHBlMhlm5DdUIqJgpFIpZoLdiVAS7PCYGBcBv5+0YkjmFUIO/RCHQcVr5h0w7Q47pobBMw5CJSJDzWQyGaaQLcPD4Xw/Hhjo776u7FJRNos5rxpTddkcrm/GxjHL8ucDV4lSO+8vyL0w4oFavT672mKF39QO0vUudyAjVRMKCAITeULOrPPbA6XbaadeysPsYjv52/13ON4DRELBlJWVcQAApVhrh/q13rA2GjcZlxYAtPOl1csIa/REwuL1ORd9+vXAkNMVsT4e8UoKnTb2dvkqZjKdhrVNmIpQPr14kWtXd5/p6bZO5ojbQ8jnx6NSXVeJUr2rUwSubBaTQoWgqA8rPMvXlon+Vo8tLPkqp21WBKTP/C0qFIrycFz/LGFXMBKJpBTruh1j4/4Jp5O4g/d84NeajtGevewSD5tKIbQvTSR4NGrqC8tKG25raJp3CuauXIkxmU6b1cHJoMDMh0oKmOXC5LGyrw4yQp3/tVzAt3y05hI0k8XkAwCSQhY6PPg+VI+GzSrrdNjx8smWSaVSoNFowvI+YffBKBQKzJTjD9s6POF+r0kc4+PC3zSdmHe+mFvFmStXJQu6Yy1HlLH/ojAv4IfUpcLk1P+UrzJAZ1oQBcX/k2SNflFRRp9WLjHn84mxpgGXM+i8FzwMHjdlwovr6A05QnUhkXDyYvpfvuruiYxpiaL8F+u/NescTqL5NYkG/eGSgnmVC/RQcf7p4iSOJJhzbhVnZv4gQxRUL6EyocD0v2UrhSl0ergt7pDwA2D6c39XWMcpowBADWajG2tNKpWGzdEbCQtmRgTJ6/eDr3p6IxZWRs2mxfs0bbpIXT9eUUiyMhfzkzpiLUc0EDHoI0+VLgxpS3ibODi/6NOLFyHRnHp6MT4eG55wIkhQijUQmqxmTLcCXpAmFML6IVZUVEz+z4wtUuvomNvp9UXyaUDfe+SYHw3BFE5kKBDE27tqqfHMQ25uc09+jolDpWaFcm65MDlg63ZBEndEnpaaEsr7RIoPx8Iaff2ew+YJTLdFOEPVYVUwcrn8ksk93IWvnzZE5gM6l6GhoeTnWzu0kX6feOPSlORL1qendcZajkgCA2C5ryA3ZAdnHocd8P33k5zsmEWJsDhqMXW12G0RGb9o8/sZOpcT66EctwoGs4L62JAec68XVhBE+LvPvzLafPgTv+co0MMLCud0hfmjC4s0+Rx2yD8yGIICvs+XCHjOUN8nAnj+3N/NjOR2rcOJGU3KqqmpyQ/H9cOtYDCLpTTDo8QqqAPEYTAUvdbeNRyN94on1qWn5a8VCU/GWo5IkMVkDtdISwjd7L12R8BbSCGdHjfbzW9NE+N6jzuiw6M7HdjdU6RSaVgKH8OmYBQKBQsAUIa11jQ4GHkL5gzcvU3N9ii9VzzB/PelKydNe1usBQk3GwtyLAwKJaiubRdybMIUsP+vw2qLmwzg90YNwbeWDZIupx1TB4RrlEk4LZglWFm6PRNG37jDGbUv7WR3L/89XTirKhODDCajdGN+zpzKB6JB0MS9+TmE7x2VTh/wsYfGjXERKOhw2MYaLSbMXP7wvo8d7++Vl5WVEVZw4bRgMAscP2hrj+6e1udNrz7w2aAfRePG1I0Wm4vyoDMpDnODx6Ul7WI266Lzfmaj1+6wvDdkCFhJvd6nS3H6/TG3BHdoe31ohGoFz2XM66GMeDA3GDyJREK4BCdsCgZvyNrXPX1RT+Ef7O3L+0/vwLybo7RUwC+5Iyf7cKzlCAc5bJb+t4uKCWWuIgD47z5ynBaMxvWiCO3Frt6YJm2etFpMp2zWoHrtEuGw2Yj594ZjlEnYFAzWiJLJL/bTjq7oWxIoKtx/7HjMn0IxgPL66uUSBgwnvKP7voJcKxWCCFWMf2kYddePTQQ80uMsT7S0czqstgki702Ed8cMUQ2VH7WYMbdCEokkPhSMVCqlYFVQt46MuF0+X0ycZl9q2rhNRtO8GzdLhaGch4oLxmMtBxFYFHj0nvwcHtHr/L2rJ6TtogtB6Jd9dZD5wZAh6krG4HHb6ozBK0UiHLGYvH505kcVjoS7sOzxFArFCgDAjKKw04aRmCUt+d2uzF99/tXRw5W3riZ6rU8No8O/b2mLitl8qVDge3H5YkJjPKuL8uh/bu9yAADiJiISDE/KFnZnMhmYEclAaTaazR/qR0IuVBz3eNk3HzrKfrA437BNugDm02kiIvIEyku6Pp8HRSLuezkXB+KnaV1OJI/FvtDgiBsFg5lg1zyo90WqqVUgNJxWZ9dfuWa0IkN00bm9s3FZajK3126fvOk44ZMOm2ajCflVUYG1JIkTcnsACZtV9Li05OsnNR1rwytd5CnksAe3LCgk1LbRh6Dee5tOhiXE+3xnb8bznb2ghMsZz+GwUDoEz1pwyKTAyNuXreZDAATte+x2OlxfGscFlBjUfnQ47CCPNeN5JKypqVm8bdu206FeNyxbJJlMhjnuQDM6GtseLX5/1t5jxwlvk5KoVM4T0pKobLcQAOCdXb2E768/yBasyGYxe8MjVfS4vzDXDgNAKDz7vt7gbjaZw2q9ddjswi+Gx1I/NowIZ/v330FD2ueG0ZACDO+MGuBkKi0mhWWd2Bm9QC6XExplQljBlJWVTX6Rl2KtHdVFLcEOl/+ePEUfsDsIy7GpME8gZjGj4jh+tU/L1DtdZoKX4VcX5REbchdleFSq4a68HML9V57v6IlpJfSWEy1cp98fVHrGoNvl+s5spLqR2GRXdDmwJz7K5fLriVyX8BchkUhkAMMc1FutyLDNHlVnFRZOm13y24ONp4hehwrDrJ/kiqNS52Tx+ZgPnWghnD/0UHGBAALAGB6pIs8zSxb1pTGCm7V8IafNFvs3YxMx9T1prDbBX9u6rYEe7/Ij3q0dmkkTAnZgT12MOO1OG55mu0KhUIS8EyGsYPA62L2naYublP03G78TacwWE9Hr3JUnidqTsVanz2iaMBFSDiwKJXtzUV5C9MlZkMTVPVCYJyNyDZff734xDNvLcPBUa0fyM21deh+CuGY7bsztcd178uSYzuMS6rET3qKC2eejal2YzzTadJZ+SBD+wYjFYswmwf9Vt8VN2Tviduc+8+3hMaLXWZDE5T26oDBqw/cfPaUh3MHs0YVFAgYMx33pRI20xE607+0Lnb3+/b0DM9qFxAIvitJ+e7o1c8ln9Y5d3X2GHptjUtFPaRAvgpjrR8cntp5QG7M++Ix22mWNi2jf58YxTAudSCNwwjcwiqJNAICV577mRxDAfOIpjw9B4qYRN4PDGdD++sH0NAadUGW3F0GsvHc+obsQJCoV4l9VlBvWilIJZXVu7+j+8uGTmqvDJ1V4yWGz2vpvWCcBABCJ0vlzP/rCNeBwRjzSR4BxDpXitPv8GWejq6lcur5ElBSWUSREKeUm+V9esHiGYaBWq/9RWlpaFco1CVkwGzZsYAIApBe+fsow7Iwn5TKJ224XP1x/kHBjJhoMJ92dL4na9u8Xx06xXEE6DC9ka0nhimIuJ14jSt7XLlnuJqhcwHuDBlucK5dJhHafX3xWucAQ8OSmsOOi7+8krTYb5PTP3GESaaFJSMHIZLLLJrf6F76uHolxeBob+J/fHEpqt1oDdr7h8bNcSdiaL1+MDpud/6Z2aNZ9fAAkby7Kj8vSibVpwj55mhDTjxcMf+/qjZseuoGSymE4GFRKcqzlOIsfoHCn0461TSqtqKgI6TdN6EvBS7Br0g3FPDyNCeLP3dd0nHCdTpkwmVeRJoxaOv7zHT2TTzxCEay78iRp2Sxm3I052VyUT1gxfD0yNvHVyFis5xYFTTqPGXeV791OB1ZiLF0ul8tDuR5RCwYzCadtdCxuzL4L2d/UTA9DKwfKi8tLiVoVAXPCbEn6Z5+WkJOaR6NmvLC8NK62SekMuuNWcSahbvkIAJ6fHzkR8cZM4SaZTTckMalxY72cpd1hw3yQKZXKkBLuQlYwCoVCAABYjLV2RKeL2o8vWIxGU+bbXT2ErZhSPi/7ylRh1HJMtp7SJE14vIR8Pz/KzrxiVbIgPCP7wsCNmel0rByqYPhXn9apdToTynqBAPDmCePH93IuOBbMJCEl3BGxYDA72BmsVp/R6YqLsBsOtH1HjoVlC3dvQfQmt465PZxXegeIFlwyHi4piJsBdWVC4g/wF7v6wiJLNBFy6XYWjRLxbnWh0Omw+3FS/RYpFIrUYK9HxILBTL45NqiPmxsYj6/bO/hHx8YJWzG3ijPpAho1ah37Xuruo3kRhND7KSTZuYv5PMKZzeEglUEnVAj7zqB++IjRFPXRrhAA4Lr0NOcfZAssr65eZnt19TLHYwuLvfI0oY8KXdz/nxGHvpezeFGUMuB0YOoYsVgc9OD9kBUM3njJ08MjUYuwhIrf50v51cefE+54x6ZQOApxVtQUTI/dwflrexehjGQKBAR7Vy2dmLyXwidZaGD1IAmUSUV7z9ETUd8aLeXzbNobr5k4cGUZ63FpCe/neRLuz/Mk7D8uXkj7Wn4ZtWndlf58Dhv3D2PRKCYekxZ3vpdz6XBg78TLy8uDjvaFrGBkMhnmm53QG+JewUzS2NaWV6cbIpzhWpUfvW3SJH/QdAoH7E5CIedLUwRXrk8XqcMnVWgMOkN31e3pGfCYvNFtZnZLVvpwnfwyajaLiTv5camAR2lbvxa9Q5KFaQWk8xhx//vAq6wOpYVmSAqmoqKCgufgPTGkT5TBZ0n7mo4T9sVcKkxOWSNMiVr5gBtB6Lt7+oh+xvCvFxSESaLQaRwP2UeO7uzqjeo2Y2Uyf+zdyy9JFdBpF3XO0mEYfvWS5aCIyzlPycAQ8GQkMeOmhAaPLqcDU0aJRBKdLZJcLr8CADAjVd7m8SCd4xPxmGSHyTunWzgDdgfhPi/bl8noIIpzsff1DtBNHi8hua9OT1uwNk0Y0wbhHxtGgNET/E6tdmDQ2Wq1RdVJ+sSiEgdWUAOPSSXzweWrUfo5/anyhZwxGIbiolZqNjocuJXVxRs2bAjK5xWSglEqlZgJdp+0dxkRFE2YnASH05n6my/r+oleZ3WKIG2tSEi4WjtQRt0e9m9OtxLt9cJ6s2zl5EOCaN+ZkDF7fWBnV3CpOcMuN7j32Kmobo0KOGz1zdkZQXdFXMhLolwtSpv6sTKoFEs6j0moFUW0MPl8FLzKaplMdlUw1wrVB4OZdPNNX3+814LM4M0jTZnq8QnCldZ35Uqi2shjT0+/SG22ErJiREzGynsLcnrCJ1XwPNPWBVTaoYCOtXp94GdHjgNLdMeP+/auWurBKokJhPLpUHwGb8rgj/vt0VkazEa8hLugJj4GrWAUCkUSAGAF1tq7mta46QETKCiCpO5vPkk4EnRHjpjNplCi9vejAMB/7+oh3Ptkc+FUqn7MeqjY/X5Q2XgMPN3aMetx3TY7WPZ5PfhseDRqsk1ymTC55ypRatC+h7MUctgIBAFfOi8qxfdh44jVjJdCEFkFgzdgbcRu9+rMlrgOv+HxRvNxhsXrJZR9TIMh9o5lsqiOuXijf5DTZ3cQ2potEfBK75Bkfxk+qULjsZZ2sOyzevCUpgN8PjwKjhvNoGF8AvyzTwvuPnp8Srn02KPfAfQeglFCCIJATjJnmArDhMewRJNmi9nvxe6ul6NQKAKethl0ohPWgDUw1X93yEO05D5WjJotoj83HFH/8crLCXVUu68gN2ObpsM85HRFJfnL4ffTq4+fnvhoDWZL5EChvFG2ovC/g/pBN4IQGtNKlJNmy9S/eIEJw6N35+cQmkhh9HmN2QImoWvEAjeKUPpcTqSYzZlhhEil0kmLLqDIadgsmNaR0YTZX2Lxt/pvU4fsDqKtHGj35Emiut34WD+ScXBsnJDlBANQ+FBxQcJPgww3DxTmGWEACFnlWp+LQrTeKlZ04iTcBdMfJmgFU15ejtk+r2FAG/cJRLPhcLrStx9qJBxR+WVxPo0Jw1Ed+P/oqVYq0TD5IwsKRSl0Wty1c4gVFAiYtpQUELLIxz0eS4PVGPPG96Fy2m7FS7gLuIVmUAqmoqKCDQDAHIp1bFAfnz1gguCVpmaqB0E8RK4hYjCSHl5QGNVO/ofHjbwPh4YJlT4IGXTx35aWtoZPqsTm1wuK2iVsFqEt457BAZsXoPFc+DsrXU474YS7oBSMXC6/GivUZnQ6fQMmU0L6X85lwmbL+OOhRsLlub9dWMQR0mlR9UhuPn6aY/f5CL3nT/PE8qV8XsxLCGJNGp0+UrOohFCfmgGX0/rRxEjQ1cfxRLfT4feimIZxZk1NTUCp4EEpGLwEu/da241oAsX4Z+OPn34hGHO7CdX6cKhU/u2S7Kj2xOl3OJP+2a8jZH0BALgPlRREdXsXj/wkV2xiUSlZRK7xwdiwH01Q38tZ3AhCUdtteBMfAwpXB+uDwVQwh/oHEt56OYsfQUT7jzYTzsqtys+Jekn+C129NAQAQkrmxznZuQuSuCfCJRMEAFidLDBvEGf6FOJM5Lr0NFMyjRa3DckAAK77CnIIJa24/H7ngfG47EsdNI1mI6YJE+jEx4AVjEKhEAEASrDW3lG3zamn3r6m49QzuWyhsyKZL1wnShsIn1QXR2OxcfZ09xHqFUyD4bTdKxfrifYAnmSDOMs6fPO1xiPrruCryldRa8tXwQeuLBPob7oW2bFMNsKiUOLOb3dXnuTEQl5SLpFrvDE8aJ3weRPW93IujWbcZ+3VUqn0oruWgBUMXnhaZ7a4xh0OYaDXSQS6RkZEr51SE65R+uvSRUwoylmyj55uFQy73IQyiq9IFV7GplBCLp8Q0ukeVdlKs6p8JTuNwZgR5mVQYPZDxQWi5nVXuHLYrLiZdsCmUIx/Kl1EqF5ozONx/NswFPUmWJGiy2mHrNilGSyZTDZjZNGFBKxg8JrNHBsais0w3cgCb/3gY5rb7yf0hF0m4IuuSU+LWhHkJBavj7Wvt59QM6nn2rtHHH5/yMPe9q1aatsgyeJfrPZmIS+J/+7lqy1ErcVwUSnJGs1kMfKJXOPA+IjPjUZnKF80QAGAO512zIekQqG4aD4MYQvmtIFwY7i4ZMJuz/7fFg3hcPNdedEtgpzk5e4BmsvvD8mK0Tmcphp1e8gOzrvzJCM/zM4IuJXCcgE/6y9LFhEeiBcGkE2FeYSmbCAAeD8YH0mYbgKB0o3TH2byGXqxcwlbMKcMw4T6qsYze48cI5w8WCnJ4vJp1Ki2RNA6nZw/aDpCyrnf0zvgdiFISE77FDrNsXfVMm6wwYNHFhTlZzIZhCvaiXBtelrT6hQBoS5cH4wabDq3K2ET6/Bod0TYgtmwYcPkTbMAa+34UOIn2OFxuLcv+ave/sB6CeBAgSDW35ctjnrPlb+2d6d12+xBlT7YfT7Tvp7+kH8gm4vyvRQIhOLcpP0gUxSzbRIMgP1vy2R8Ii1k7X6/a8+Qds4pFzDlh7HhfS5LpVLprA/hgD5QmUxWgVVP4fB6ka7xiTnhLceBvvmDj70owTT8n+WJs3LZrKhm9/pQlPpSV3CtNX/f0m7Uu9whVf1CACCbi0J3X5SlJMesZcQt2RlDi3hJmA/QQPlyYsxv8nnjctYRUXocThQn4U6oUChKZzs3IAWDNyL2vdb2iURqohMKrYbh3AOd3UTHxFLvjkFezCt9WpbZ6w0ou7fDajP+vbNHHOp7Pb14kT6NQQ85esKlUWP249xUmEf0u0HeHTXM2d+BH6Bws8WC+QCQSqWzJtwFasFgXuRw/0BCTdQLlT1HjhG+xsYYOHuNXi/z9b7Asnt3dvX5EABCclDmsFiWRxcWiUI59yx+hMAMEwIs4SedWJeelkfkGodMRnu70z4nrZezfGcxYeqKyspKYgpGoVCk4SXY/belNW5yGCLJR23tSa1j44RaqWWzWan35EmimngHpiYf9tL8KDpr5qzB5Z54rV8bcjZ2ddGUBUAoetJiscYi3cGza8USmEg7BS+CeF/Q9c7ZQMdZGizYGb0AgMvKyspwfU+BWDCY0aNhm901ZLXOqQQ7PLx+P/PhTz4jnK38/PJSFgWCojrwrMNm5zzf2Tur/2fLCbXdHOKMIQYMe6qL8ghvD+pHie5Cg+cqUWr/ZakpmBNKA+Vb84RPOwcjRxcy4HJSTD7MW5cpkUhwG7UFYsFgKpgm3WDMnHKx4JPWdnHTkJ6Qo5ZLpabdmZMdVWfvJI+3tCUPOp2YeTHNRtP4m9rBkCuHd61YMsqhUgmN4mgcN441jBuj/rC6MyebsNX07uhwQvdBCoYOhx3z85otXH1RBSOVSjEVTMvISFxkX0YReM+RY4RvyJ/nigklc4WCw+9n7u3BHpz/fGdwY0PORcrjmu7OlxCqOgYA+O5pOhmLH6m3UpxF6Ltod9gsx6zmOe17OZcupx3v8wpdweC1xzs+NHe95ni8daqFNepwEmoauzY9jbcqmR/d1vhnxpzQbT7feT6zdqtt4i3tUMiO+s2FU2FpQsrhPzq9pdUS/a02l0o9mUSjhlzUiADge3agZ85l7c5G2C2YDRs2pE4+qLDWDvcPEO09knBYXC72z1XvOIm0p4QBoL92yXIEDkO1cjDoXW72nY3N7rOyexDEddvhJsiNICE5OFcI+Kb7CnMJ5UChAPgeb2mLSd3OAi7XSsS5++XEqFdjt81538u5tNhw8zZXbtiwAfNemFXByGSy1Vh5Lg6P1zdosc6rD/csn3V0JndPGAlVK0t5SWkrkvlEG4wHzUeGYUG71TYl+6GxCbvaYg25oXWNtMRFgSBCPU9OmSz2VqstJr2EDG4XIdnrTVGdUBMXjHg8wO7HfC4yZTIZpitlVgWjVCoVWK+/earFiKDonGioEyx+FKU/++1hopEg+DcLi6MaTZoEQQHl8Zb2yff1/+ZUa8jm/Y2Z6cabszNCrrY+y+9Ot8asEn/Q6Vpu9flCaslxymax1RnH590D1g9Q+BvTBF5dUiXW6xfzwWCOiD08oJ3L5QEX5dVjx9l2r5dQDtCPxJm8NAY96o9BlW4o5cETLYNHjKaQB4E9WEyoo8EUzUaz4SPDSCwH9bE/1o8EvU1FAfA/N9BDnW8RjrMcsZgwfa94ybi4CkahUOQAADAjBO9o2uZsgWMguHw+5q8//oyQgoEBYL6wvDQmU8b+3tkb8rhCKY9rX5eeRiiD24eg7o1NJ2MefXmhs3dShqB8id8Yx3xdTkfMZY8V31lMfhyzc+F0Uu554CoYvPB0v8lkm3A4UghJOQfY/d3RjAGzmVCV9O2S7JwiLiembQqCAQIA+WVRvjeUiaDn8v6QwXHcZA64Z0ykODQ+kf0HTcfsQ7HPwYMg3p26/qg65+MNs89HGXJjJ4ZLpdIZ0SRcBYPntDk+ZIh6Hke8svfIMaKfBXxXriRhErXuzBGbfpIrJux7+1tnT9zcQzXqdtlTrR1DF7NkOqw27+3NzSODHvecaXAfKh127HA1VkrLbBYMZgr1Sb1h3oWn8dh7tBlGCYab7y3MQYhOZYwWvyzKg7hUKiH/2+fDo4ZvxybiqWct9HhLe9aKz78xnTZbDBcu+hDEu7en31H29UH3MPDMe8sdnOkPg/lQxLJgcE1dvAS7U4bhOdNvlCjDNhvng9Z2882LFoT8gxExGGnVhXl9O7v7CFX0RprVyQLrpcJkQorB5fc7NzWfjsvoy3GTWbTks3p0VbJgNJ/D4jFgmGr3+32HxiYoI24PWyxgmSEIECqJmCt0OrA7gARswdTU1CQDAIqw1o4NDs2pESVE2XOU8DYJPLtUmkSDoHieFQQeLM73E+n4Nslb2iFXl80eT9bLhUBNRlOaSqdnvDEwSHln0MAYcXumHsLpvHnr151BhxN7GBsAYGFNTc15ShjvhrkGKwXc5HS5B0zmkMObc5ED7Z2cU4ZhQtEgJoUi/FmeOOptNQNlYRLXrJBkEf2F+Z7vTMzU+kw+c4RBheNZMUaVMa8XNngwA8nwhcMZMRWMUqnEzH95t7VtHCUYQZhr+FEUfujDA4QjCz/LlcSN4/NCdq9c4qTDMCEF8+bA4NhxkyXhthgUGHLnpbDnvWP3QhrMRsx7XqlUnpcPM+OmFounuiZeg3XyIQJNieYyX/f0pjQMaAml/l+ZJhSUC5OHwydVeFidzLdWpAkJZe2avV7HlpPqhFMuk6QnMV0QBJH3/QUcsZjwDI1rp3XIFDMUTHl5+eQqZn+Q/7Zo4tpPEEv2HGkiaoHQdiyVEapxigS3iTMJRw1f79N5DC53QiqYDB4jYdIIoskR/IS73GkdMgWWBYMZPRq0WOwTTiehsZpzGdVpDUNvsRJSEJcKkwvKU5LjKvGumMshFPVBAHDv7OpNSN8Ln0WzMmkU0ueIgQtBKP1OB6azVywWLz/731gWDGb+S5NuaL6WXwSE3eulPvb5l4QLGO8tiP70gdng02iEOhe+1NU70W6zJ+QWI4OMHM1KJ3aTxPOGNM5QMGVlZZgWTMvwSEIkg8WS146dELSPjhHaRt4mzmJwqZSARo1EA5cfCXnrN+xy2x873RazkgA6DPvWiVKN9+bnuB9ZUGjfmJ/jXytKdVGhi+962DSKNYVNI3O+ZqHTga1gysrKvrdgZjhqJBIJ3ojYedmeIRjQqezeY+izP8AMwgUEj0bl3ZqdOfp6vy4uKtZH3FOFJyFZIPt7B7xWny8mCuaGTJHxpRVL4Bw262zF9lllQemx2T0/OXIcNIwbce/p/DSOB4KgeTGWJ1Q6nQ5MTS2RSL43Us57Om3YsCEFAIA5n7d5UE8m2AXAGydOUeweD6HP6t78nLixFj8fDq27p9uPOF7u6Y+J7+Wl5YtNH665VJDDZmHmrhRwOfTDV62h/n5RMWYyRxKTauczafNiYgYROh02vPs0r6amZspfe56CkclkV2NZNS6fz9s1MUFq8wAYttnpz9QfJBR5WZMmTFsp4Ed9hhIW/xk0cE0eb9AzRWo07aYBhzPqvpd78iSWB4ryBAH0CoafLF3IuDtPMiNJMpPHjCs/WLxi8vngARfms/T7hLvzFIxSqcQcEfuOunWUaIn+fOLZbw9zBy0WIr4Y+PnlpXA8FEF6EIRxw8HvILvPF/Dfc3BswvyXti7CHe+CpSJN6HpCWhKU32T3yiWMBUnc731eTBrFnsKhJ2TUKxY0mLEHsp1NuPtewYjFYgoA4IdYB3/U3km604PA5fNRdhxsIJTde3lqivimzPSoTx/A4vC4MeWWQ0dd4+6Lbv2Q/+r0plsOHWGhBOuWQuHpxQv9uRx2UAqGDsOMTYW5Z5UnWpLORWAIIp27AfKVEde4vamsrIz+/U1QXl5eAABIxTryXU3rvBqyFg72Hm2mexGEkC/m7vz46RXz5ciY4PKvDvr+d2BwcNqffR52n99615HjttsamgQTHm/UAwKL+UmOcmFKSFuyNakpU99TMptu59KppCsgCNR2K+REMI2YJIlEsuD7bU9ZWRlm9Kh7fMJs93hntMIjmR2L201/4vOvxp++bl3IiWo3ZqZzizickS67ndBg+XDRbrMn3fldc9LTbZ2WUj6PlUqnu90IQu21O7x1I2NsL4rGbFbWxvyckJVxKZ83dW4Gj0H6XoIEBQDqctiQxVweVsrL8u8VDF54+oTBQO5HQ+SZ+oPCLZeXW0VcTkhPRRoMs/+4eOHw7Y3Hwi8cAU6brbzT5qnSq7P3Rky30EwY9m/MD3mG2uQ2icqmU6zJbHpCJgTGmi6nA17MnZnwPKlTvtc6eBbMiSEDWX9EgJePNBHa5lRKsrIXJXGjPs86kXhuqczIplJCthT1LpezMHWqVCpuK9rjmQ6HHdPyUygUy7//QPEsGM3IaFwkfCUq+442TyoYIiUE9Hvyc+b1FIfZyGGz7JuK8giNP2l32GlJTNL3EiqdTjveQ/SMBVNTU4NbQX1ENxh3Fb6JxIDZzNn13dGg80jO5c6cbAYNgshERwzuzZ+awELI93PQPBGXbTwThR6nA/FiO3pTzlowV2MlJlncbofObInlcKw5wcMffSp0EhjUlsViJj9YnD+jIfV8Z/KGvb8wj1CE0+H3O74wjpEV0wRwIwistmPf3lMKRqFQYJYHqE6rTeS+lDhOn4/2j6bjhJLmfi8tSeJTqYSGvc01freo2JDGoBNSDi/q+pBYRr/mCt9ZTJj395TykMlkJViLJ/XDCdkkKB7Z39RMSMHwabRUhSQrbqqsY00yjeZUyhYS6pOrd7tc742R93g4GHS7MA2Rsy9iThA42D8Q9dnJc5XjeoPg/dZ2PZFrbMyPr14xseS+ghw3BQKEfCcfjA3HTSJjomP0eTG3qmcVDOaTYNBsIb+AMPLAex8mIQgSctj/UmGy6HJhSk94pUpM7ivII6RsEQD8748Nk1ujMOHw+3DHDIBzemWch4dAsyGSmQxZrNy31a1EtjnQ9mUyOgCAcOkGm0IxXpee1qsQZw0qxFm6K1JTugAACRExvCdPoi/gsgkFH/5tGPQafT6ygDdM+NGZ5SPgnAppzEUUoKQFE2b2HDkGKhfLQj7/khSBWJ4mHK4bHQ+pPzIFghxPSEu6H1lQmM6iUPLPXXP4/d33HztlfqNftyJkASMMHYbdL6xYTChz2OrzefYODZAFvGGERaFg6pCzFgrmuAwRlxPzdgFzja+6ewTfaXWExpP8PFcS0vagmMsZPXr1FaYnpCWLWRTKjPomNoVS+M9Lli/5/MqyjiwmMy4HwW3Ml1jYFAoh6+X9sWHYh5LurHAiotExFfZZBYPpfKzIzyVzYMIMCgC8+f2PCGX3/iQ3m8OmwEEpAAmbNX7y2gpkeTI/6yKHUtelp5X857JVplDliyRVBIoap0HfGzWQ2iXMFLDYmPfzlIJRq9VqrMVlmRlk9mgEaBrUi77u7g3ZQqDCcNKOZaUjwZzzx9IFDhaFEvC2qkyYnDu5lQpJwAhxU2a6fkWyIIXINd4fG3YOetxkAW+YWcThYnZxnFIwKpWqEWvxpoULyEbfEeLlI02Ezr+vIDcnk8kIqARBykvq/2muJGifzTbZAomQTiM0sTJcQAD49q1aihJJ/HQhiPcFbR9ZWxdmIAC8S7g8zEj0WQtmUsHM6MCWI+ALioUphAa7k2DzrqaN3zNhJOKLYVTl51y0a97kl79/1dLJbUUoDwv69ZnxMWvvDkn2mIjJuNj2blY+HhsBDoTsnRZuFnG4LiaMrfenXn377bdHAQBHsA74kWxRhMWbn7j9ftqdb71NQVA05LyYzUX5dAYMzxpavjtfMlwmTM4J9T3KUwSER8eGAeSxRcWEQspeBPH+a1hHRkUjQIVAiKe1Nd+rnYaGhpNYR1xdiFmmRBIGvtMOpp42DIe8BUlnMpJvFWfOagXdLs4O9fJTcKjUmCejrUlN0cv4SYTKAg6ZjR6Dx0PmvYQf5BKeAFNxa7XaE98rGJVKVYt10LXFhbyK/DyyZCBCPF33LaGIxt6VSwQpdBrmNvbSFMHwtRlphLYVJi/habiEYFFg+5uXrqCc0z0vaExer/fp/i6yJUMEuF6Y1l3C5mAqf5VK9d/vFcynn376DQBAh3Xg7h/eSIMAFNs7bY6iatGkGqzW/lDP51CpKbeLszGzgx8szvcRrYY/abLEtI3k9RkiYzabRWgEyoGJUcTm95NZ6WGGCcPjj+YU4n039v3793/8/Yeu0WiQ2traJ7COXJiWmrRx9XJSwUQABEXh+9/9kEokL6aqYGavsEVJXP0GcRahsa1+ALxfDI/GNNnyBxkiQvcdAoDv/dFhUrlEgJ9miM00GMbsBKhWq3doNBrneR/87bff/goAoB3rhN+vraAyKBSydWMEeL+1Pfuk3hBy17uVyYKMq0Wpnee+tmvlEgsNhglZH6/09Du1TldMZwSJmAxCTuYDY8PufreTzHsJMwUsdvPPMsWYY44AABPV1dVPASzzefv27S9gnZEj4NO/2PhzKIlBJzRQjASbvUebCfli/rpEyoKmUw0q0oT6ijQhZo+fQBlzezyPnmqNud9CxAhdwdj9Pu/uoQFyiFqYSafTtX8tWiSEAcBs9tXQ0LCvvr5+yhiZoWD279+/BwDQhXXimtwc+mPyK+MhbDnneLX5eLLT6w25X8zyZL54XXrq1CTIh4rzkQBmM8/KK70D/gmvN+ZP/jG3J+TtzZfGcf+410tGjsIL8tvcotEMOgNvToxrx44d28/+nxlfnkaj8SqVyg0AAMzw6dY15azbSqVk68YwY/d4mb/99AsnkVYMd+VK0BUC/uBN2ZmE0uk9COLZ3dMf8/D0JOMeT6g+GP97o4a4+BvmEJ77snK+Xc0TLMNZR2pra+9TqVTfp05gfgH19fXDMpnMKpPJfnDhGgWGoQ2LZfT/tmicI3Z7zJ9wc4nvtIPJ961eMZzEYIQ0QkPKT4LKhSmWTCaD0CTIv7R32d/W6eMipZ5BgQc3iLOCDrUfNE043xzRky0Zwsg1KanHH5LkX4ZnHavV6v1XXXXVU+e+hqvhGxoamq+77roCkUi05MK1yauX5YjRfx4/5fchCPmUCCNcOt26tiA/JAUDQxA9g8kgVAGvdTg9ioZjDB+KxkXkpdNmpynEme2pDEZmoOc4/X7/Yz3tsMXvI+/NMCFhsDpq8ktSORQK3r156pZbbvmpTqc7r0Aa9ybS6XS+6urqnwEAjmKtr8jKpP/nx7f7z0QCScLF/qZmLoqzPY0Ge3r6/U6/P25+mB4ESbv50FHEj6IBj21RjeidOreLtK7DBAOCh15cIEPT6HQ8JT8il8uvbmxsnBEJnfUpVV9fj1ZWVm4EAGC2Fri+pIj1P1deTrZ0CCODFivvk/bOmBSYWn0+177egbhRLmfptNlXbTjcpLd4fb2zHYcA4P1YPzKybzD+/oYExveb3MLRVBp9Ac46olKpHqivrx/DWryoGaxSqU7V1dX9CM/5+Mdrr+aszM5KiF6uiQLRVg6hUtPS7jW43HHZouPdIcPylPc+hQ4YRj/BSkq0+/zjN3773fDdJ06w/QSnDZD8Hzemig5cK0yb4SY5S11dnbKysvK/eOsBhzIPHz78h/Ly8sex1sYdDk/5rn1I5/gE6VQLA1QY9p341QM9MlEaoVyWYOiw2lzST+uY/vhvJekv4LDbViYLaAIaDfUgfqbJ66N9MTzK9kEoq0TE9SUxaTEtb5grlPEF6ueKpPkAAEyHv1ar/c/69esVGo0G96YJWMFIpVKKWq3+BgBwGdb6N339roo9r5AKJkxcV1zYd+Dun2YAAKLymT50osX5fGdvQj/5c5LZdnEyi1QuYQAGkE61eIUvg87IwzlkrLKycqFKpZo1Az3gSIFGo/HLZLIbAQCY7TWvzMtlvnTLDVYoDCM1SAD4tLM774h2EHNfG26GXW7na326hHaKQgAgoiQGmVQXBjgwZXTfoiXG2ZSLUqm86mLKBcwWpsZidHTUBQA4IZfLq7DWV4uzGYMWi6t5SJ/QN2u8gAJgvnnRAkJ9UALhgWOnXEeMpoS2XoQcuiOdx0zovyFeqMqStF+VnIqXTAdUKtUvN2/e/Gkg1wo612Hbtm2H1Wp1FVaLTTDl9F1HE/N5ZFFkGFCdVqeN2OwRneR43Gh2vjEwGFLeTTyRwWOS6RJhYDE3qe3HGWK8iBFQq9Uvbd269dVArxdSMlVpaek/1Gr1Pqy1NA6b9tLNN5AFkWHA4nYzH//iKy+eMg8HL3T1xr1X92JwGVQTn0Ujh9gTZ/y3uUUUGAA8P1ZdaWlptU6nC1iZh5ytuXHjxscmH4BYazctWsBRrpNbyCQ84uw72lzUOTZOaGg+Ht02u/NN7WCiVxujBakcCtHizvkOFYKMfy+R9eYyWcU4h4xUVlbeH+x1Q1YwjY2NRplMdiUAADNpo+YqOW/rmnIyP4YgCIpSnv32MBpuZe1FEO9tDU3A6U/sUg9REsPKZVATfosXY3yP5RYNrEzir8JZ1ymVynKVStUR7IUJ1ZtoNBqbUqnciHfz/3n9NdzlmZlxMVcnkXn9+MkMq9vTGc5rvjdk8J00WeLGKVrC5YCrRUJQnpIMWJTAb8v0JCZpuRDkB0LRgetmSaZTKpUPbtu2LSRfYFi+nLfeemtDZWXlv7Bm74za7e7yXfuQ7glj3NzMich9q1e2vfyjm/LClRez5quD7kPjxphuj9IYdPCEtAQoxFkgnfl/ovhRFNSNjIG9PQPg7cEh4MfxEglYNKs0k8ch+qCcz5TxBOrniqWT9xWm30WtVj+5fv36J3Q6zHbdFyVs2r+lpeVZmUz2MNZaXU+fY+2+V+Oi/D+R6X3kwd685OR8otc5oB+xXn/wu5huK9IZDHDoqstBIXf2vLg93f3g/uZTmGsrc5LHGVRYGCER5zwwBHS1shW+TAYTM99FrVa/U1paeiuR9wjb/ru5ublh48aNVwAAZgz5yksW0IRslumTji4a+bQJHQ6dbrm6sIBQI2+Hz++58dAR2BjDTm+FHDZy8Ko1IJ/DvugDbmWKAKTS6eCA4fxR3EIO3ZzOYxJqTTGfYcOUsV0LF4/ms9h4Ien+zZs3V2o0GkKFt2H7sTc2Nlrlcvl6AMAA1vovyy8V3LNyBVl5TYD9Tc1CP4IQyot5Uzvo77E7YlrSUSMt8eWwWQFbz5uL88GNmef30Ernkb4XIvw0I3tgIZu7GGfZrlQq16pUKi3R9wlrBKG/v9/L4/HU5eXld2Ipr/IcMfiwrcM15nDEZcVuvGP3eOlcOl17eW5OSijfHQqA7+6jx6FhtydmkaMl/CTnC8sXU2EICurhxqFQwZvaoan/5jGpFkkKe9L8Ia3hELgqWXjowZyCUghnXrlKpdq8efPmL8PxXhF5CrS0tOyTyWSY5QRjdodrwfYXwITTSRZGhgAVhr3jjz86yGPg1ongsr9nwLzx2MmIlx7MRp38MktFmhCzG/1s2H0+wHvnk6lw5TKxYIRNpxBqCzpfKWCxW/4pXVY0S7DgSwiC1oXr/SLyBNi4ceNvAACnsdZSOWzmS7fcQHbCCxEfgtD2HW0OOrN31O12P3JKE9NI3uXCZFcoygWcmWAJSvlJIJlNM5PKJTToEGRQ5hezZlEuw5WVlZvC+Z4RUTCNjY1jcrn86kmDBWv99iWlnN9UrBmNxHvPB/Y3NScDAAaDOqdX6zd6vTHdmj5QmEeoLEHEYID0JNLwDRHnc8XS7kIWpxBn3VNXV3d9KMl0sxGxPWx9ff2oSqV64MzWfyZ/um5d+k0LF5BJeCGgGRkV1p5qGQ3UCnT5/a5d3X0xzdjNY7Ndt4ozCclgQX2mZDadzKcKgZ9mZGtWJPEvx1tXqVS/Xbt2LWbpDxEi6iSrrKx8u66u7k9YaxAAYO+tN9G4dDo5YykENn/wcaEXQQKqUXqytdM54HDGNKnu2aWLPCwKJWQLyoMgTi8ddUMQtmOSBJ/F3KSGX2TnLpzlkPeVSuX2SLx3xL3w1dXVj2u12vew1tK5XGb9fXfDySwm2d4hSEbtjiTVKfVFLcBum93517aumDp2lwp47tvEWYSqnZstZhOLQU0Pn1Tzg2wGs+evRYty8TJ1tVrtdzKZ7A6NRhOR94+4gtFoNOjDDz98HwDAiLW+IiuTvW3dWkek5ZiL7G06ljypa2Y75qWuPr83xjOOflGQ6yd6r31mHEv4thIxwP2HghJ7EoWKN7jOt3///iqNRhOx319U9uUajcYOAPhcLpcrAJjZ8X1VdhZDa7ZMnNAbyHKCIOg3mjjrCgvacgR8zBvI7PW67jp6nOqK4XC8VDrds3fVUohJoYScOWzwuIeeHegW+AEgOyUGjuORnIJjawQpq3HWXbW1tRs2b958MJJCRO3Jtm3btmaVSvV7rDUKDMP/uO0W4Spxlila8swFUACgX374iQQFANMX82qf1mv0+mLqs3iqdKGLT6MR8v/s1PWbPShKPnyCoFKU2fbDtIw1eOtqtXr77bff/kGk5Yiq6bx169Y9arX6Fbz11zb8iCFgMsntUhAcH9KLvurumTEYz4eg7he7+mLaBLuYy3FvLMglFPXpdjoGvzaO4bZwJJlJAYut/nmmWDLLIV+sX78eM/gSbqKqYHQ6nb+6uvoeAEAD1rpUlMZ6/+d3eiGMwVok+Lz83bHJH/F5Dt/tHd3mLps9piHdu/IkHgpEbFvz3qgBRcmSgIBJptL69y1ckiSg0tJwDumWy+U36nS6qDSDi/oXV19fDyorK3Gdvlfk5vCV69aSoesgeK+1LatrfOL7MIDW4XQoNe2Eqq7DwQ2ZIkLZ2mafV//ZxGhImb/zFOcjuYVWBgzP6GgwjXv79u331NfXRy1qG5Mng0qlaqmrq7sZbxzt41dVJK/Jy4nKTKC5gMfvpz3yyWdZZyNKL3f3e51+JNb5It7FAj4hGf6h141b/X5SwQTIL7Jyv6wQpJTirdfV1d378MMPfxNNmWJmeq5du/ZgQ0PDH7DWIADAxz//cVJpuojM9A2QdzVtkhNDBrPZ67Xu7e2PtXIBGQyGHsaIGAbKoNs19O6oIWqjcxOdtQLhyZ9mZl+Ht67VanetXbv2n9GVKsZ728rKyifVavXzWGtJDAbj3Z/eQRMwySS8QHm6/lvq//v6sGXE7Yl5Or3Z56XgWaiB8C/DoMeHojFXlInAIg732O/yiyQAJ4yvVqvfvuyyyx6KvmRxMuoBRdHPAADXYK3tONgwsfXjT1OiL1WCAlNQULoYApTYDwuw/ej6fg6Vmhv0eX5/z00nj2Z5UISsbLwI2Qxm91ulK3gQAHhO3RNyuXxlfX19TLoXxIV3frpE3IC19qvLLhX8dPnSkehLlaAgfggYJ2ItxRQf60dCyb71/13b6yaVS0DYH8kp8MyiXGxbt26tipVyAfGiYFQqVVddXd16AMCM7RAFhuHXFT8SrcjKxIw6kWAwFh/+8Vf6tEErGK3LafhkfGRRZCSaW/y/9Mz21TwB3meF1NXVKXbs2NEcZbHOIy4UDDjj9D2pUqkew1t/TfEjehKDQQ5yCwSnAwCTKea1O58YRsS7u/uPB9pWAgHA84K2z0d2Irs4hSz26Z9l4CfTNTQ0/Hnt2rUHoivVTOLCB3MWqVQK1Gr1ewCAm7HW63v7jPK9r3LxnFkk50Cno0BaCgEo5l8x+urqZeqf50lww6fgzCwk10+OHm8foLgWAgASfZxtRBHS6H1vl66g0mFYjHPIEZlMdrlGo4n5jPjYewLPYXR0dHK79P7NN9+8js/nz/jw8pIFLBRFTfW9/WRdysXw+yHAZALAinlACfpAP5w06HRpCzhsu4jJOC+vxYeirs+GR+13Hz3hHwAuhEmjpMZO1ITA8UR+8XABi12Es94qk8nWTRcYx5y4UjDgjJLx8ni8Rrlcfj/WFq6iIJ/5RVf3qNZsmX1iFwkAPj8KhMLYmzAA0I4Zzckvdffx/juo7+y1O1yHxiag94aGJ+46epy+p2cgyYz6JnJS2HgZqCRnQH8lzvv8hlQRbhGjUqm87e23326Lrlj4xPzmw+Ott976YWVl5ZtY5rLZ5XKW797nbR0ZI7M8L8YiGQqY8T9DqFjEHUzjMrJjLUc8c3Vy6sk/FJTIAABYRaw+tVr9QGlp6b4YiIZL3Dh5L+T2229/V61W78Ba4zOZrFc3/Aglksg1bxiP/0ZNNApsSOUwyCmNs8Cj0lofzS0U4SgXoFar98ebcgHxrGAmWb9+/VOTnx3W2iXibP4rG344BgHIE33JEoiJcQj441sPF6VxbBAESL8aDkIaTb97QSmFQ6Fk4hxyfOPGjbgR2FgSdz6Yc7FYLF4AwEm5XH4P1vqyzAzuhNNl/k6ri7knM25BEAhAEAKSkuJym8RlUIfyhJygs33nE1skBe2reQK8Ma8jcrn80kOHDsVHduUFxLUFA850wjukVqs3Tu4xsdaVV1ewl2ZmjEdfsgRiZBgCnvg09NJ5ZER6Fvw/Ts+uvyFVtARnHVGpVPfV19fHpXIBiaBgJiktLd0/ucfEWktmsZgH77+HlZHEtURfsgRh0ooxTsSdLwaGIKuIyyAd9Tgs5/JPbBLnXgFwZkir1eq3KisrMSd2xAsJoWDAmXG0k3vME1hrXDqdvfuHN05aOGQnPDzGxgBA40vHZPAYVgiCCI0zmauk0ei9v88vSp/lN9q5bdu2h6MsVtAkjIJpbGycmB5Hi1n4eMuihSl/vf4aXfQlSxA8bgiMj8VVFj45BhYbCIDxvxYvMmfQGXiZuma5XL5WpVIFNHgvliSMggFn2m1OqFSq+/FqW359xeX5isWy+Kj0i0f0QwD4Y549PkUal9HJolPw5vXMZ5CHcwoGilmcZXgHqFSqzfX19UHNJo8VCaVgwJnWDu/W1dVtw1vf88ObWEI2m3T6YuHzwWDCGHMrBgLAUZjGIX0vGFzGT/78R2kZeE7dSf5WWVn5RhRFIkTCKRhwZhztk1qt9j9YawIWk/PNfXdTRRxOXNRixB3jsffFpPOYRhiCyDGwF7CEy2v7c9GiS/HSR7Ra7ScymezX0ZcsdBJSwWg0GrSysvJuAMAhrHWpKI3/5h0b3DAEOaMvXZzjdMBgbDSWVowrW8AknS8XkMNkdTxZUMKHAcCbBtFcWVn5Y41GE99ZkxeQkAoGnHH6WuVy+XWTih1rfW1Bfsq/br9tONBeJPOKoUE0Vtm92QLWAINKEcbkzeMUBgwPvVhSiqbS6HiZusNyuXxdY2NjwjVdi+tM3ovR39/v5fF46vLy8juwlGVpukgwZLHom4f0SbGRME5BURjQaH7A4UT1AUODIfOC9CQmDEFkWcD/4X08r6i/lJskw1lHVCrVT5599tmTUZYrLCSsBXOWhx9++LO6uroteOsv3nxDyiJR2lB0pUoAxsaiXjqQlsR0UGCItF7O4Za0jAPXpKQtxVuvq6v7XWVl5fvRlSp8JLyCAWfabb6o1Wpfx1qjUyjMT+/+CSuHz0848zKiuJwwMEY1ouRJ5zHIToTncBk/ueV/cgrW4a1rtdq3qqurn4muVOFlTigYcKby+pcAAMxEOwmfn7zvtpvJcbQXotOi0YooZfCYfSyyW933UADU/0hOweTWHa9Qd3j9+vUPaDSaKEsWXhLaB3Muo6OjbgDAh3K5fAMAYIbPpTAlhc+mUTu+6OrhzaW/mxAIAgMGEwEsVkS3SxQYsi5KT6LBMER2IZy8OSnU0d0LFxtzmKxinENGlErlVW+//TZmACORmFM/tOmq0iG5XH4b1vr/Z+/cY5vIrj9+Zvy2Y8exYycmHhIT5+UbFtj9/bZh2WLz0MarLoiXYyo1iFKkPuSqgnYl1G5F/uhDLaWvVdltRaS2Yllqt6W7qLTsrpSkXZEAKktK7PAOyZgCedIEEtuZeCoTR03ZGW8S7LEzMx8JCelYo+PJ9XfOPXPuOWtKlxp7Rh70dd69JzY3mmGKioOxMKORbJFOOWzUKMS6lyR7lxBXXAVG1rxLIBD4is/n+4BbrzIDrwQmwc2bN4P19fVqs9m8hsm+mrBK3u68/Ggslv3xqjlBLIaBVhsHuSJTIjNlN+VFZBJcjF4en5DWdR8os9tTjHn9eWNj46HR0dHcOpm6QHKyCVE6oGn6NAC8zGT7Q1fo5o7j/nLuvcpRlEoKqh3STIw4MeUprlWY88Qh9tP0n0Crxgilim3tvY9h2Esc+5RReJPkfZKGhgZfYrvEZNte67B9e73zstjTN0kkIoXR0bS/UcIx7FGpQS2eOQIAOY4Pv1G1/E4KcbmXHKHMK3i3RZohFAqNAMCZZLvNJxslY+uW2You3b13/erAoPhmAx7PUYqDwZDWB45Zqxw0aRVs1amC4vMW6xW30bSKxRxtampyHjlypJtjtzIObwUGppO+AwihMYQQ41bpxdKl2DvdV4ZHJiLiUzYWA8jXx0EmS5fIxO0mzbhcigu+odRqnb79G6Xl1ThgjP1BA4HAqz6fL6c70y0U3uZgZkiOow0AwA4m++2RBz3VP3ldG6WmxEgmT0tBRSXjWIz5YtDIr1YXaavSca3FjE2p6j6GVhGJu8vykT8ihLYv9noXNnibg5kh8YdDCDWSJNnOZC8r0Nt+tXXzsJiPAYCHY1J49PCpczEYBuNlBrHfiwSw/tfKKqRs4pJYkwihz/FVXEAIAgPTIhNpbm7+AlvP3l2rVlTufm7V37j3LAcZfPpBbYV5igdKGS703Ev0cIWju1qTx1ZMN5lYk6FQiNctRXidg5lNW1vboMPhuIgQ2spUg7DFUV18jgz33BgaFvZhvGgUwGCkQSJZ8Pa5vFAzppBKBH2CvcFs6dxmLl7NYp7w+/3bfD4fY1TNJwQRwczg9Xr/HAwGD7OYVW9ueUUlxfFF0es0Y8TjONy9s+Btkl4lu6ZVygTda9ehzjv/NcLGWvsTDAZ/5PV6T3PrVXbgfZL3SaxWq5okyQ4AYJyUd/Ffd7vXH/216d+RqJCTvnGodgCoVPN6AGEAkZVW/ZBKLhHsEHuLXHH7aM0zUr1UxjYRoJMgiBfC4fA4x65lBcFskWZIjqO96HK59jLZLVqtCQP86gc3bwk5h4ABhk2BLn9eAmPUyPuL85WCFRcAmPxxheNOikOMdFNT0+ZTp071cuxX1hCcwMB0PuaOx+PpMZvNm5i2iWvKlub3jIyc67x7f2l2PMwBYlEaCk044HPXmGWFmlGlTCLUt0cT+5YuO+/SG59nsU/6/f5dPp/vDMd+ZRVB5WBmU1tb+9tAIHCAyYYBqH+zY2tdw3L0Efee5QgUJYG+3jkPtDZq5LfyVTLBRn1fKikN7TAVf5rNHggEXvV6vce59Sr7CC4HM5tkEd67ALCJyT4Wjd6xHfrZyND4eC333uUI1TUUqNSfVHwX+VSZYViCY4JM7j6rzW99vRKtBgC2Sf6/Rwh5+FzvwoZgIxj4bxHeTpIkzzPZtQpFyd+/uEdi0WqFO5J2Dr17i7SKIaGKS7lKff2wvcbBJi4kSZ5FCDUKUVxA6AID0yIz3tzcvJetkrfGVFjz/fqNfdx7liMMD9EQT/3WukinFOo6enjQVknJcdzMYp8ppotw7FfOIMgk75O0tbX1OxyOywihLQwnr2GlpbgoRlHvfdjbZxOcKNM0DvF4FHT5jNukArWst0SvsgjtvmAAo98trwo+q81nOyE94ff7t/p8vg6OXcspBLUoUuH1ek8Gg8Gfspjl36vfWP9Shf1Djt3KDQb6ZRCLMUV4k3bT42M2gntQ7bJYb7j0xjo2ezAY/KHX6/0Lt17lHqLAzMLtdn8nEdCwmPFjDdsqd65Y3gIAc367whNwGPr4GSVTnqJfJsFLs+NS9ngmT9uyq7gk1fc+43a7f8ChSzmLKDCzCIfDD10u18sAcJvJbtKol7zt3e56bd3a9xObB+49zCKDgx8bcVKky1gf35zFrtK890bV8pVKnHX87TWXy7U5HA7z+hDjXBFcaPtJ9Pb2Ujqdris5jpbp/mDry222/ytZcqmjLxx7EImwDSvnF/G4BFRqCpTTCd18pZQkCtRmAa2hh26D+Z1v2uw1GgnrUYjI/v37t584cYLxASVEBF0Hk4qWlpYvu1yuI6k+Q8Xjg9vf8l96t/vKekFEgzrdJJTapCCVxp8j9L0KmWRZtl3iiN4DpeUnNxUWfTWVoLa2tu5ct27d77h1LbcRytNn3ly4cOEfZrM5ghDawCbEOIapP7ui1vqZqoqgWi4fuDE0NDQxSRl5K9zRKIBMRhnMhv5inZL3uRcFjl/0mCwt3yqzTzyv07NFtI9pb28/tHbtWraXBIKFnz+ENNLS0rLb5XIdnaMYT5y+ev3sW5f+SR/vvFwFAAQHLnKLQkE5NrwwoOffsQAaAEgACK43FJ6zKTQTe5aUvAIArOX/s2hFCG0MhUJiV8QnEAVmDvj9/i0ej+eXAMBWUMXEwOV79+/fGB7Jo6amaP4khbF4gaXwI4kE70827lrka+jxMChMplLhLyrViegzEZlVppgZ/T+QJHnC7XbvDoVC0cz7uvhY5IuDO5xOp6G1tfWvAPD/2fYly0zO6gg4lfxHpziHw2eOIYR2i5ELO/xPTKaJtra2YYIgXIFA4OsAcC/b/uQIiW2jPCkucQCgkjVCU8n/85WRQCCwB8OwRlFcRNKOx+Mx0DT9Jk3TFC08YvP4bCR5j6IZ9Idr/uR0OguyvQZFBMC+ffscZ8+e/QVN0wPZXvUcMh+Bmc2M2FBPcY1s8aivr+/4wYMHN1itVjGtIMItTqcT9/v9m2iaPknT9ES2fw0ZJl3iMCM0kTRdLxOQXV1dB5xOp+CnUy4UUY3TTF1dnYogiOq6ujoHQRAEAFgAgE/VvlMZqJ+iEtd0OBwShBDBcX1W4vuMB4PBR8l55j0kSd7q6Ojoam9v7w6Hw089iE7I/CcAAP//LazR1LfsgEMAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - hco.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - v2v.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - machineremediation.kubevirt.io
+          resources:
+          - machineremediationoperators
+          - machineremediationoperators/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - daemonsets
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - '*'
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consoleclidownloads
+          - consolequickstarts
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+        serviceAccountName: hyperconverged-cluster-operator
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - networkaddonsconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          - endpoints
+          - pods/exec
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - patch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - kubevirt-handler
+          - kubevirt-controller
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - put
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - delete
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines/status
+          verbs:
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancemigrations
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancepresets
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - limitranges
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinerestores
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - update
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/addvolume
+          - virtualmachineinstances/removevolume
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstances
+          verbs:
+          - update
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - version
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          - virtualmachineinstances/addvolume
+          - virtualmachineinstances/removevolume
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          - virtualmachineinstances/addvolume
+          - virtualmachineinstances/removevolume
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes/source
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirtcommontemplatesbundles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirtmetricsaggregations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirtnodelabellerbundles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirttemplatevalidators
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - ssps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - ssps/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - ssps/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - templates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: ssp-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          - upload.cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - '*'
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes
+          verbs:
+          - list
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims/finalizers
+          - pods/finalizers
+          - volumesnapshots/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - events
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+          - create
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - nodemaintenance.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: node-maintenance-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - list
+          - watch
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - clusterrolebindings
+          verbs:
+          - update
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - clusterroles
+          verbs:
+          - update
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - hostpath-provisioner-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - hostpathprovisioner.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - delete
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+        serviceAccountName: hostpath-provisioner-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - v2v.kubevirt.io
+          resources:
+          - vmimportconfigs
+          - vmimportconfigs/finalizers
+          - vmimportconfigs/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - '*'
+        serviceAccountName: vm-import-operator
+      deployments:
+      - name: hco-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-operator
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-operator
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                - name: WEBHOOK_MODE
+                  value: "false"
+                - name: APP
+                  value: OPERATOR
+                - name: KVM_EMULATION
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:914c75180c2c1aa6bfabc033ee3bd9d1a0169999e0958aab8c44bad9aa262719
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-operator
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                - name: CONVERSION_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-v2v-conversion@sha256:c620233c71b805004c2cd38927c421b69d99b27cb40af521967e655882b2f815
+                - name: VMWARE_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-vmware@sha256:ae5ccd98a49ab9e154ce482d2fa73f044b00211f273210a9cd371b40746d3c92
+                - name: SMBIOS
+                  value: |-
+                    Family: KubeVirt
+                    Manufacturer: KubeVirt
+                    Product: None
+                - name: MACHINETYPE
+                - name: HCO_KV_IO_VERSION
+                  value: 1.3.0
+                - name: KUBEVIRT_VERSION
+                  value: v0.36.0
+                - name: CDI_VERSION
+                  value: v1.28.0
+                - name: NETWORK_ADDONS_VERSION
+                  value: v0.44.0
+                - name: SSP_VERSION
+                  value: v0.1.0-rc.2
+                - name: NMO_VERSION
+                  value: v0.7.0
+                - name: HPPO_VERSION
+                  value: v0.7.0
+                - name: VM_IMPORT_VERSION
+                  value: v0.2.5
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:914c75180c2c1aa6bfabc033ee3bd9d1a0169999e0958aab8c44bad9aa262719
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /livez
+                    port: 6060
+                    scheme: HTTP
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                name: hyperconverged-cluster-operator
+                readinessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /readyz
+                    port: 6060
+                    scheme: HTTP
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: hco-webhook
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-webhook
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                name: hyperconverged-cluster-webhook
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-webhook
+                env:
+                - name: WEBHOOK_MODE
+                  value: "true"
+                - name: APP
+                  value: WEBHOOK
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:b0c670ce23cbca458c8dca188379c77e7211cb48fd8023684af6c32fb6b9299f
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-webhook
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:b0c670ce23cbca458c8dca188379c77e7211cb48fd8023684af6c32fb6b9299f
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /livez
+                    port: 6060
+                    scheme: HTTP
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                name: hyperconverged-cluster-webhook
+                readinessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /readyz
+                    port: 6060
+                    scheme: HTTP
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - name: cluster-network-addons-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cluster-network-addons-operator
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                name: cluster-network-addons-operator
+            spec:
+              containers:
+              - env:
+                - name: MULTUS_IMAGE
+                  value: nfvpe/multus@sha256:ac1266b87ba44c09dc2a336f0d5dad968fccd389ce1944a85e87b32cd21f7224
+                - name: LINUX_BRIDGE_IMAGE
+                  value: quay.io/kubevirt/cni-default-plugins@sha256:606eaa06262ad6edd5aa809491c7e46b9ddbc9c52ba8c47e89e734e3e80cd311
+                - name: LINUX_BRIDGE_MARKER_IMAGE
+                  value: quay.io/kubevirt/bridge-marker@sha256:799459f8509a06ea643aa2f6ac02826721a641333aacab07e53166139a5a66c3
+                - name: NMSTATE_HANDLER_IMAGE
+                  value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:d5155de6aa6cf97c2feb5f4171384e63ce957362a66d47ec14982cbabca5169c
+                - name: OVS_CNI_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-plugin@sha256:d43d34ed4b1bd0b107c2049d21e33f9f870c36e5bf6dc1d80ab567271735c8da
+                - name: OVS_MARKER_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-marker@sha256:8ec72d6a3d58cea27a2b9a52e6ef4ee0d753b3ba989d24555bdfbf01a995a9c1
+                - name: KUBEMACPOOL_IMAGE
+                  value: quay.io/kubevirt/kubemacpool@sha256:e68811ce7697ab0f1257f307fcd63b08b6295de7f300e01a982e4e624bfa7398
+                - name: MACVTAP_CNI_IMAGE
+                  value: quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/cluster-network-addons-operator@sha256:38dadf3624c30092b67aa74487b3f744c835f9a17f33b4408f1f1bab3a79004d
+                - name: OPERATOR_NAME
+                  value: cluster-network-addons-operator
+                - name: OPERATOR_VERSION
+                  value: v0.44.0
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERAND_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/cluster-network-addons-operator@sha256:38dadf3624c30092b67aa74487b3f744c835f9a17f33b4408f1f1bab3a79004d
+                imagePullPolicy: IfNotPresent
+                name: cluster-network-addons-operator
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cluster-network-addons-operator
+      - name: virt-operator
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              kubevirt.io: virt-operator
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              annotations:
+                scheduler.alpha.kubernetes.io/critical-pod: ""
+              labels:
+                kubevirt.io: virt-operator
+                prometheus.kubevirt.io: ""
+              name: virt-operator
+            spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: kubevirt.io
+                          operator: In
+                          values:
+                          - virt-operator
+                      topologyKey: kubernetes.io/hostname
+                    weight: 1
+              containers:
+              - command:
+                - virt-operator
+                - --port
+                - "8443"
+                - -v
+                - "2"
+                env:
+                - name: OPERATOR_IMAGE
+                  value: docker.io/kubevirt/virt-operator@sha256:4c33eaab42033c84310b62e146274f95a55699235c59846c8cec3009a91a723f
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: KUBEVIRT_VERSION
+                  value: v0.36.0
+                - name: VIRT_API_SHASUM
+                  value: sha256:4d778f63d2f5ecb61d4f6fe8b5ead010836d46d75349f3c3634f5862614e4a21
+                - name: VIRT_CONTROLLER_SHASUM
+                  value: sha256:f1fe5d43cd89b2f7d18cb23a14753b260a85f7e862b13529b640d7e8c36e81d5
+                - name: VIRT_HANDLER_SHASUM
+                  value: sha256:10e9294253c2037d29a9a33dfeb3b096dbb7ceb5ed2f0fc1662d66535108d236
+                - name: VIRT_LAUNCHER_SHASUM
+                  value: sha256:1bb248aeb9d0bc66667f6133f8230cc80944b562c3d267cc00a5382954140c12
+                image: docker.io/kubevirt/virt-operator@sha256:4c33eaab42033c84310b62e146274f95a55699235c59846c8cec3009a91a723f
+                imagePullPolicy: IfNotPresent
+                name: virt-operator
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8444
+                  name: webhooks
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /metrics
+                    port: 8443
+                    scheme: HTTPS
+                  initialDelaySeconds: 5
+                  timeoutSeconds: 10
+                resources: {}
+                volumeMounts:
+                - mountPath: /etc/virt-operator/certificates
+                  name: kubevirt-operator-certs
+                  readOnly: true
+              priorityClassName: kubevirt-cluster-critical
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: kubevirt-operator
+              tolerations:
+              - key: CriticalAddonsOnly
+                operator: Exists
+              volumes:
+              - name: kubevirt-operator-certs
+                secret:
+                  optional: true
+                  secretName: kubevirt-operator-certs
+      - name: ssp-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: ssp-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: ssp-operator
+            spec:
+              containers:
+              - args:
+                - --enable-leader-election
+                command:
+                - /manager
+                env:
+                - name: KVM_IMAGE
+                - name: VALIDATOR_IMAGE
+                - name: VIRT_LAUNCHER_IMAGE
+                - name: NODE_LABELLER_IMAGE
+                - name: CPU_PLUGIN_IMAGE
+                - name: OPERATOR_VERSION
+                  value: v0.1.0-rc.2
+                image: quay.io/kubevirt/ssp-operator@sha256:1466407727c1c802b2b1191b1f5a22a0a8933a39bdf68556a2f97607f7c523aa
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                resources: {}
+              serviceAccountName: ssp-operator
+              terminationGracePeriodSeconds: 10
+      - name: cdi-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cdi-operator
+              operator.cdi.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: cdi-operator
+                operator.cdi.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                  value: v1.28.0
+                - name: CONTROLLER_IMAGE
+                  value: docker.io/kubevirt/cdi-controller@sha256:bbd22f481ec1dd1eaf63af9888d107c3f67507e578600da8a5429540c78527bc
+                - name: IMPORTER_IMAGE
+                  value: docker.io/kubevirt/cdi-importer@sha256:d16dd224def1713a51278f6f164a04c7e9b38364b794f14d18c2d8d14ab04eb3
+                - name: CLONER_IMAGE
+                  value: docker.io/kubevirt/cdi-cloner@sha256:c8946ef116d4d2fccf08b895faf07d9bb85f76d315e4380416261db9970306f1
+                - name: APISERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-apiserver@sha256:02d0363e32cd28145a9802cad2c0adc077e67715d55a948c0bc92ae2adf08813
+                - name: UPLOAD_SERVER_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadserver@sha256:3915ba0501fa0e3ee9ae178d6617d0c1ac5f34a83243f723421c42de99e705e5
+                - name: UPLOAD_PROXY_IMAGE
+                  value: docker.io/kubevirt/cdi-uploadproxy@sha256:9e5ae41e3da07c30ac9a0326c89f2d64021abfc5d74ee6c4b750d6915f02eeb5
+                - name: VERBOSITY
+                  value: "1"
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: docker.io/kubevirt/cdi-operator@sha256:8e9a4d4a819c11e53b9ebc316590aeb0515ffd92a92f0281d8c2d90fd819e711
+                imagePullPolicy: IfNotPresent
+                name: cdi-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                  protocol: TCP
+                resources: {}
+              nodeSelector:
+                kubernetes.io/os: linux
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cdi-operator
+              tolerations:
+              - key: CriticalAddonsOnly
+                operator: Exists
+      - name: node-maintenance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: node-maintenance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: node-maintenance-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: node-maintenance-operator
+                image: quay.io/kubevirt/node-maintenance-operator@sha256:71bb8de714dc0de0616050d66405ccb58841930fc1562a61399e1b964a0b678a
+                imagePullPolicy: Always
+                name: node-maintenance-operator
+                resources: {}
+              serviceAccountName: node-maintenance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+      - name: hostpath-provisioner-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hostpath-provisioner-operator
+              operator.hostpath-provisioner.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: hostpath-provisioner-operator
+                operator.hostpath-provisioner.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: hostpath-provisioner-operator
+                - name: PROVISIONER_IMAGE
+                  value: quay.io/kubevirt/hostpath-provisioner@sha256:3838d8e713d2e85a807a9c302501b25c248ba3f3c1602fe50480e6510de43e11
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:a51e9b075a60600244757386f5894b314170543edb1d7f4738f4860a19602072
+                imagePullPolicy: IfNotPresent
+                name: hostpath-provisioner-operator
+                resources: {}
+              serviceAccountName: hostpath-provisioner-operator
+      - name: vm-import-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: vm-import-operator
+              operator.v2v.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: vm-import-operator
+                operator.v2v.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                  value: v0.2.5
+                - name: CONTROLLER_IMAGE
+                  value: quay.io/kubevirt/vm-import-controller@sha256:481f4a493a66d1310734ac135e8dbaa5dc01c9d93f6e9ecc9326b81c1c08dbfe
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: MONITORING_NAMESPACE
+                  value: openshift-monitoring
+                - name: VIRTV2V_IMAGE
+                  value: quay.io/kubevirt/vm-import-virtv2v@sha256:97caccb965d771afefd901c71381b6c1126e4177b477d47f2ca5ca57c5b06593
+                image: quay.io/kubevirt/vm-import-operator@sha256:74fc74dab0671ef1098e69872e47bcb6f85a40b4b18a1e23fd6d3cfc36dfee32
+                imagePullPolicy: IfNotPresent
+                name: vm-import-operator
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: vm-import-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: ssp-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - events
+          - secrets
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - daemonsets
+          verbs:
+          - delete
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - ""
+          resourceNames:
+          - hostpath-provisioner-admin
+          resources:
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        serviceAccountName: hostpath-provisioner-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  labels:
+    alm-owner-kubevirt: kubevirt-hyperconverged
+    operated-by: kubevirt-hyperconverged
+  links:
+  - name: KubeVirt project
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/hyperconverged-cluster-operator
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  relatedImages:
+  - image: quay.io/kubevirt/bridge-marker@sha256:799459f8509a06ea643aa2f6ac02826721a641333aacab07e53166139a5a66c3
+    name: bridge-marker
+  - image: docker.io/kubevirt/cdi-apiserver@sha256:02d0363e32cd28145a9802cad2c0adc077e67715d55a948c0bc92ae2adf08813
+    name: cdi-apiserver
+  - image: docker.io/kubevirt/cdi-cloner@sha256:c8946ef116d4d2fccf08b895faf07d9bb85f76d315e4380416261db9970306f1
+    name: cdi-cloner
+  - image: docker.io/kubevirt/cdi-controller@sha256:bbd22f481ec1dd1eaf63af9888d107c3f67507e578600da8a5429540c78527bc
+    name: cdi-controller
+  - image: docker.io/kubevirt/cdi-importer@sha256:d16dd224def1713a51278f6f164a04c7e9b38364b794f14d18c2d8d14ab04eb3
+    name: cdi-importer
+  - image: docker.io/kubevirt/cdi-operator@sha256:8e9a4d4a819c11e53b9ebc316590aeb0515ffd92a92f0281d8c2d90fd819e711
+    name: cdi-operator
+  - image: docker.io/kubevirt/cdi-uploadproxy@sha256:9e5ae41e3da07c30ac9a0326c89f2d64021abfc5d74ee6c4b750d6915f02eeb5
+    name: cdi-uploadproxy
+  - image: docker.io/kubevirt/cdi-uploadserver@sha256:3915ba0501fa0e3ee9ae178d6617d0c1ac5f34a83243f723421c42de99e705e5
+    name: cdi-uploadserver
+  - image: quay.io/kubevirt/cluster-network-addons-operator@sha256:38dadf3624c30092b67aa74487b3f744c835f9a17f33b4408f1f1bab3a79004d
+    name: cluster-network-addons-operator
+  - image: quay.io/kubevirt/cni-default-plugins@sha256:606eaa06262ad6edd5aa809491c7e46b9ddbc9c52ba8c47e89e734e3e80cd311
+    name: cni-default-plugins
+  - image: quay.io/kubevirt/hostpath-provisioner@sha256:3838d8e713d2e85a807a9c302501b25c248ba3f3c1602fe50480e6510de43e11
+    name: hostpath-provisioner
+  - image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:a51e9b075a60600244757386f5894b314170543edb1d7f4738f4860a19602072
+    name: hostpath-provisioner-operator
+  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:914c75180c2c1aa6bfabc033ee3bd9d1a0169999e0958aab8c44bad9aa262719
+    name: hyperconverged-cluster-operator
+  - image: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:b0c670ce23cbca458c8dca188379c77e7211cb48fd8023684af6c32fb6b9299f
+    name: hyperconverged-cluster-webhook
+  - image: quay.io/kubevirt/kubemacpool@sha256:e68811ce7697ab0f1257f307fcd63b08b6295de7f300e01a982e4e624bfa7398
+    name: kubemacpool
+  - image: quay.io/nmstate/kubernetes-nmstate-handler@sha256:d5155de6aa6cf97c2feb5f4171384e63ce957362a66d47ec14982cbabca5169c
+    name: kubernetes-nmstate-handler
+  - image: quay.io/kubevirt/kubevirt-v2v-conversion@sha256:c620233c71b805004c2cd38927c421b69d99b27cb40af521967e655882b2f815
+    name: kubevirt-v2v-conversion
+  - image: quay.io/kubevirt/kubevirt-vmware@sha256:ae5ccd98a49ab9e154ce482d2fa73f044b00211f273210a9cd371b40746d3c92
+    name: kubevirt-vmware
+  - image: quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266
+    name: macvtap-cni
+  - image: nfvpe/multus@sha256:ac1266b87ba44c09dc2a336f0d5dad968fccd389ce1944a85e87b32cd21f7224
+    name: multus
+  - image: quay.io/kubevirt/node-maintenance-operator@sha256:71bb8de714dc0de0616050d66405ccb58841930fc1562a61399e1b964a0b678a
+    name: node-maintenance-operator
+  - image: quay.io/kubevirt/ovs-cni-marker@sha256:8ec72d6a3d58cea27a2b9a52e6ef4ee0d753b3ba989d24555bdfbf01a995a9c1
+    name: ovs-cni-marker
+  - image: quay.io/kubevirt/ovs-cni-plugin@sha256:d43d34ed4b1bd0b107c2049d21e33f9f870c36e5bf6dc1d80ab567271735c8da
+    name: ovs-cni-plugin
+  - image: quay.io/kubevirt/ssp-operator@sha256:1466407727c1c802b2b1191b1f5a22a0a8933a39bdf68556a2f97607f7c523aa
+    name: ssp-operator
+  - image: docker.io/kubevirt/virt-api@sha256:4d778f63d2f5ecb61d4f6fe8b5ead010836d46d75349f3c3634f5862614e4a21
+    name: virt-api
+  - image: docker.io/kubevirt/virt-controller@sha256:f1fe5d43cd89b2f7d18cb23a14753b260a85f7e862b13529b640d7e8c36e81d5
+    name: virt-controller
+  - image: docker.io/kubevirt/virt-handler@sha256:10e9294253c2037d29a9a33dfeb3b096dbb7ceb5ed2f0fc1662d66535108d236
+    name: virt-handler
+  - image: docker.io/kubevirt/virt-launcher@sha256:1bb248aeb9d0bc66667f6133f8230cc80944b562c3d267cc00a5382954140c12
+    name: virt-launcher
+  - image: docker.io/kubevirt/virt-operator@sha256:4c33eaab42033c84310b62e146274f95a55699235c59846c8cec3009a91a723f
+    name: virt-operator
+  - image: quay.io/kubevirt/vm-import-controller@sha256:481f4a493a66d1310734ac135e8dbaa5dc01c9d93f6e9ecc9326b81c1c08dbfe
+    name: vm-import-controller
+  - image: quay.io/kubevirt/vm-import-operator@sha256:74fc74dab0671ef1098e69872e47bcb6f85a40b4b18a1e23fd6d3cfc36dfee32
+    name: vm-import-operator
+  - image: quay.io/kubevirt/vm-import-virtv2v@sha256:97caccb965d771afefd901c71381b6c1126e4177b477d47f2ca5ca57c5b06593
+    name: vm-import-virtv2v
+  replaces: kubevirt-hyperconverged-operator.v1.2.0
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-hyperconverged
+      operated-by: kubevirt-hyperconverged
+  version: 1.3.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1beta1
+    - v1
+    containerPort: 4343
+    deploymentName: hco-webhook
+    failurePolicy: Fail
+    generateName: validate-hco.kubevirt.io
+    rules:
+    - apiGroups:
+      - hco.kubevirt.io
+      apiVersions:
+      - v1alpha1
+      - v1beta1
+      operations:
+      - CREATE
+      - DELETE
+      - UPDATE
+      resources:
+      - hyperconvergeds
+    sideEffects: None
+    timeoutSeconds: 30
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-hco-kubevirt-io-v1beta1-hyperconverged
+  - admissionReviewVersions:
+    - v1beta1
+    - v1
+    containerPort: 4343
+    deploymentName: hco-webhook
+    failurePolicy: Fail
+    generateName: mutate-ns-hco.kubevirt.io
+    objectSelector:
+      matchLabels:
+        name: kubevirt-hyperconverged
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - DELETE
+      resources:
+      - namespaces
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 30
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-ns-hco-kubevirt-io
+  - admissionReviewVersions:
+    - v1beta1
+    containerPort: 9443
+    deploymentName: ssp-operator
+    failurePolicy: Fail
+    generateName: vssp.kb.io
+    rules:
+    - apiGroups:
+      - ssp.kubevirt.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - ssps
+    sideEffects: None
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-ssp-kubevirt-io-v1beta1-ssp
+  - admissionReviewVersions:
+    - v1beta1
+    containerPort: 8443
+    deploymentName: node-maintenance-operator
+    failurePolicy: Fail
+    generateName: nodemaintenance-validation.kubevirt.io
+    rules:
+    - apiGroups:
+      - nodemaintenance.kubevirt.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - nodemaintenances
+      scope: Cluster
+    sideEffects: None
+    timeoutSeconds: 15
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/kubevirt00.crd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    categories:
+    - all
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/node-maintenance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/node-maintenance00.crd.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nodemaintenances.nodemaintenance.kubevirt.io
+spec:
+  group: nodemaintenance.kubevirt.io
+  names:
+    kind: NodeMaintenance
+    listKind: NodeMaintenanceList
+    plural: nodemaintenances
+    singular: nodemaintenance
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: NodeMaintenance is the Schema for the nodemaintenances API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: NodeMaintenanceSpec defines the desired state of NodeMaintenance
+          properties:
+            nodeName:
+              description: Node name to apply maintanance on/off
+              type: string
+            reason:
+              description: Reason for maintanance
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          description: NodeMaintenanceStatus defines the observed state of NodeMaintenance
+          properties:
+            errorOnLeaseCount:
+              description: Consecutive number of errors upon obtaining a lease
+              type: integer
+            evictionPods:
+              description: EvictionPods is the total number of pods up for eviction
+                from the start
+              type: integer
+            lastError:
+              description: LastError represents the latest error if any in the latest
+                reconciliation
+              type: string
+            pendingPods:
+              description: PendingPods is a list of pending pods for eviction
+              items:
+                type: string
+              type: array
+            phase:
+              description: Phase is the represtation of the maintenance progress (Running,Succeeded,Failed)
+              type: string
+            totalpods:
+              description: TotalPods is the total number of all pods on the node from
+                the start
+              type: integer
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/scheduling-scale-performance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/scheduling-scale-performance00.crd.yaml
@@ -1,0 +1,852 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  name: ssps.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: SSP
+    listKind: SSPList
+    plural: ssps
+    singular: ssp
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: SSP is the Schema for the ssps API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SSPSpec defines the desired state of SSP
+            properties:
+              commonTemplates:
+                description: CommonTemplates is the configuration of the common templates operand
+                properties:
+                  namespace:
+                    description: Namespace is the k8s namespace where CommonTemplates should be installed
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - namespace
+                type: object
+              nodeLabeller:
+                description: NodeLabeller is configuration of the node-labeller operand
+                properties:
+                  placement:
+                    description: Placement describes the node scheduling configuration
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              templateValidator:
+                description: TemplateValidator is configuration of the template validator operand
+                properties:
+                  placement:
+                    description: Placement describes the node scheduling configuration
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  replicas:
+                    default: 2
+                    description: Replicas is the number of replicas of the template validator pod
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+            required:
+            - commonTemplates
+            type: object
+          status:
+            description: SSPStatus defines the observed state of SSP
+            properties:
+              conditions:
+                description: A list of current conditions of the resource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the resource
+                type: string
+              operatorVersion:
+                description: The version of the resource as defined by the operator
+                type: string
+              phase:
+                description: Phase is the current phase of the deployment
+                type: string
+              targetVersion:
+                description: The desired version of the resource
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/vm-import-operator00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/manifests/vm-import-operator00.crd.yaml
@@ -1,0 +1,903 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.v2v.kubevirt.io: ""
+  name: vmimportconfigs.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: VMImportConfig
+    listKind: VMImportConfigList
+    plural: vmimportconfigs
+    singular: vmimportconfig
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VMImportConfig is the Schema for the vmimportconfigs API
+        properties:
+          apiVersion:
+            description: APIVersion defines the versioned schema of this representation of an object
+            type: string
+          kind:
+            description: Kind is a string value representing the REST resource this object represents
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VMImportConfigSpec defines the desired state of VMImportConfig
+            properties:
+              imagePullPolicy:
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes vm import infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: VMImportConfigStatus defines the observed state of VMImportConfig
+            properties:
+              conditions:
+                description: A list of current conditions of the VMImportConfig resource
+                items:
+                  properties:
+                    lastHeartbeatTime:
+                      description: Last time the state of the condition was checked
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the state of the condition changed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message related to the last condition change
+                      type: string
+                    reason:
+                      description: Reason the last condition changed
+                      type: string
+                    status:
+                      description: Current status of the condition, True, False, Unknown
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the VMImportConfig resource
+                type: string
+              operatorVersion:
+                description: The version of the VMImportConfig resource as defined by the operator
+                type: string
+              phase:
+                description: VMImportPhase is the current phase of the VMImport deployment
+                type: string
+              targetVersion:
+                description: The desired version of the VMImportConfig resource
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VMImportConfig is the Schema for the vmimportconfigs API
+        properties:
+          apiVersion:
+            description: APIVersion defines the versioned schema of this representation of an object
+            type: string
+          kind:
+            description: Kind is a string value representing the REST resource this object represents
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VMImportConfigSpec defines the desired state of VMImportConfig
+            properties:
+              imagePullPolicy:
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes vm import infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: ' defines the status of the VMImportConfig installation'
+            properties:
+              conditions:
+                description: A list of current conditions of the VMImportConfigresource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the VMImportConfig resource
+                type: string
+              operatorVersion:
+                description: The version of the VMImportConfig resource as defined by the operator
+                type: string
+              phase:
+                description: Phase is the current phase of the VMImportConfig deployment
+                type: string
+              targetVersion:
+                description: The desired version of the VMImportConfig resource
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.3.0/metadata/annotations.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.3.0/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: community-kubevirt-hyperconverged
+  com.redhat.openshift.versions: "=v4.7"

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/cluster-network-addons00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/cluster-network-addons00.crd.yaml
@@ -1,0 +1,3049 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NetworkAddonsConfig is the Schema for the networkaddonsconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkAddonsConfigSpec defines the desired state of NetworkAddonsConfig
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
+                type: string
+              kubeMacPool:
+                description: KubeMacPool plugin manages MAC allocation to Pods and
+                  VMs in Kubernetes
+                properties:
+                  rangeEnd:
+                    description: RangeEnd defines the first mac in range
+                    type: string
+                  rangeStart:
+                    description: RangeStart defines the first mac in range
+                    type: string
+                type: object
+              linuxBridge:
+                description: LinuxBridge plugin allows users to create a bridge and
+                  add the host and the container to it
+                type: object
+              macvtap:
+                description: MacvtapCni plugin allows users to define Kubernetes networks
+                  on top of existing host interfaces
+                type: object
+              multus:
+                description: Multus plugin enables attaching multiple network interfaces
+                  to Pods in Kubernetes
+                type: object
+              nmstate:
+                description: NMState is a declarative node network configuration driven
+                  through Kubernetes API
+                type: object
+              ovs:
+                description: Ovs plugin allows users to define Kubernetes networks
+                  on top of Open vSwitch bridges available on nodes
+                type: object
+              placementConfiguration:
+                description: PlacementConfiguration defines node placement configuration
+                properties:
+                  infra:
+                    description: Infra defines placement configuration for master
+                      nodes
+                    properties:
+                      affinity:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  workloads:
+                    properties:
+                      affinity:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              selfSignConfiguration:
+                description: SelfSignConfiguration defines self sign configuration
+                properties:
+                  caOverlapInterval:
+                    description: CAOverlapInterval defines the duration of CA Certificates
+                      at CABundle if not set it will default to CARotateInterval
+                    type: string
+                  caRotateInterval:
+                    description: CARotateInterval defines duration for CA and certificate
+                    type: string
+                  certRotateInterval:
+                    description: CertRotateInterval defines duration for of service
+                      certificate
+                    type: string
+                type: object
+            type: object
+          status:
+            description: NetworkAddonsConfigStatus defines the observed state of NetworkAddonsConfig
+            properties:
+              conditions:
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              containers:
+                items:
+                  properties:
+                    image:
+                      type: string
+                    name:
+                      type: string
+                    parentKind:
+                      type: string
+                    parentName:
+                      type: string
+                  required:
+                  - image
+                  - name
+                  - parentKind
+                  - parentName
+                  type: object
+                type: array
+              observedVersion:
+                type: string
+              operatorVersion:
+                type: string
+              targetVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetworkAddonsConfig is the Schema for the networkaddonsconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkAddonsConfigSpec defines the desired state of NetworkAddonsConfig
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
+                type: string
+              kubeMacPool:
+                description: KubeMacPool plugin manages MAC allocation to Pods and
+                  VMs in Kubernetes
+                properties:
+                  rangeEnd:
+                    description: RangeEnd defines the first mac in range
+                    type: string
+                  rangeStart:
+                    description: RangeStart defines the first mac in range
+                    type: string
+                type: object
+              linuxBridge:
+                description: LinuxBridge plugin allows users to create a bridge and
+                  add the host and the container to it
+                type: object
+              macvtap:
+                description: MacvtapCni plugin allows users to define Kubernetes networks
+                  on top of existing host interfaces
+                type: object
+              multus:
+                description: Multus plugin enables attaching multiple network interfaces
+                  to Pods in Kubernetes
+                type: object
+              nmstate:
+                description: NMState is a declarative node network configuration driven
+                  through Kubernetes API
+                type: object
+              ovs:
+                description: Ovs plugin allows users to define Kubernetes networks
+                  on top of Open vSwitch bridges available on nodes
+                type: object
+              placementConfiguration:
+                description: PlacementConfiguration defines node placement configuration
+                properties:
+                  infra:
+                    description: Infra defines placement configuration for master
+                      nodes
+                    properties:
+                      affinity:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  workloads:
+                    properties:
+                      affinity:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              selfSignConfiguration:
+                description: SelfSignConfiguration defines self sign configuration
+                properties:
+                  caOverlapInterval:
+                    description: CAOverlapInterval defines the duration of CA Certificates
+                      at CABundle if not set it will default to CARotateInterval
+                    type: string
+                  caRotateInterval:
+                    description: CARotateInterval defines duration for CA and certificate
+                    type: string
+                  certRotateInterval:
+                    description: CertRotateInterval defines duration for of service
+                      certificate
+                    type: string
+                type: object
+            type: object
+          status:
+            description: NetworkAddonsConfigStatus defines the observed state of NetworkAddonsConfig
+            properties:
+              conditions:
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              containers:
+                items:
+                  properties:
+                    image:
+                      type: string
+                    name:
+                      type: string
+                    parentKind:
+                      type: string
+                    parentName:
+                      type: string
+                  required:
+                  - image
+                  - name
+                  - parentKind
+                  - parentName
+                  type: object
+                type: array
+              observedVersion:
+                type: string
+              operatorVersion:
+                type: string
+              targetVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  preserveUnknownFields: false

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/containerized-data-importer00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/containerized-data-importer00.crd.yaml
@@ -1,0 +1,1843 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.cdi.kubevirt.io: ""
+  name: cdis.cdi.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: cdi.kubevirt.io
+  names:
+    kind: CDI
+    listKind: CDIList
+    plural: cdis
+    shortNames:
+    - cdi
+    - cdis
+    singular: cdi
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CDI is the CDI Operator CRD
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CDISpec defines our specification for the CDI installation
+            properties:
+              certConfig:
+                description: certificate configuration
+                properties:
+                  ca:
+                    description: CA configuration CA certs are kept in the CA bundle as long as they are valid
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued certificate's `notAfter` time that we will begin to attempt to renew the certificate.
+                        type: string
+                    type: object
+                  server:
+                    description: Server configuration Certs are rotated and discarded
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued certificate's `notAfter` time that we will begin to attempt to renew the certificate.
+                        type: string
+                    type: object
+                type: object
+              cloneStrategyOverride:
+                description: 'Clone strategy override: should we use a host-assisted copy even if snapshots are available?'
+                enum:
+                - copy
+                - snapshot
+                type: string
+              config:
+                description: CDIConfig at CDI level
+                properties:
+                  filesystemOverhead:
+                    description: FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)
+                    properties:
+                      global:
+                        description: Global is how much space of a Filesystem volume should be reserved for overhead. This value is used unless overridden by a more specific value (per storageClass)
+                        pattern: ^(0(?:\.\d{1,3})?|1)$
+                        type: string
+                      storageClass:
+                        additionalProperties:
+                          description: 'Percent is a string that can only be a value between [0,1) (Note: we actually rely on reconcile to reject invalid values)'
+                          pattern: ^(0(?:\.\d{1,3})?|1)$
+                          type: string
+                        description: StorageClass specifies how much space of a Filesystem volume should be reserved for safety. The keys are the storageClass and the values are the overhead. This value overrides the global value
+                        type: object
+                    type: object
+                  podResourceRequirements:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  scratchSpaceStorageClass:
+                    description: 'Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn''t exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space'
+                    type: string
+                  uploadProxyURLOverride:
+                    description: Override the URL used when uploading to a DataVolume
+                    type: string
+                type: object
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes CDI infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              uninstallStrategy:
+                description: CDIUninstallStrategy defines the state to leave CDI on uninstall
+                enum:
+                - RemoveWorkloads
+                - BlockUninstallIfWorkloadsExist
+                type: string
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: CDIStatus defines the status of the installation
+            properties:
+              conditions:
+                description: A list of current conditions of the resource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the resource
+                type: string
+              operatorVersion:
+                description: The version of the resource as defined by the operator
+                type: string
+              phase:
+                description: Phase is the current phase of the deployment
+                type: string
+              targetVersion:
+                description: The desired version of the resource
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CDI is the CDI Operator CRD
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CDISpec defines our specification for the CDI installation
+            properties:
+              certConfig:
+                description: certificate configuration
+                properties:
+                  ca:
+                    description: CA configuration CA certs are kept in the CA bundle as long as they are valid
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued certificate's `notAfter` time that we will begin to attempt to renew the certificate.
+                        type: string
+                    type: object
+                  server:
+                    description: Server configuration Certs are rotated and discarded
+                    properties:
+                      duration:
+                        description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                        type: string
+                      renewBefore:
+                        description: The amount of time before the currently issued certificate's `notAfter` time that we will begin to attempt to renew the certificate.
+                        type: string
+                    type: object
+                type: object
+              cloneStrategyOverride:
+                description: 'Clone strategy override: should we use a host-assisted copy even if snapshots are available?'
+                enum:
+                - copy
+                - snapshot
+                type: string
+              config:
+                description: CDIConfig at CDI level
+                properties:
+                  featureGates:
+                    description: FeatureGates are a list of specific enabled feature gates
+                    items:
+                      type: string
+                    type: array
+                  filesystemOverhead:
+                    description: FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)
+                    properties:
+                      global:
+                        description: Global is how much space of a Filesystem volume should be reserved for overhead. This value is used unless overridden by a more specific value (per storageClass)
+                        pattern: ^(0(?:\.\d{1,3})?|1)$
+                        type: string
+                      storageClass:
+                        additionalProperties:
+                          description: 'Percent is a string that can only be a value between [0,1) (Note: we actually rely on reconcile to reject invalid values)'
+                          pattern: ^(0(?:\.\d{1,3})?|1)$
+                          type: string
+                        description: StorageClass specifies how much space of a Filesystem volume should be reserved for safety. The keys are the storageClass and the values are the overhead. This value overrides the global value
+                        type: object
+                    type: object
+                  podResourceRequirements:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  preallocation:
+                    description: Preallocation controls whether storage for DataVolumes should be allocated in advance.
+                    type: boolean
+                  scratchSpaceStorageClass:
+                    description: 'Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn''t exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space'
+                    type: string
+                  uploadProxyURLOverride:
+                    description: Override the URL used when uploading to a DataVolume
+                    type: string
+                type: object
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes CDI infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              uninstallStrategy:
+                description: CDIUninstallStrategy defines the state to leave CDI on uninstall
+                enum:
+                - RemoveWorkloads
+                - BlockUninstallIfWorkloadsExist
+                type: string
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: CDIStatus defines the status of the installation
+            properties:
+              conditions:
+                description: A list of current conditions of the resource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the resource
+                type: string
+              operatorVersion:
+                description: The version of the resource as defined by the operator
+                type: string
+              phase:
+                description: Phase is the current phase of the deployment
+                type: string
+              targetVersion:
+                description: The desired version of the resource
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/hco00.crd.yaml
@@ -1,0 +1,1623 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hyperconvergeds.hco.kubevirt.io
+spec:
+  group: hco.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: HyperConverged
+    listKind: HyperConvergedList
+    plural: hyperconvergeds
+    shortNames:
+    - hco
+    - hcos
+    singular: hyperconverged
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HyperConverged is the Schema for the hyperconvergeds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                pattern: kubevirt-hyperconverged
+                type: string
+            type: object
+          spec:
+            description: HyperConvergedSpec defines the desired state of HyperConverged
+            properties:
+              featureGates:
+                default:
+                  hypervStrictCheck: true
+                  withHostModelCPU: true
+                  withHostPassthroughCPU: false
+                description: featureGates is a map of feature gate flags. Setting
+                  a flag to `true` will enable the feature. Setting `false` or removing
+                  the feature gate, disables the feature.
+                properties:
+                  hotplugVolumes:
+                    description: Allow attaching a data volume to a running VMI
+                    type: boolean
+                  hypervStrictCheck:
+                    default: true
+                    description: Enable HyperV strict host checking for HyperV enlightenments
+                      Defaults to true, even when HyperConvergedFeatureGates is empty
+                    type: boolean
+                  sriovLiveMigration:
+                    description: Allow migrating a virtual machine with SRIOV interfaces.
+                      When enabled virt-launcher pods of virtual machines with SRIOV
+                      interfaces run with CAP_SYS_RESOURCE capability. This may degrade
+                      virt-launcher security.
+                    type: boolean
+                  withHostModelCPU:
+                    default: true
+                    description: Support migration for VMs with host-model CPU mode
+                    type: boolean
+                  withHostPassthroughCPU:
+                    default: false
+                    description: Allow migrating a virtual machine with CPU host-passthrough
+                      mode. This should be enabled only when the Cluster is homogeneous
+                      from CPU HW perspective doc here
+                    type: boolean
+                type: object
+              infra:
+                description: infra HyperConvergedConfig influences the pod configuration
+                  (currently only placement) for all the infra components needed on
+                  the virtualization enabled cluster but not necessarely directly
+                  on each node running VMs/VMIs.
+                properties:
+                  nodePlacement:
+                    description: NodePlacement describes node scheduling configuration.
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement
+                          expanding the types of constraints that can be expressed
+                          with nodeSelector. affinity is going to be applied to the
+                          relevant kind of pods in parallel with nodeSelector See
+                          https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to
+                          the relevant kind of pods It specifies a map of key-value
+                          pairs: for the pod to be eligible to run on a node, the
+                          node must have each of the indicated key-value pairs as
+                          labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied
+                          to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                          for more info. These are additional tolerations other than
+                          default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              localStorageClassName:
+                description: LocalStorageClassName the name of the local storage class.
+                type: string
+              version:
+                description: operator version
+                type: string
+              workloads:
+                description: workloads HyperConvergedConfig influences the pod configuration
+                  (currently only placement) of components which need to be running
+                  on a node where virtualization workloads should be able to run.
+                  Changes to Workloads HyperConvergedConfig can be applied only without
+                  existing workload.
+                properties:
+                  nodePlacement:
+                    description: NodePlacement describes node scheduling configuration.
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement
+                          expanding the types of constraints that can be expressed
+                          with nodeSelector. affinity is going to be applied to the
+                          relevant kind of pods in parallel with nodeSelector See
+                          https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to
+                          the relevant kind of pods It specifies a map of key-value
+                          pairs: for the pod to be eligible to run on a node, the
+                          node must have each of the indicated key-value pairs as
+                          labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied
+                          to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                          for more info. These are additional tolerations other than
+                          default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            type: object
+          status:
+            description: HyperConvergedStatus defines the observed state of HyperConverged
+            properties:
+              conditions:
+                description: Conditions describes the state of the HyperConverged
+                  resource.
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              relatedObjects:
+                description: RelatedObjects is a list of objects created and maintained
+                  by this operator. Object references will be added to this list after
+                  they have been created AND found in the cluster.
+                items:
+                  description: 'ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs.  1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage.  2.
+                    Invalid usage help.  It is impossible to add specific help for
+                    individual usage.  In most embedded usages, there are particular     restrictions
+                    like, "must refer only to types A and B" or "UID not honored"
+                    or "name must be restricted".     Those cannot be well described
+                    when embedded.  3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen.  4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity     during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple     and the version of the actual
+                    struct is irrelevant.  5. We cannot easily change it.  Because
+                    this type is embedded in many locations, updates to this type     will
+                    affect numerous schemas.  Don''t make new APIs embed an underspecified
+                    API type they do not control. Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              versions:
+                description: 'Versions is a list of HCO component versions, as name/version
+                  pairs. The version with a name of "operator" is the HCO version
+                  itself, as described here: https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version'
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/hco01.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/hco01.crd.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: v2vvmwares.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    kind: V2VVmware
+    listKind: V2VVmwareList
+    plural: v2vvmwares
+    singular: v2vvmware
+  scope: Namespaced
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/hco02.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/hco02.crd.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ovirtproviders.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    kind: OVirtProvider
+    listKind: OVirtProviderList
+    plural: ovirtproviders
+    singular: ovirtprovider
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: OVirtProvider is the Schema for the ovirtproviders API
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation
+                                    of an object. Servers should convert recognized schemas to the latest
+                                    internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this
+                                    object represents. Servers may infer this from the endpoint the client
+                                    submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: OVirtProviderSpec defines the desired state of OVirtProvider
+          properties:
+            connection:
+              type: string
+            timeToLive:
+              type: string
+            vms:
+              items:
+                description: OVirtVM aligns with maintained UI interface
+                properties:
+                  cluster:
+                    type: string
+                  detail:
+                    description: OVirtVMDetail contains ovirt vm details as json string
+                    properties:
+                      raw:
+                        type: string
+                    type: object
+                  detailRequest:
+                    type: boolean
+                  id:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - cluster
+                - id
+                - name
+                type: object
+              type: array
+          type: object
+        status:
+          description: OVirtProviderStatus defines the observed state of OVirtProvider
+          properties:
+            phase:
+              description: VirtualMachineProviderPhase defines provider phase
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/hostpath-provisioner00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/hostpath-provisioner00.crd.yaml
@@ -1,0 +1,925 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.hostpathprovisioner.kubevirt.io: ""
+  name: hostpathprovisioners.hostpathprovisioner.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: hostpathprovisioner.kubevirt.io
+  names:
+    kind: HostPathProvisioner
+    listKind: HostPathProvisionerList
+    plural: hostpathprovisioners
+    shortNames:
+    - hpp
+    - hpps
+    singular: hostpathprovisioner
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HostPathProvisioner is the Schema for the hostpathprovisioners API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostPathProvisionerSpec defines the desired state of HostPathProvisioner
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              imageRegistry:
+                type: string
+              imageTag:
+                type: string
+              pathConfig:
+                description: PathConfig describes the location and layout of PV storage on nodes
+                properties:
+                  path:
+                    description: Path The path the directories for the PVs are created under
+                    type: string
+                  useNamingPrefix:
+                    description: UseNamingPrefix Use the name of the PVC requesting the PV as part of the directory created
+                    type: string
+                type: object
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - pathConfig
+            type: object
+          status:
+            description: HostPathProvisionerStatus defines the observed state of HostPathProvisioner
+            properties:
+              conditions:
+                description: Conditions contains the current conditions observed by the operator
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: ObservedVersion The observed version of the HostPathProvisioner deployment
+                type: string
+              operatorVersion:
+                description: OperatorVersion The version of the HostPathProvisioner Operator
+                type: string
+              targetVersion:
+                description: TargetVersion The targeted version of the HostPathProvisioner deployment
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HostPathProvisioner is the Schema for the hostpathprovisioners API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostPathProvisionerSpec defines the desired state of HostPathProvisioner
+            properties:
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              imageRegistry:
+                type: string
+              imageTag:
+                type: string
+              pathConfig:
+                description: PathConfig describes the location and layout of PV storage on nodes
+                properties:
+                  path:
+                    description: Path The path the directories for the PVs are created under
+                    type: string
+                  useNamingPrefix:
+                    description: UseNamingPrefix Use the name of the PVC requesting the PV as part of the directory created
+                    type: boolean
+                type: object
+              workload:
+                description: Restrict on which nodes CDI workload pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - pathConfig
+            type: object
+          status:
+            description: HostPathProvisionerStatus defines the observed state of HostPathProvisioner
+            properties:
+              conditions:
+                description: Conditions contains the current conditions observed by the operator
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: ObservedVersion The observed version of the HostPathProvisioner deployment
+                type: string
+              operatorVersion:
+                description: OperatorVersion The version of the HostPathProvisioner Operator
+                type: string
+              targetVersion:
+                description: TargetVersion The targeted version of the HostPathProvisioner deployment
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/kubevirt-hyperconverged-operator.v1.4.0.clusterserviceversion.yaml
@@ -1,0 +1,2700 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}},{"apiVersion":"networkaddonsoperator.network.kubevirt.io/v1","kind":"NetworkAddonsConfig","metadata":{"name":"cluster"},"spec":{"imagePullPolicy":"IfNotPresent","kubeMacPool":{"rangeEnd":"FD:FF:FF:FF:FF:FF","rangeStart":"02:00:00:00:00:00"},"linuxBridge":{},"macvtap":{},"multus":{},"nmstate":{},"ovs":{}}},{"apiVersion":"kubevirt.io/v1","kind":"KubeVirt","metadata":{"name":"kubevirt","namespace":"kubevirt"},"spec":{"imagePullPolicy":"Always"}},{"apiVersion":"ssp.kubevirt.io/v1beta1","kind":"SSP","metadata":{"name":"ssp-sample","namespace":"kubevirt"},"spec":{"commonTemplates":{"namespace":"kubevirt"},"templateValidator":{"replicas":2}}},{"apiVersion":"cdi.kubevirt.io/v1beta1","kind":"CDI","metadata":{"name":"cdi","namespace":"cdi"},"spec":{"imagePullPolicy":"IfNotPresent"}},{"apiVersion":"nodemaintenance.kubevirt.io/v1beta1","kind":"NodeMaintenance","metadata":{"name":"nodemaintenance-example"},"spec":{"nodeName":"node02","reason":"Test
+      node maintenance"}},{"apiVersion":"hostpathprovisioner.kubevirt.io/v1beta1","kind":"HostPathProvisioner","metadata":{"name":"hostpath-provisioner"},"spec":{"imagePullPolicy":"IfNotPresent","pathConfig":{"path":"/var/hpvolumes","useNamingPrefix":false}}},{"apiVersion":"v2v.kubevirt.io/v1beta1","kind":"VMImportConfig","metadata":{"name":"vm-import-operator-config"},"spec":{"imagePullPolicy":"IfNotPresent"}}]'
+    capabilities: Full Lifecycle
+    categories: OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:ca0ad2865a5d70abc8d1f5670c4191502eda2e8b68849e0b9f78f72e41cf7cc5
+    createdAt: "2021-02-22 19:52:47"
+    description: |-
+      **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+      Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+      Containerized Data Importer (CDI), Virtual Machine import operator and Cluster Network Addons (CNA) operators.
+
+      **KubeVirt** is a virtual machine management add-on for Kubernetes.
+      The aim is to provide a common ground for virtualization solutions on top of
+      Kubernetes.
+
+      # Virtualization extension for Kubernetes
+
+      At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+      additional virtualization resource types (especially the `VirtualMachine` type) through
+      [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+      By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+      resources alongside all other resources Kubernetes provides.
+
+      The resources themselves are not enough to launch virtual machines.
+      For this to happen the _functionality and business logic_ needs to be added to
+      the cluster. The functionality is not added to Kubernetes itself, but rather
+      added to a Kubernetes cluster by _running_ additional controllers and agents
+      on an existing cluster.
+
+      The necessary controllers and agents are provided by KubeVirt.
+
+      As of today KubeVirt can be used to declaratively
+
+        * Create a predefined VM
+        * Schedule a VM on a Kubernetes cluster
+        * Launch a VM
+        * Migrate a VM
+        * Stop a VM
+        * Delete a VM
+
+      # Start using KubeVirt
+
+        * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+        * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+      # Start developing KubeVirt
+
+      To set up a development environment please read our
+      [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+      To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+      You can learn more about how KubeVirt is designed (and why it is that way),
+      and learn more about the major components by taking a look at our developer documentation:
+
+        * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+        * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+        * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+      # Community
+
+      If you got enough of code and want to speak to people, then you got a couple of options:
+
+        * Follow us on [Twitter](https://twitter.com/kubevirt)
+        * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+        * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+        * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+      # License
+
+      KubeVirt is distributed under the
+      [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+    operatorframework.io/initialization-resource: '{"apiVersion":"hco.kubevirt.io/v1beta1","kind":"HyperConverged","metadata":{"annotations":{"deployOVS":"false"},"name":"kubevirt-hyperconverged","namespace":"kubevirt-hyperconverged"},"spec":{}}'
+    operatorframework.io/suggested-namespace: kubevirt-hyperconverged
+    operators.operatorframework.io/internal-objects: '["v2vvmwares.v2v.kubevirt.io","ovirtproviders.v2v.kubevirt.io","networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io","kubevirts.kubevirt.io","ssps.ssp.kubevirt.io","cdis.cdi.kubevirt.io","nodemaintenances.nodemaintenance.kubevirt.io","vmimportconfigs.v2v.kubevirt.io"]'
+    repository: https://github.com/kubevirt/hyperconverged-cluster-operator
+    support: "false"
+  name: kubevirt-hyperconverged-operator.v1.4.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents the deployment of HyperConverged Cluster Operator
+      displayName: HyperConverged Cluster Operator Deployment
+      kind: HyperConverged
+      name: hyperconvergeds.hco.kubevirt.io
+      specDescriptors:
+      - description: nodeAffinity describes node affinity scheduling rules for the
+          infra pods.
+        displayName: Infra components node affinity
+        path: infra.nodePlacement.affinity.nodeAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+      - description: podAffinity describes pod affinity scheduling rules for the infra
+          pods.
+        displayName: Infra components pod affinity
+        path: infra.nodePlacement.affinity.podAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAffinity
+      - description: podAntiAffinity describes pod anti affinity scheduling rules
+          for the infra pods.
+        displayName: Infra components pod anti-affinity
+        path: infra.nodePlacement.affinity.podAntiAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
+      - description: nodeAffinity describes node affinity scheduling rules for the
+          workloads pods.
+        displayName: Workloads components node affinity
+        path: workloads.nodePlacement.affinity.nodeAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+      - description: podAffinity describes pod affinity scheduling rules for the workloads
+          pods.
+        displayName: Workloads components pod affinity
+        path: workloads.nodePlacement.affinity.podAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAffinity
+      - description: podAntiAffinity describes pod anti affinity scheduling rules
+          for the workloads pods.
+        displayName: Workloads components pod anti-affinity
+        path: workloads.nodePlacement.affinity.podAntiAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
+      - description: HIDDEN FIELDS - operator version.
+        displayName: HIDDEN FIELDS - operator version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      version: v1beta1
+    - description: V2V Vmware
+      displayName: V2V Vmware
+      kind: V2VVmware
+      name: v2vvmwares.v2v.kubevirt.io
+      version: v1alpha1
+    - description: V2V oVirt
+      displayName: V2V oVirt
+      kind: OVirtProvider
+      name: ovirtproviders.v2v.kubevirt.io
+      version: v1alpha1
+    - description: Cluster Network Addons
+      displayName: Cluster Network Addons
+      kind: NetworkAddonsConfig
+      name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+      version: v1
+    - description: Represents a KubeVirt deployment
+      displayName: KubeVirt deployment
+      kind: KubeVirt
+      name: kubevirts.kubevirt.io
+      version: v1
+    - description: SSP is the Schema for the ssps API
+      displayName: SSP
+      kind: SSP
+      name: ssps.ssp.kubevirt.io
+      version: v1beta1
+    - description: Represents a CDI deployment
+      displayName: CDI deployment
+      kind: CDI
+      name: cdis.cdi.kubevirt.io
+      version: v1beta1
+    - description: NodeMaintenance is the Schema for the nodemaintenances API
+      kind: NodeMaintenance
+      name: nodemaintenances.nodemaintenance.kubevirt.io
+      version: v1beta1
+    - description: Represents a HostPathProvisioner deployment
+      displayName: HostPathProvisioner deployment
+      kind: HostPathProvisioner
+      name: hostpathprovisioners.hostpathprovisioner.kubevirt.io
+      version: v1beta1
+    - description: Represents a virtual machine import config
+      displayName: Virtual Machine import config
+      kind: VMImportConfig
+      name: vmimportconfigs.v2v.kubevirt.io
+      version: v1beta1
+  description: |-
+    **HyperConverged Cluster Operator** is an Operator pattern for managing multi-operator products.
+    Specifcally, the HyperConverged Cluster Operator manages the deployment of KubeVirt,
+    Containerized Data Importer (CDI), Virtual Machine import operator and Cluster Network Addons (CNA) operators.
+
+    **KubeVirt** is a virtual machine management add-on for Kubernetes.
+    The aim is to provide a common ground for virtualization solutions on top of
+    Kubernetes.
+
+    # Virtualization extension for Kubernetes
+
+    At its core, KubeVirt extends [Kubernetes](https://kubernetes.io) by adding
+    additional virtualization resource types (especially the `VirtualMachine` type) through
+    [Kubernetes's Custom Resource Definitions API](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+    By using this mechanism, the Kubernetes API can be used to manage these `VirtualMachine`
+    resources alongside all other resources Kubernetes provides.
+
+    The resources themselves are not enough to launch virtual machines.
+    For this to happen the _functionality and business logic_ needs to be added to
+    the cluster. The functionality is not added to Kubernetes itself, but rather
+    added to a Kubernetes cluster by _running_ additional controllers and agents
+    on an existing cluster.
+
+    The necessary controllers and agents are provided by KubeVirt.
+
+    As of today KubeVirt can be used to declaratively
+
+      * Create a predefined VM
+      * Schedule a VM on a Kubernetes cluster
+      * Launch a VM
+      * Migrate a VM
+      * Stop a VM
+      * Delete a VM
+
+    # Start using KubeVirt
+
+      * Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
+      * See our user documentation at [kubevirt.io/docs](http://kubevirt.io/user-guide).
+
+    # Start developing KubeVirt
+
+    To set up a development environment please read our
+    [Getting Started Guide](https://github.com/kubevirt/kubevirt/blob/master/docs/getting-started.md).
+    To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
+
+    You can learn more about how KubeVirt is designed (and why it is that way),
+    and learn more about the major components by taking a look at our developer documentation:
+
+      * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
+      * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
+      * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+
+    # Community
+
+    If you got enough of code and want to speak to people, then you got a couple of options:
+
+      * Follow us on [Twitter](https://twitter.com/kubevirt)
+      * Chat with us in the #virtualization channel of the [Kubernetes Slack](https://slack.k8s.io/)
+      * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
+      * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
+
+    # License
+
+    KubeVirt is distributed under the
+    [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+  displayName: KubeVirt HyperConverged Cluster Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAARgAAAEYCAYAAACHjumMAABam0lEQVR4nOydB3gb9fn4v3faw5Js2fKSvO0kkrMTsCFgBQKEslqIzB+6AAcocVpIKD9aWrBSaKEtJKUQEjLKKO0PLFo2hG1DEpvEcZYl7ynZkqf2lu7+jx2HXxLfOZJO077P8+Qp1ffu9Fo6vfd+30kFJCTTKBQKLgBgoUKhKAEA5AIAssRicVp5efnk62wAADL9zzv5r6GhwarT6QYAAL0qleqEVqs92djY6I3130FCQhJHVFRUcFpaWl5CUdSPEmMMRdFdCoUiP9Z/EwkJSYxRKBRFhw8f3o6iqImgYrkQF4qiHz/33HO3SqVSONZ/JwkJSRSpqKjgTlss0aCttrZ2baz/ZhISkgijUChKDh8+/DcURc1RUi5nmdx6ff3cc88ppFIpJdafAwkJSRipqKjgtbS0vBxlpYJHV21t7bWx/kxIogMUawFIIkdZWZl4+/bt/1NeXn4XACAp0PMQAGxDTqel3Wpnj7s9DA+CuLwIgkyaIQgAKAwgiEWBqRwqlV3M5TiKkzhUOgxzgxANBQAc2r59++4dO3a8qdPp/KH9hSTxDqlg5iBSqZS1c+fOR+Ry+f8AADiBnudDENsjp1qtz3f2pKEABJzCQIEgz63ZmdpfLyhkXJIiEAcp7mGlUnn/tm3bWoI8jyQBIBXMHGLSYtm6dWuVQqHYCAAI+Ifeb3eYdnX3gZd7+hkmr48V6vtDAHivzxCNVhfloT/ITBcBAGgBnopqtdoP9u/fv2v//v2fkxbN3IFUMHMAqVTK2blz5//I5fJfTyfEBcSkxbL1pNr2QldfRrhlKuUl9e9ZtRSUC5Nzgzz1u2mL5mS4ZSKJPqSCSWDKyspypi2We4KxWHpsdtPunn6wu7ufafX5mBEU0XdNetrIpsJc9IfZmWkAAHqgJ2q12o+mLZpPdTqdL4IykkQQUsEkIFKplLtz587fyOXyrQCAgLc0XgSxPXi8xbarpz/sFsvFKOZytPtWLfVfmSbMC/LUY0ql8hfbtm1ripBoJBGEVDAJhEKhyFUoFBunLZasQM/rstlNL3f3o7u6+1h2vz+SFsvF8MvThCObCvMQhSRLCAAIWBatVvvptEXzsU6nI+udEgRSwSQACoUiqba29jEAwEPB/Ch9COLc1Hzasrd3ID2yEgZPDps1tH/VMte69NSCIE89qVQqN23btu1whEQjCSOkgoljtmzZkl9VVXWvTCa7CwCQGeh5Q06X/ZU+rXdfTz+tz+EMOEwdA5AfZmXoHyjMg67NSJu0aBiBnqjVar+ctmg+0Ol0nsiKSRIqpIKJQxQKBa+2tvZxAMAvg/nReRHE8df2bstTrZ3JTr8/4PPigbKU5MG9q5Y4Svm84iBPbVEqlZu3bdtWHyHRSAhAKpg4QqFQ8Lds2bKxvLz8EQBAwNuaQafL/o/eAe++3gHaQHxbLBcDvT5DpK8uygPXZ6anwMH5aOp37NixTaVSHdbpdO7IikkSKKSCiQMqKiqgnTt3/lImkz0TTFTIgyCOP7d1Wf7U2pniQpCAQ8CJwMpkwdDuFUtsq1L4JUGe2lZZWXm7SqU6FSHRSIKAVDAxRKFQJE9bLA8AAAJu0qR1OKcslv29AzSt05XIFstFuVqUOrS5KB+6KStdQIGgQJWvBwDw0fbt26cygzUaTYSlJMGDVDAxYNpieUgmk/0pmKiQy++3P9PWZX26rSvFM8cslouxhM/Tv7RisfXy1JTiIO/b71Qq1QOVlZXHIygeCQ6kgokiCoUiZcuWLfeVl5f/YrrnbUAMOJz2/T393v19Wvqg0xVwKcBc5MrUFP3monz0h9kZAhoMB/pZeAEAB7Zv3/7S/v37D5AWTfQgFUyEEYvFUFVVVVlVVdUmiURyezAFgF+PjBlf7OqD3xsycP0oSjZoP4dsFtN4T36OsypPwsjlsIVBnNrb0NCwa8eOHftUKpUxgiKSkAomstTU1OQolcpdAIAfBHPeSZNlYlPzKd/hcaMoctLNDagQ5Pz1gkLtE9KSNBaFkhzEqS61Wv276urqHfX19WgERZzXkAomzExbLJdNWyyVIPC+KugJk9m8u7sf2dc7wPejKNlaMggymAzT1pIC123ZmbQCLicYi2agoaFh944dO/aoVKrxCIo4LyEVTBipqanJUyqVuwEA1wVznsnjndjYdBL5z6A+NXLSzQ9gANx/X764p7oorzCY6m0AgEetVtdUV1f/pb6+HomgiPMKUsEQZNpiuaKqquoBiUSyIQiLBWk2mi27u/uQV/q0PB/pYwkruWzWyP2Fucimwjwqn0YLRnEPNjQ0vLxjx46XVSrVSARFnBeQCoYACoUivba29g0AwLpgzpvweMarjp5E3x0ykBZLhIEBcP1lyaLehxcU5QeTEgAA8KrV6icrKyv/qNFoSIsmREgFEwJbtmwpnbRYZDLZnQAAQYCnIUcnTJaXe/qRV/u0pI8lymSxmGO/KMj1bSrKg4V0ejDO89Mqlerl7du3/6uxsdEUQRHnJKSCCQKFQpFZW1v7DADgxwCAgBXEmNszds/RE9AH+uFgnI8kkcHzpGxh9++lxTnBNEQHAAzX1dX9rrq6+lWNRkP2DA4QUsEEwJYtW5ZMWyx3AAD4AZ6GfDdhtOzu6kde79fxEUBaLPGEiEEff6Awz/tAYR6UzmQE0y+nddqi+WdjY+NEBEWcE5AKZhYUCkVWbW3tXwAAd5zZzgfGsMs9es/RE/DHhhHSYol/fI8tKup8snSRGA5idtSkYVpXV/dEdXX1Xo1GQ/YMxoFUMBhs2bJl2bTF8v8AALwAT/M3jButu7v7kDf6dQIkCIVEEnuS6TTjpsI89y8KcoGYzQqmZ3HHtEXzemNj41gERUxISAVzDgqFQlxbW/vs5H8GY7Hona6Re5pOUg8YRlIiKyFJFEAeKi7oeHapNIMCQYE68CeZqKur+0N1dfUujUZDdtibhlQwZyyWFdMWy+3BjFhts9gsT7V2+P49MChASYtlTpFEpZo3FeY5tpQUMNOZjGBKELpVKtWe7du3v9rY2Djv82jmtYJRKBQ5tbW1zwEAbgvmsxh3e8yPnW517u0dEJGKZW7DoVAsNbIFhq0lBZkUCArGR2Ouq6t7qrq6+gWNRjNvO+zNSwWzZcuWVVVVVZtkMtnkVijgoe2tFqtlV3c/8s9+HdPk9cZy/AdJlMnjsIwb83Ncd+flMLJYzGC2wr0qlWrf9u3bX2lsbNRHUMS4ZF4pmIqKCtbOnTv/JJPJHgzmbx91u82/OdXqfKVPm47Os8+M5HyYMGz73aLioUcXFqXTYDjQlIVJrHV1dc9UV1fv0Gg0zgiKGFfMix+LQqHI37Jly6by8vIqAEDA+2n1pMXS1Ye8MaBjmr0RHbFKkmBIWCzjPfkSZ1V+DlPCZgVj0Qxs37796f3797+u0WgcERQxLpjTCqaiooK9c+fOZ2Qy2S+DOW/Y5TY9ekrjeq1flz7XPyMSYtAgyPHowiLd7xYVi5gUSjBRJ5NKpXqosrLytQiKF3Pm5I9HoVAUnmOxBGzGnjZbzbu6e9F/9Q+yLD5fQs0VIoktWUyG6a78HOfG/Bx6fnAd9jTTzclf0Wg09giKGBPmjIIRi8W0qqqqH0y3TQi4HwsCgOetgUHbru4++NuxiWCeQCQkM4AB8NyQlT6+uTAfuTYjLT2I9h3OhoaG13fs2LGroaHhpE6ni7Ck0WFOKJiamppypVL5EgBgWTDnfTY8Olx19ART53QF46wjIQmI5QJ+7+6VS6iXpAgkQZ76plKp/NW2bdtGIyRa1EhYBSMWi+lVVVU3TLemDLgfCwKA93/7dZMWC3Ro3EhaLCQRBQLAtz4jbXRTYT5yY1a6KIim7y6tVvuv6fnbxxLVoklIBVNTU7NGqVTuBAAsCeY8jcVquLfpJOPwuDGYzEwSkrAg5SX17125BFyWmhLwyJpp/jM9f9sQIdEiRsIomGmL5aZpi+WqQM+btFg+04/YX+ruQz/QD5OKhSTW+O+UZBt+UZgLX5EmTA3CovFotdp/T1s0RxLFokkIBVNTU1OhVCpfBACUBnPeabNFf2/TKeZ3E6TFQhJ/rE1L1f5j9VJfHocd8NjgaT5QKpWbtm3bFvdaJq4VzJYtW+RbtmypkUgk8kDPQQDwHNAPO3Z29aEfG0ZIxUIS7/g3iDMNDxTmQVeJUlODmITg1Wq1b+3YseOpHTt2tEdYxpCJSwWjUChKa2trdwIArgzmvOMms+H+plOMo0YTqVhIEo41qSm6fauWuhckcQuDOM0HAPhHZWXl71UqVdxFneJKwWzZskVWVVX1qEwmqwQABJTo5keB5xP9sP3Frl7o0+FRMipEkuggN2Wl6zcV5sHXZYhSoAB/BwCACbVa/a/9+/dPWjWHIixjwMSFgpFKpWDnzp33yeXyvwEAWIGe1zRhMtzffIrZbDSTioVkznFpSvLgnpVLHEsEvOIgTz1QWVl5l0qlGo6QaAETcwUjlUqFBw4c2C6RSH4WyPF+FPV8ODTs2NnVCz4fGSMVC8lcB12fkaavLsoHP8hMT4EDn+00qFKpfrd169Z/6nS6mM11iqmCqampKVEqlQcBAGkAAD0AIHO24xsnjIYHmk4xT5gtpGIhmXesEPCHdq1cbL8kJTlgi0atVu8sLS3dHFnJ8ImZgqmpqVmiVCr/AwAomn7JON2u8rzaDR+CuD/QDztf7OoDX5EWCwkJuEqUqt9cmIfenJ0hoEAQO4BTnpBIJE/pdDo0CuKdR0wUTE1NTb5SqTyF0U3OdO6kxA6rzaJoOIacIi0WEpIZLOYn6d8qW4ks4iVlz3LY5IM7Wa1W/7a0tPSZKIo3RdQVjFQqZR04cOBriURyKcbyBAAgxeByef7c1u3b29NPt/v95FB4EhIcqBDkvk2cOfr4ohKajJ+ENUDOON1kzadWq59Yv379M9G0ZKI+bXBkZOQ1Pp9/Pc4y47jR3Hd1fQP3s+FRlhdFyYbaJCSzgABAVVusvN3dfdQsFuvEymR++jkjd2zTiXu0yddEItHVEolEq1KpjkdLvqgqmOeee+628vLyJ/HW//T1N947PzwwYOJOmXwxj3CRkCQKKADUD/TDWV02u3Z9hgihwTALADA2uSM49ziZTLYGAPBpfX19VELYUf0Royh6anLriLX2dN233sc++5I2pZQXLuoBLHZRNGUjIZkr5HJY2kNr1ziyWcwFOIfoZTLZQo1GY4m0LFHbgrz11lv34SmXN0+1+B777Evq9zKNj0fd201CMlfotzslD7dqPFYf7sjszH379v0mGrJEZYsklUpZL7300gGAkSTk9vnA9a++gdg8nv+TxelAQHqGDUBQwDOLSEhIzgBBoI3HpwsbLSbWDUIRTIFmblQkEskqAMCe+vr6iE42iIoFU1VVddO54edz+WntOy6D1XZ+pAhF04B2oDcaspGQzDGQElFSH4BARpfTTtk12I+XxctSKpUvicXiiAoTFQWjUCh+gvX6p51dPlWLGjv1eXxsJXA4SCVDQhIESQzqKSGH/n0L2doRPfzB2DCektmgUCiC6lgQLBFXMBUVFZBEIsH8I145Nmu0jAbGRvwRE4yEZA6SKWCiF2bD/6W/G4x43Jh+zaqqqjsiKU/EFYxcLr8SazaRD0HQzzq7cb1QUxiNycDvH4+kfCQkcwUWjXJKyGHkXPg6AgD87ugwpoKRyWTXS6XSiEWTI65glErlLVivv6tpMxmdrtkrQxFECIwTxkjJRkIyh0DyUzl6CADMoW+fG8fwtkm5CoVihlIKF9HwwWAOQfv3ydOBRYjGRqnTXbtISEhw4DKoGgGLthZvfcjtonY47Ji/I6lUuiZSckVUwSgUikltKr3w9UlV+kl7Z2A9KpzOPGAyRS21mYQkEcnkM30X6+f7tXEccytUWVm5PlJyRVTBiMXipVivtw6PeF3BzH4e1AkBikY865CEJBFhUuFWIYc+W0X1FA1mI17Q5BqxWBwRXRBRBVNeXo45yvXU8HBw7+txFwCTcSRccpGQzCXyhBwtDEFpFzuu02mnO/yYOia9vLw8LxKyRdqCwZy8eHzIEHz4eXSULH4kIbkADp3SmsKhXxHo8W0OG6YfpqysLKi57oESEwtGPTwS6DS7/8NuywN2O+mLISE5hww+yxNMo/xupwOzv5JEIlkeVsGmiZiC2bBhAxsAsBBr7dig3hvCJSlA288CKOoiLh0JSeJDhSFDKoeO1WQKl3Z8CwbTX0qUiCkYmUx2BdZso0GLBQzbbIFOrzsfp3MhsFgGwyEfCUmik8pljFBgKCOYc7qdDszffMJZMAqF4lqs199vbSdWvTk2SrZyICEBwJnBYwY6wuR7epwO1I1gZoiIa2pqcsMi2TlE0oLBjK1/3dMXeHgaC4tZDNzuNkLXICFJcNK4jMNsOqUk2PN8KEo5YbXgJa5iJsUSISIKZjrBbob/BUFR8GlHVyj+l3NhgoF+L5ndSzJfgSFoNDeFHXJ6/3cWI2ZEVqlUhj3hLlIWzBKsa3eOT/gsbnfQZt0MbNbFwGYdIHwdEpIEJJVLN9CpcLDjZL/nsNmE93C+RiqVhlUnRMqCwQxPn9Qbwvcm4+MxG4dJQhJDPJk8ZmhBkmm0bifD5MPcSHBlMhlm5DdUIqJgpFIpZoLdiVAS7PCYGBcBv5+0YkjmFUIO/RCHQcVr5h0w7Q47pobBMw5CJSJDzWQyGaaQLcPD4Xw/Hhjo776u7FJRNos5rxpTddkcrm/GxjHL8ucDV4lSO+8vyL0w4oFavT672mKF39QO0vUudyAjVRMKCAITeULOrPPbA6XbaadeysPsYjv52/13ON4DRELBlJWVcQAApVhrh/q13rA2GjcZlxYAtPOl1csIa/REwuL1ORd9+vXAkNMVsT4e8UoKnTb2dvkqZjKdhrVNmIpQPr14kWtXd5/p6bZO5ojbQ8jnx6NSXVeJUr2rUwSubBaTQoWgqA8rPMvXlon+Vo8tLPkqp21WBKTP/C0qFIrycFz/LGFXMBKJpBTruh1j4/4Jp5O4g/d84NeajtGevewSD5tKIbQvTSR4NGrqC8tKG25raJp3CuauXIkxmU6b1cHJoMDMh0oKmOXC5LGyrw4yQp3/tVzAt3y05hI0k8XkAwCSQhY6PPg+VI+GzSrrdNjx8smWSaVSoNFowvI+YffBKBQKzJTjD9s6POF+r0kc4+PC3zSdmHe+mFvFmStXJQu6Yy1HlLH/ojAv4IfUpcLk1P+UrzJAZ1oQBcX/k2SNflFRRp9WLjHn84mxpgGXM+i8FzwMHjdlwovr6A05QnUhkXDyYvpfvuruiYxpiaL8F+u/NescTqL5NYkG/eGSgnmVC/RQcf7p4iSOJJhzbhVnZv4gQxRUL6EyocD0v2UrhSl0ergt7pDwA2D6c39XWMcpowBADWajG2tNKpWGzdEbCQtmRgTJ6/eDr3p6IxZWRs2mxfs0bbpIXT9eUUiyMhfzkzpiLUc0EDHoI0+VLgxpS3ibODi/6NOLFyHRnHp6MT4eG55wIkhQijUQmqxmTLcCXpAmFML6IVZUVEz+z4wtUuvomNvp9UXyaUDfe+SYHw3BFE5kKBDE27tqqfHMQ25uc09+jolDpWaFcm65MDlg63ZBEndEnpaaEsr7RIoPx8Iaff2ew+YJTLdFOEPVYVUwcrn8ksk93IWvnzZE5gM6l6GhoeTnWzu0kX6feOPSlORL1qendcZajkgCA2C5ryA3ZAdnHocd8P33k5zsmEWJsDhqMXW12G0RGb9o8/sZOpcT66EctwoGs4L62JAec68XVhBE+LvPvzLafPgTv+co0MMLCud0hfmjC4s0+Rx2yD8yGIICvs+XCHjOUN8nAnj+3N/NjOR2rcOJGU3KqqmpyQ/H9cOtYDCLpTTDo8QqqAPEYTAUvdbeNRyN94on1qWn5a8VCU/GWo5IkMVkDtdISwjd7L12R8BbSCGdHjfbzW9NE+N6jzuiw6M7HdjdU6RSaVgKH8OmYBQKBQsAUIa11jQ4GHkL5gzcvU3N9ii9VzzB/PelKydNe1usBQk3GwtyLAwKJaiubRdybMIUsP+vw2qLmwzg90YNwbeWDZIupx1TB4RrlEk4LZglWFm6PRNG37jDGbUv7WR3L/89XTirKhODDCajdGN+zpzKB6JB0MS9+TmE7x2VTh/wsYfGjXERKOhw2MYaLSbMXP7wvo8d7++Vl5WVEVZw4bRgMAscP2hrj+6e1udNrz7w2aAfRePG1I0Wm4vyoDMpDnODx6Ul7WI266Lzfmaj1+6wvDdkCFhJvd6nS3H6/TG3BHdoe31ohGoFz2XM66GMeDA3GDyJREK4BCdsCgZvyNrXPX1RT+Ef7O3L+0/vwLybo7RUwC+5Iyf7cKzlCAc5bJb+t4uKCWWuIgD47z5ynBaMxvWiCO3Frt6YJm2etFpMp2zWoHrtEuGw2Yj594ZjlEnYFAzWiJLJL/bTjq7oWxIoKtx/7HjMn0IxgPL66uUSBgwnvKP7voJcKxWCCFWMf2kYddePTQQ80uMsT7S0czqstgki702Ed8cMUQ2VH7WYMbdCEokkPhSMVCqlYFVQt46MuF0+X0ycZl9q2rhNRtO8GzdLhaGch4oLxmMtBxFYFHj0nvwcHtHr/L2rJ6TtogtB6Jd9dZD5wZAh6krG4HHb6ozBK0UiHLGYvH505kcVjoS7sOzxFArFCgDAjKKw04aRmCUt+d2uzF99/tXRw5W3riZ6rU8No8O/b2mLitl8qVDge3H5YkJjPKuL8uh/bu9yAADiJiISDE/KFnZnMhmYEclAaTaazR/qR0IuVBz3eNk3HzrKfrA437BNugDm02kiIvIEyku6Pp8HRSLuezkXB+KnaV1OJI/FvtDgiBsFg5lg1zyo90WqqVUgNJxWZ9dfuWa0IkN00bm9s3FZajK3126fvOk44ZMOm2ajCflVUYG1JIkTcnsACZtV9Li05OsnNR1rwytd5CnksAe3LCgk1LbRh6Dee5tOhiXE+3xnb8bznb2ghMsZz+GwUDoEz1pwyKTAyNuXreZDAATte+x2OlxfGscFlBjUfnQ47CCPNeN5JKypqVm8bdu206FeNyxbJJlMhjnuQDM6GtseLX5/1t5jxwlvk5KoVM4T0pKobLcQAOCdXb2E768/yBasyGYxe8MjVfS4vzDXDgNAKDz7vt7gbjaZw2q9ddjswi+Gx1I/NowIZ/v330FD2ueG0ZACDO+MGuBkKi0mhWWd2Bm9QC6XExplQljBlJWVTX6Rl2KtHdVFLcEOl/+ePEUfsDsIy7GpME8gZjGj4jh+tU/L1DtdZoKX4VcX5REbchdleFSq4a68HML9V57v6IlpJfSWEy1cp98fVHrGoNvl+s5spLqR2GRXdDmwJz7K5fLriVyX8BchkUhkAMMc1FutyLDNHlVnFRZOm13y24ONp4hehwrDrJ/kiqNS52Tx+ZgPnWghnD/0UHGBAALAGB6pIs8zSxb1pTGCm7V8IafNFvs3YxMx9T1prDbBX9u6rYEe7/Ij3q0dmkkTAnZgT12MOO1OG55mu0KhUIS8EyGsYPA62L2naYublP03G78TacwWE9Hr3JUnidqTsVanz2iaMBFSDiwKJXtzUV5C9MlZkMTVPVCYJyNyDZff734xDNvLcPBUa0fyM21deh+CuGY7bsztcd178uSYzuMS6rET3qKC2eejal2YzzTadJZ+SBD+wYjFYswmwf9Vt8VN2Tviduc+8+3hMaLXWZDE5T26oDBqw/cfPaUh3MHs0YVFAgYMx33pRI20xE607+0Lnb3+/b0DM9qFxAIvitJ+e7o1c8ln9Y5d3X2GHptjUtFPaRAvgpjrR8cntp5QG7M++Ix22mWNi2jf58YxTAudSCNwwjcwiqJNAICV577mRxDAfOIpjw9B4qYRN4PDGdD++sH0NAadUGW3F0GsvHc+obsQJCoV4l9VlBvWilIJZXVu7+j+8uGTmqvDJ1V4yWGz2vpvWCcBABCJ0vlzP/rCNeBwRjzSR4BxDpXitPv8GWejq6lcur5ElBSWUSREKeUm+V9esHiGYaBWq/9RWlpaFco1CVkwGzZsYAIApBe+fsow7Iwn5TKJ224XP1x/kHBjJhoMJ92dL4na9u8Xx06xXEE6DC9ka0nhimIuJ14jSt7XLlnuJqhcwHuDBlucK5dJhHafX3xWucAQ8OSmsOOi7+8krTYb5PTP3GESaaFJSMHIZLLLJrf6F76uHolxeBob+J/fHEpqt1oDdr7h8bNcSdiaL1+MDpud/6Z2aNZ9fAAkby7Kj8vSibVpwj55mhDTjxcMf+/qjZseuoGSymE4GFRKcqzlOIsfoHCn0461TSqtqKgI6TdN6EvBS7Br0g3FPDyNCeLP3dd0nHCdTpkwmVeRJoxaOv7zHT2TTzxCEay78iRp2Sxm3I052VyUT1gxfD0yNvHVyFis5xYFTTqPGXeV791OB1ZiLF0ul8tDuR5RCwYzCadtdCxuzL4L2d/UTA9DKwfKi8tLiVoVAXPCbEn6Z5+WkJOaR6NmvLC8NK62SekMuuNWcSahbvkIAJ6fHzkR8cZM4SaZTTckMalxY72cpd1hw3yQKZXKkBLuQlYwCoVCAABYjLV2RKeL2o8vWIxGU+bbXT2ErZhSPi/7ylRh1HJMtp7SJE14vIR8Pz/KzrxiVbIgPCP7wsCNmel0rByqYPhXn9apdToTynqBAPDmCePH93IuOBbMJCEl3BGxYDA72BmsVp/R6YqLsBsOtH1HjoVlC3dvQfQmt465PZxXegeIFlwyHi4piJsBdWVC4g/wF7v6wiJLNBFy6XYWjRLxbnWh0Omw+3FS/RYpFIrUYK9HxILBTL45NqiPmxsYj6/bO/hHx8YJWzG3ijPpAho1ah37Xuruo3kRhND7KSTZuYv5PMKZzeEglUEnVAj7zqB++IjRFPXRrhAA4Lr0NOcfZAssr65eZnt19TLHYwuLvfI0oY8KXdz/nxGHvpezeFGUMuB0YOoYsVgc9OD9kBUM3njJ08MjUYuwhIrf50v51cefE+54x6ZQOApxVtQUTI/dwflrexehjGQKBAR7Vy2dmLyXwidZaGD1IAmUSUV7z9ETUd8aLeXzbNobr5k4cGUZ63FpCe/neRLuz/Mk7D8uXkj7Wn4ZtWndlf58Dhv3D2PRKCYekxZ3vpdz6XBg78TLy8uDjvaFrGBkMhnmm53QG+JewUzS2NaWV6cbIpzhWpUfvW3SJH/QdAoH7E5CIedLUwRXrk8XqcMnVWgMOkN31e3pGfCYvNFtZnZLVvpwnfwyajaLiTv5camAR2lbvxa9Q5KFaQWk8xhx//vAq6wOpYVmSAqmoqKCgufgPTGkT5TBZ0n7mo4T9sVcKkxOWSNMiVr5gBtB6Lt7+oh+xvCvFxSESaLQaRwP2UeO7uzqjeo2Y2Uyf+zdyy9JFdBpF3XO0mEYfvWS5aCIyzlPycAQ8GQkMeOmhAaPLqcDU0aJRBKdLZJcLr8CADAjVd7m8SCd4xPxmGSHyTunWzgDdgfhPi/bl8noIIpzsff1DtBNHi8hua9OT1uwNk0Y0wbhHxtGgNET/E6tdmDQ2Wq1RdVJ+sSiEgdWUAOPSSXzweWrUfo5/anyhZwxGIbiolZqNjocuJXVxRs2bAjK5xWSglEqlZgJdp+0dxkRFE2YnASH05n6my/r+oleZ3WKIG2tSEi4WjtQRt0e9m9OtxLt9cJ6s2zl5EOCaN+ZkDF7fWBnV3CpOcMuN7j32Kmobo0KOGz1zdkZQXdFXMhLolwtSpv6sTKoFEs6j0moFUW0MPl8FLzKaplMdlUw1wrVB4OZdPNNX3+814LM4M0jTZnq8QnCldZ35Uqi2shjT0+/SG22ErJiREzGynsLcnrCJ1XwPNPWBVTaoYCOtXp94GdHjgNLdMeP+/auWurBKokJhPLpUHwGb8rgj/vt0VkazEa8hLugJj4GrWAUCkUSAGAF1tq7mta46QETKCiCpO5vPkk4EnRHjpjNplCi9vejAMB/7+oh3Ptkc+FUqn7MeqjY/X5Q2XgMPN3aMetx3TY7WPZ5PfhseDRqsk1ymTC55ypRatC+h7MUctgIBAFfOi8qxfdh44jVjJdCEFkFgzdgbcRu9+rMlrgOv+HxRvNxhsXrJZR9TIMh9o5lsqiOuXijf5DTZ3cQ2potEfBK75Bkfxk+qULjsZZ2sOyzevCUpgN8PjwKjhvNoGF8AvyzTwvuPnp8Srn02KPfAfQeglFCCIJATjJnmArDhMewRJNmi9nvxe6ul6NQKAKethl0ohPWgDUw1X93yEO05D5WjJotoj83HFH/8crLCXVUu68gN2ObpsM85HRFJfnL4ffTq4+fnvhoDWZL5EChvFG2ovC/g/pBN4IQGtNKlJNmy9S/eIEJw6N35+cQmkhh9HmN2QImoWvEAjeKUPpcTqSYzZlhhEil0kmLLqDIadgsmNaR0YTZX2Lxt/pvU4fsDqKtHGj35Emiut34WD+ScXBsnJDlBANQ+FBxQcJPgww3DxTmGWEACFnlWp+LQrTeKlZ04iTcBdMfJmgFU15ejtk+r2FAG/cJRLPhcLrStx9qJBxR+WVxPo0Jw1Ed+P/oqVYq0TD5IwsKRSl0Wty1c4gVFAiYtpQUELLIxz0eS4PVGPPG96Fy2m7FS7gLuIVmUAqmoqKCDQDAHIp1bFAfnz1gguCVpmaqB0E8RK4hYjCSHl5QGNVO/ofHjbwPh4YJlT4IGXTx35aWtoZPqsTm1wuK2iVsFqEt457BAZsXoPFc+DsrXU474YS7oBSMXC6/GivUZnQ6fQMmU0L6X85lwmbL+OOhRsLlub9dWMQR0mlR9UhuPn6aY/f5CL3nT/PE8qV8XsxLCGJNGp0+UrOohFCfmgGX0/rRxEjQ1cfxRLfT4feimIZxZk1NTUCp4EEpGLwEu/da241oAsX4Z+OPn34hGHO7CdX6cKhU/u2S7Kj2xOl3OJP+2a8jZH0BALgPlRREdXsXj/wkV2xiUSlZRK7xwdiwH01Q38tZ3AhCUdtteBMfAwpXB+uDwVQwh/oHEt56OYsfQUT7jzYTzsqtys+Jekn+C129NAQAQkrmxznZuQuSuCfCJRMEAFidLDBvEGf6FOJM5Lr0NFMyjRa3DckAAK77CnIIJa24/H7ngfG47EsdNI1mI6YJE+jEx4AVjEKhEAEASrDW3lG3zamn3r6m49QzuWyhsyKZL1wnShsIn1QXR2OxcfZ09xHqFUyD4bTdKxfrifYAnmSDOMs6fPO1xiPrruCryldRa8tXwQeuLBPob7oW2bFMNsKiUOLOb3dXnuTEQl5SLpFrvDE8aJ3weRPW93IujWbcZ+3VUqn0oruWgBUMXnhaZ7a4xh0OYaDXSQS6RkZEr51SE65R+uvSRUwoylmyj55uFQy73IQyiq9IFV7GplBCLp8Q0ukeVdlKs6p8JTuNwZgR5mVQYPZDxQWi5nVXuHLYrLiZdsCmUIx/Kl1EqF5ozONx/NswFPUmWJGiy2mHrNilGSyZTDZjZNGFBKxg8JrNHBsais0w3cgCb/3gY5rb7yf0hF0m4IuuSU+LWhHkJBavj7Wvt59QM6nn2rtHHH5/yMPe9q1aatsgyeJfrPZmIS+J/+7lqy1ErcVwUSnJGs1kMfKJXOPA+IjPjUZnKF80QAGAO512zIekQqG4aD4MYQvmtIFwY7i4ZMJuz/7fFg3hcPNdedEtgpzk5e4BmsvvD8mK0Tmcphp1e8gOzrvzJCM/zM4IuJXCcgE/6y9LFhEeiBcGkE2FeYSmbCAAeD8YH0mYbgKB0o3TH2byGXqxcwlbMKcMw4T6qsYze48cI5w8WCnJ4vJp1Ki2RNA6nZw/aDpCyrnf0zvgdiFISE77FDrNsXfVMm6wwYNHFhTlZzIZhCvaiXBtelrT6hQBoS5cH4wabDq3K2ET6/Bod0TYgtmwYcPkTbMAa+34UOIn2OFxuLcv+ave/sB6CeBAgSDW35ctjnrPlb+2d6d12+xBlT7YfT7Tvp7+kH8gm4vyvRQIhOLcpP0gUxSzbRIMgP1vy2R8Ii1k7X6/a8+Qds4pFzDlh7HhfS5LpVLprA/hgD5QmUxWgVVP4fB6ka7xiTnhLceBvvmDj70owTT8n+WJs3LZrKhm9/pQlPpSV3CtNX/f0m7Uu9whVf1CACCbi0J3X5SlJMesZcQt2RlDi3hJmA/QQPlyYsxv8nnjctYRUXocThQn4U6oUChKZzs3IAWDNyL2vdb2iURqohMKrYbh3AOd3UTHxFLvjkFezCt9WpbZ6w0ou7fDajP+vbNHHOp7Pb14kT6NQQ85esKlUWP249xUmEf0u0HeHTXM2d+BH6Bws8WC+QCQSqWzJtwFasFgXuRw/0BCTdQLlT1HjhG+xsYYOHuNXi/z9b7Asnt3dvX5EABCclDmsFiWRxcWiUI59yx+hMAMEwIs4SedWJeelkfkGodMRnu70z4nrZezfGcxYeqKyspKYgpGoVCk4SXY/belNW5yGCLJR23tSa1j44RaqWWzWan35EmimngHpiYf9tL8KDpr5qzB5Z54rV8bcjZ2ddGUBUAoetJiscYi3cGza8USmEg7BS+CeF/Q9c7ZQMdZGizYGb0AgMvKyspwfU+BWDCY0aNhm901ZLXOqQQ7PLx+P/PhTz4jnK38/PJSFgWCojrwrMNm5zzf2Tur/2fLCbXdHOKMIQYMe6qL8ghvD+pHie5Cg+cqUWr/ZakpmBNKA+Vb84RPOwcjRxcy4HJSTD7MW5cpkUhwG7UFYsFgKpgm3WDMnHKx4JPWdnHTkJ6Qo5ZLpabdmZMdVWfvJI+3tCUPOp2YeTHNRtP4m9rBkCuHd61YMsqhUgmN4mgcN441jBuj/rC6MyebsNX07uhwQvdBCoYOhx3z85otXH1RBSOVSjEVTMvISFxkX0YReM+RY4RvyJ/nigklc4WCw+9n7u3BHpz/fGdwY0PORcrjmu7OlxCqOgYA+O5pOhmLH6m3UpxF6Ltod9gsx6zmOe17OZcupx3v8wpdweC1xzs+NHe95ni8daqFNepwEmoauzY9jbcqmR/d1vhnxpzQbT7feT6zdqtt4i3tUMiO+s2FU2FpQsrhPzq9pdUS/a02l0o9mUSjhlzUiADge3agZ85l7c5G2C2YDRs2pE4+qLDWDvcPEO09knBYXC72z1XvOIm0p4QBoL92yXIEDkO1cjDoXW72nY3N7rOyexDEddvhJsiNICE5OFcI+Kb7CnMJ5UChAPgeb2mLSd3OAi7XSsS5++XEqFdjt81538u5tNhw8zZXbtiwAfNemFXByGSy1Vh5Lg6P1zdosc6rD/csn3V0JndPGAlVK0t5SWkrkvlEG4wHzUeGYUG71TYl+6GxCbvaYg25oXWNtMRFgSBCPU9OmSz2VqstJr2EDG4XIdnrTVGdUBMXjHg8wO7HfC4yZTIZpitlVgWjVCoVWK+/earFiKDonGioEyx+FKU/++1hopEg+DcLi6MaTZoEQQHl8Zb2yff1/+ZUa8jm/Y2Z6cabszNCrrY+y+9Ot8asEn/Q6Vpu9flCaslxymax1RnH590D1g9Q+BvTBF5dUiXW6xfzwWCOiD08oJ3L5QEX5dVjx9l2r5dQDtCPxJm8NAY96o9BlW4o5cETLYNHjKaQB4E9WEyoo8EUzUaz4SPDSCwH9bE/1o8EvU1FAfA/N9BDnW8RjrMcsZgwfa94ybi4CkahUOQAADAjBO9o2uZsgWMguHw+5q8//oyQgoEBYL6wvDQmU8b+3tkb8rhCKY9rX5eeRiiD24eg7o1NJ2MefXmhs3dShqB8id8Yx3xdTkfMZY8V31lMfhyzc+F0Uu554CoYvPB0v8lkm3A4UghJOQfY/d3RjAGzmVCV9O2S7JwiLiembQqCAQIA+WVRvjeUiaDn8v6QwXHcZA64Z0ykODQ+kf0HTcfsQ7HPwYMg3p26/qg65+MNs89HGXJjJ4ZLpdIZ0SRcBYPntDk+ZIh6Hke8svfIMaKfBXxXriRhErXuzBGbfpIrJux7+1tnT9zcQzXqdtlTrR1DF7NkOqw27+3NzSODHvecaXAfKh127HA1VkrLbBYMZgr1Sb1h3oWn8dh7tBlGCYab7y3MQYhOZYwWvyzKg7hUKiH/2+fDo4ZvxybiqWct9HhLe9aKz78xnTZbDBcu+hDEu7en31H29UH3MPDMe8sdnOkPg/lQxLJgcE1dvAS7U4bhOdNvlCjDNhvng9Z2882LFoT8gxExGGnVhXl9O7v7CFX0RprVyQLrpcJkQorB5fc7NzWfjsvoy3GTWbTks3p0VbJgNJ/D4jFgmGr3+32HxiYoI24PWyxgmSEIECqJmCt0OrA7gARswdTU1CQDAIqw1o4NDs2pESVE2XOU8DYJPLtUmkSDoHieFQQeLM73E+n4Nslb2iFXl80eT9bLhUBNRlOaSqdnvDEwSHln0MAYcXumHsLpvHnr151BhxN7GBsAYGFNTc15ShjvhrkGKwXc5HS5B0zmkMObc5ED7Z2cU4ZhQtEgJoUi/FmeOOptNQNlYRLXrJBkEf2F+Z7vTMzU+kw+c4RBheNZMUaVMa8XNngwA8nwhcMZMRWMUqnEzH95t7VtHCUYQZhr+FEUfujDA4QjCz/LlcSN4/NCdq9c4qTDMCEF8+bA4NhxkyXhthgUGHLnpbDnvWP3QhrMRsx7XqlUnpcPM+OmFounuiZeg3XyIQJNieYyX/f0pjQMaAml/l+ZJhSUC5OHwydVeFidzLdWpAkJZe2avV7HlpPqhFMuk6QnMV0QBJH3/QUcsZjwDI1rp3XIFDMUTHl5+eQqZn+Q/7Zo4tpPEEv2HGkiaoHQdiyVEapxigS3iTMJRw1f79N5DC53QiqYDB4jYdIIoskR/IS73GkdMgWWBYMZPRq0WOwTTiehsZpzGdVpDUNvsRJSEJcKkwvKU5LjKvGumMshFPVBAHDv7OpNSN8Ln0WzMmkU0ueIgQtBKP1OB6azVywWLz/731gWDGb+S5NuaL6WXwSE3eulPvb5l4QLGO8tiP70gdng02iEOhe+1NU70W6zJ+QWI4OMHM1KJ3aTxPOGNM5QMGVlZZgWTMvwSEIkg8WS146dELSPjhHaRt4mzmJwqZSARo1EA5cfCXnrN+xy2x873RazkgA6DPvWiVKN9+bnuB9ZUGjfmJ/jXytKdVGhi+962DSKNYVNI3O+ZqHTga1gysrKvrdgZjhqJBIJ3ojYedmeIRjQqezeY+izP8AMwgUEj0bl3ZqdOfp6vy4uKtZH3FOFJyFZIPt7B7xWny8mCuaGTJHxpRVL4Bw262zF9lllQemx2T0/OXIcNIwbce/p/DSOB4KgeTGWJ1Q6nQ5MTS2RSL43Us57Om3YsCEFAIA5n7d5UE8m2AXAGydOUeweD6HP6t78nLixFj8fDq27p9uPOF7u6Y+J7+Wl5YtNH665VJDDZmHmrhRwOfTDV62h/n5RMWYyRxKTauczafNiYgYROh02vPs0r6amZspfe56CkclkV2NZNS6fz9s1MUFq8wAYttnpz9QfJBR5WZMmTFsp4Ed9hhIW/xk0cE0eb9AzRWo07aYBhzPqvpd78iSWB4ryBAH0CoafLF3IuDtPMiNJMpPHjCs/WLxi8vngARfms/T7hLvzFIxSqcQcEfuOunWUaIn+fOLZbw9zBy0WIr4Y+PnlpXA8FEF6EIRxw8HvILvPF/Dfc3BswvyXti7CHe+CpSJN6HpCWhKU32T3yiWMBUnc731eTBrFnsKhJ2TUKxY0mLEHsp1NuPtewYjFYgoA4IdYB3/U3km604PA5fNRdhxsIJTde3lqivimzPSoTx/A4vC4MeWWQ0dd4+6Lbv2Q/+r0plsOHWGhBOuWQuHpxQv9uRx2UAqGDsOMTYW5Z5UnWpLORWAIIp27AfKVEde4vamsrIz+/U1QXl5eAABIxTryXU3rvBqyFg72Hm2mexGEkC/m7vz46RXz5ciY4PKvDvr+d2BwcNqffR52n99615HjttsamgQTHm/UAwKL+UmOcmFKSFuyNakpU99TMptu59KppCsgCNR2K+REMI2YJIlEsuD7bU9ZWRlm9Kh7fMJs93hntMIjmR2L201/4vOvxp++bl3IiWo3ZqZzizickS67ndBg+XDRbrMn3fldc9LTbZ2WUj6PlUqnu90IQu21O7x1I2NsL4rGbFbWxvyckJVxKZ83dW4Gj0H6XoIEBQDqctiQxVweVsrL8u8VDF54+oTBQO5HQ+SZ+oPCLZeXW0VcTkhPRRoMs/+4eOHw7Y3Hwi8cAU6brbzT5qnSq7P3Rky30EwY9m/MD3mG2uQ2icqmU6zJbHpCJgTGmi6nA17MnZnwPKlTvtc6eBbMiSEDWX9EgJePNBHa5lRKsrIXJXGjPs86kXhuqczIplJCthT1LpezMHWqVCpuK9rjmQ6HHdPyUygUy7//QPEsGM3IaFwkfCUq+442TyoYIiUE9Hvyc+b1FIfZyGGz7JuK8giNP2l32GlJTNL3EiqdTjveQ/SMBVNTU4NbQX1ENxh3Fb6JxIDZzNn13dGg80jO5c6cbAYNgshERwzuzZ+awELI93PQPBGXbTwThR6nA/FiO3pTzlowV2MlJlncbofObInlcKw5wcMffSp0EhjUlsViJj9YnD+jIfV8Z/KGvb8wj1CE0+H3O74wjpEV0wRwIwistmPf3lMKRqFQYJYHqE6rTeS+lDhOn4/2j6bjhJLmfi8tSeJTqYSGvc01freo2JDGoBNSDi/q+pBYRr/mCt9ZTJj395TykMlkJViLJ/XDCdkkKB7Z39RMSMHwabRUhSQrbqqsY00yjeZUyhYS6pOrd7tc742R93g4GHS7MA2Rsy9iThA42D8Q9dnJc5XjeoPg/dZ2PZFrbMyPr14xseS+ghw3BQKEfCcfjA3HTSJjomP0eTG3qmcVDOaTYNBsIb+AMPLAex8mIQgSctj/UmGy6HJhSk94pUpM7ivII6RsEQD8748Nk1ujMOHw+3DHDIBzemWch4dAsyGSmQxZrNy31a1EtjnQ9mUyOgCAcOkGm0IxXpee1qsQZw0qxFm6K1JTugAACRExvCdPoi/gsgkFH/5tGPQafT6ygDdM+NGZ5SPgnAppzEUUoKQFE2b2HDkGKhfLQj7/khSBWJ4mHK4bHQ+pPzIFghxPSEu6H1lQmM6iUPLPXXP4/d33HztlfqNftyJkASMMHYbdL6xYTChz2OrzefYODZAFvGGERaFg6pCzFgrmuAwRlxPzdgFzja+6ewTfaXWExpP8PFcS0vagmMsZPXr1FaYnpCWLWRTKjPomNoVS+M9Lli/5/MqyjiwmMy4HwW3Ml1jYFAoh6+X9sWHYh5LurHAiotExFfZZBYPpfKzIzyVzYMIMCgC8+f2PCGX3/iQ3m8OmwEEpAAmbNX7y2gpkeTI/6yKHUtelp5X857JVplDliyRVBIoap0HfGzWQ2iXMFLDYmPfzlIJRq9VqrMVlmRlk9mgEaBrUi77u7g3ZQqDCcNKOZaUjwZzzx9IFDhaFEvC2qkyYnDu5lQpJwAhxU2a6fkWyIIXINd4fG3YOetxkAW+YWcThYnZxnFIwKpWqEWvxpoULyEbfEeLlI02Ezr+vIDcnk8kIqARBykvq/2muJGifzTbZAomQTiM0sTJcQAD49q1aihJJ/HQhiPcFbR9ZWxdmIAC8S7g8zEj0WQtmUsHM6MCWI+ALioUphAa7k2DzrqaN3zNhJOKLYVTl51y0a97kl79/1dLJbUUoDwv69ZnxMWvvDkn2mIjJuNj2blY+HhsBDoTsnRZuFnG4LiaMrfenXn377bdHAQBHsA74kWxRhMWbn7j9ftqdb71NQVA05LyYzUX5dAYMzxpavjtfMlwmTM4J9T3KUwSER8eGAeSxRcWEQspeBPH+a1hHRkUjQIVAiKe1Nd+rnYaGhpNYR1xdiFmmRBIGvtMOpp42DIe8BUlnMpJvFWfOagXdLs4O9fJTcKjUmCejrUlN0cv4SYTKAg6ZjR6Dx0PmvYQf5BKeAFNxa7XaE98rGJVKVYt10LXFhbyK/DyyZCBCPF33LaGIxt6VSwQpdBrmNvbSFMHwtRlphLYVJi/habiEYFFg+5uXrqCc0z0vaExer/fp/i6yJUMEuF6Y1l3C5mAqf5VK9d/vFcynn376DQBAh3Xg7h/eSIMAFNs7bY6iatGkGqzW/lDP51CpKbeLszGzgx8szvcRrYY/abLEtI3k9RkiYzabRWgEyoGJUcTm95NZ6WGGCcPjj+YU4n039v3793/8/Yeu0WiQ2traJ7COXJiWmrRx9XJSwUQABEXh+9/9kEokL6aqYGavsEVJXP0GcRahsa1+ALxfDI/GNNnyBxkiQvcdAoDv/dFhUrlEgJ9miM00GMbsBKhWq3doNBrneR/87bff/goAoB3rhN+vraAyKBSydWMEeL+1Pfuk3hBy17uVyYKMq0Wpnee+tmvlEgsNhglZH6/09Du1TldMZwSJmAxCTuYDY8PufreTzHsJMwUsdvPPMsWYY44AABPV1dVPASzzefv27S9gnZEj4NO/2PhzKIlBJzRQjASbvUebCfli/rpEyoKmUw0q0oT6ijQhZo+fQBlzezyPnmqNud9CxAhdwdj9Pu/uoQFyiFqYSafTtX8tWiSEAcBs9tXQ0LCvvr5+yhiZoWD279+/BwDQhXXimtwc+mPyK+MhbDnneLX5eLLT6w25X8zyZL54XXrq1CTIh4rzkQBmM8/KK70D/gmvN+ZP/jG3J+TtzZfGcf+410tGjsIL8tvcotEMOgNvToxrx44d28/+nxlfnkaj8SqVyg0AAMzw6dY15azbSqVk68YwY/d4mb/99AsnkVYMd+VK0BUC/uBN2ZmE0uk9COLZ3dMf8/D0JOMeT6g+GP97o4a4+BvmEJ77snK+Xc0TLMNZR2pra+9TqVTfp05gfgH19fXDMpnMKpPJfnDhGgWGoQ2LZfT/tmicI3Z7zJ9wc4nvtIPJ961eMZzEYIQ0QkPKT4LKhSmWTCaD0CTIv7R32d/W6eMipZ5BgQc3iLOCDrUfNE043xzRky0Zwsg1KanHH5LkX4ZnHavV6v1XXXXVU+e+hqvhGxoamq+77roCkUi05MK1yauX5YjRfx4/5fchCPmUCCNcOt26tiA/JAUDQxA9g8kgVAGvdTg9ioZjDB+KxkXkpdNmpynEme2pDEZmoOc4/X7/Yz3tsMXvI+/NMCFhsDpq8ktSORQK3r156pZbbvmpTqc7r0Aa9ybS6XS+6urqnwEAjmKtr8jKpP/nx7f7z0QCScLF/qZmLoqzPY0Ge3r6/U6/P25+mB4ESbv50FHEj6IBj21RjeidOreLtK7DBAOCh15cIEPT6HQ8JT8il8uvbmxsnBEJnfUpVV9fj1ZWVm4EAGC2Fri+pIj1P1deTrZ0CCODFivvk/bOmBSYWn0+177egbhRLmfptNlXbTjcpLd4fb2zHYcA4P1YPzKybzD+/oYExveb3MLRVBp9Ac46olKpHqivrx/DWryoGaxSqU7V1dX9CM/5+Mdrr+aszM5KiF6uiQLRVg6hUtPS7jW43HHZouPdIcPylPc+hQ4YRj/BSkq0+/zjN3773fDdJ06w/QSnDZD8Hzemig5cK0yb4SY5S11dnbKysvK/eOsBhzIPHz78h/Ly8sex1sYdDk/5rn1I5/gE6VQLA1QY9p341QM9MlEaoVyWYOiw2lzST+uY/vhvJekv4LDbViYLaAIaDfUgfqbJ66N9MTzK9kEoq0TE9SUxaTEtb5grlPEF6ueKpPkAAEyHv1ar/c/69esVGo0G96YJWMFIpVKKWq3+BgBwGdb6N339roo9r5AKJkxcV1zYd+Dun2YAAKLymT50osX5fGdvQj/5c5LZdnEyi1QuYQAGkE61eIUvg87IwzlkrLKycqFKpZo1Az3gSIFGo/HLZLIbAQCY7TWvzMtlvnTLDVYoDCM1SAD4tLM774h2EHNfG26GXW7na326hHaKQgAgoiQGmVQXBjgwZXTfoiXG2ZSLUqm86mLKBcwWpsZidHTUBQA4IZfLq7DWV4uzGYMWi6t5SJ/QN2u8gAJgvnnRAkJ9UALhgWOnXEeMpoS2XoQcuiOdx0zovyFeqMqStF+VnIqXTAdUKtUvN2/e/Gkg1wo612Hbtm2H1Wp1FVaLTTDl9F1HE/N5ZFFkGFCdVqeN2OwRneR43Gh2vjEwGFLeTTyRwWOS6RJhYDE3qe3HGWK8iBFQq9Uvbd269dVArxdSMlVpaek/1Gr1Pqy1NA6b9tLNN5AFkWHA4nYzH//iKy+eMg8HL3T1xr1X92JwGVQTn0Ujh9gTZ/y3uUUUGAA8P1ZdaWlptU6nC1iZh5ytuXHjxscmH4BYazctWsBRrpNbyCQ84uw72lzUOTZOaGg+Ht02u/NN7WCiVxujBakcCtHizvkOFYKMfy+R9eYyWcU4h4xUVlbeH+x1Q1YwjY2NRplMdiUAADNpo+YqOW/rmnIyP4YgCIpSnv32MBpuZe1FEO9tDU3A6U/sUg9REsPKZVATfosXY3yP5RYNrEzir8JZ1ymVynKVStUR7IUJ1ZtoNBqbUqnciHfz/3n9NdzlmZlxMVcnkXn9+MkMq9vTGc5rvjdk8J00WeLGKVrC5YCrRUJQnpIMWJTAb8v0JCZpuRDkB0LRgetmSaZTKpUPbtu2LSRfYFi+nLfeemtDZWXlv7Bm74za7e7yXfuQ7glj3NzMich9q1e2vfyjm/LClRez5quD7kPjxphuj9IYdPCEtAQoxFkgnfl/ovhRFNSNjIG9PQPg7cEh4MfxEglYNKs0k8ch+qCcz5TxBOrniqWT9xWm30WtVj+5fv36J3Q6zHbdFyVs2r+lpeVZmUz2MNZaXU+fY+2+V+Oi/D+R6X3kwd685OR8otc5oB+xXn/wu5huK9IZDHDoqstBIXf2vLg93f3g/uZTmGsrc5LHGVRYGCER5zwwBHS1shW+TAYTM99FrVa/U1paeiuR9wjb/ru5ublh48aNVwAAZgz5yksW0IRslumTji4a+bQJHQ6dbrm6sIBQI2+Hz++58dAR2BjDTm+FHDZy8Ko1IJ/DvugDbmWKAKTS6eCA4fxR3EIO3ZzOYxJqTTGfYcOUsV0LF4/ms9h4Ien+zZs3V2o0GkKFt2H7sTc2Nlrlcvl6AMAA1vovyy8V3LNyBVl5TYD9Tc1CP4IQyot5Uzvo77E7YlrSUSMt8eWwWQFbz5uL88GNmef30Ernkb4XIvw0I3tgIZu7GGfZrlQq16pUKi3R9wlrBKG/v9/L4/HU5eXld2Ipr/IcMfiwrcM15nDEZcVuvGP3eOlcOl17eW5OSijfHQqA7+6jx6FhtydmkaMl/CTnC8sXU2EICurhxqFQwZvaoan/5jGpFkkKe9L8Ia3hELgqWXjowZyCUghnXrlKpdq8efPmL8PxXhF5CrS0tOyTyWSY5QRjdodrwfYXwITTSRZGhgAVhr3jjz86yGPg1ongsr9nwLzx2MmIlx7MRp38MktFmhCzG/1s2H0+wHvnk6lw5TKxYIRNpxBqCzpfKWCxW/4pXVY0S7DgSwiC1oXr/SLyBNi4ceNvAACnsdZSOWzmS7fcQHbCCxEfgtD2HW0OOrN31O12P3JKE9NI3uXCZFcoygWcmWAJSvlJIJlNM5PKJTToEGRQ5hezZlEuw5WVlZvC+Z4RUTCNjY1jcrn86kmDBWv99iWlnN9UrBmNxHvPB/Y3NScDAAaDOqdX6zd6vTHdmj5QmEeoLEHEYID0JNLwDRHnc8XS7kIWpxBn3VNXV3d9KMl0sxGxPWx9ff2oSqV64MzWfyZ/um5d+k0LF5BJeCGgGRkV1p5qGQ3UCnT5/a5d3X0xzdjNY7Ndt4ozCclgQX2mZDadzKcKgZ9mZGtWJPEvx1tXqVS/Xbt2LWbpDxEi6iSrrKx8u66u7k9YaxAAYO+tN9G4dDo5YykENn/wcaEXQQKqUXqytdM54HDGNKnu2aWLPCwKJWQLyoMgTi8ddUMQtmOSBJ/F3KSGX2TnLpzlkPeVSuX2SLx3xL3w1dXVj2u12vew1tK5XGb9fXfDySwm2d4hSEbtjiTVKfVFLcBum93517aumDp2lwp47tvEWYSqnZstZhOLQU0Pn1Tzg2wGs+evRYty8TJ1tVrtdzKZ7A6NRhOR94+4gtFoNOjDDz98HwDAiLW+IiuTvW3dWkek5ZiL7G06ljypa2Y75qWuPr83xjOOflGQ6yd6r31mHEv4thIxwP2HghJ7EoWKN7jOt3///iqNRhOx319U9uUajcYOAPhcLpcrAJjZ8X1VdhZDa7ZMnNAbyHKCIOg3mjjrCgvacgR8zBvI7PW67jp6nOqK4XC8VDrds3fVUohJoYScOWzwuIeeHegW+AEgOyUGjuORnIJjawQpq3HWXbW1tRs2b958MJJCRO3Jtm3btmaVSvV7rDUKDMP/uO0W4Spxlila8swFUACgX374iQQFANMX82qf1mv0+mLqs3iqdKGLT6MR8v/s1PWbPShKPnyCoFKU2fbDtIw1eOtqtXr77bff/kGk5Yiq6bx169Y9arX6Fbz11zb8iCFgMsntUhAcH9KLvurumTEYz4eg7he7+mLaBLuYy3FvLMglFPXpdjoGvzaO4bZwJJlJAYut/nmmWDLLIV+sX78eM/gSbqKqYHQ6nb+6uvoeAEAD1rpUlMZ6/+d3eiGMwVok+Lz83bHJH/F5Dt/tHd3mLps9piHdu/IkHgpEbFvz3qgBRcmSgIBJptL69y1ckiSg0tJwDumWy+U36nS6qDSDi/oXV19fDyorK3Gdvlfk5vCV69aSoesgeK+1LatrfOL7MIDW4XQoNe2Eqq7DwQ2ZIkLZ2mafV//ZxGhImb/zFOcjuYVWBgzP6GgwjXv79u331NfXRy1qG5Mng0qlaqmrq7sZbxzt41dVJK/Jy4nKTKC5gMfvpz3yyWdZZyNKL3f3e51+JNb5It7FAj4hGf6h141b/X5SwQTIL7Jyv6wQpJTirdfV1d378MMPfxNNmWJmeq5du/ZgQ0PDH7DWIADAxz//cVJpuojM9A2QdzVtkhNDBrPZ67Xu7e2PtXIBGQyGHsaIGAbKoNs19O6oIWqjcxOdtQLhyZ9mZl+Ht67VanetXbv2n9GVKsZ728rKyifVavXzWGtJDAbj3Z/eQRMwySS8QHm6/lvq//v6sGXE7Yl5Or3Z56XgWaiB8C/DoMeHojFXlInAIg732O/yiyQAJ4yvVqvfvuyyyx6KvmRxMuoBRdHPAADXYK3tONgwsfXjT1OiL1WCAlNQULoYApTYDwuw/ej6fg6Vmhv0eX5/z00nj2Z5UISsbLwI2Qxm91ulK3gQAHhO3RNyuXxlfX19TLoXxIV3frpE3IC19qvLLhX8dPnSkehLlaAgfggYJ2ItxRQf60dCyb71/13b6yaVS0DYH8kp8MyiXGxbt26tipVyAfGiYFQqVVddXd16AMCM7RAFhuHXFT8SrcjKxIw6kWAwFh/+8Vf6tEErGK3LafhkfGRRZCSaW/y/9Mz21TwB3meF1NXVKXbs2NEcZbHOIy4UDDjj9D2pUqkew1t/TfEjehKDQQ5yCwSnAwCTKea1O58YRsS7u/uPB9pWAgHA84K2z0d2Irs4hSz26Z9l4CfTNTQ0/Hnt2rUHoivVTOLCB3MWqVQK1Gr1ewCAm7HW63v7jPK9r3LxnFkk50Cno0BaCgEo5l8x+urqZeqf50lww6fgzCwk10+OHm8foLgWAgASfZxtRBHS6H1vl66g0mFYjHPIEZlMdrlGo4n5jPjYewLPYXR0dHK79P7NN9+8js/nz/jw8pIFLBRFTfW9/WRdysXw+yHAZALAinlACfpAP5w06HRpCzhsu4jJOC+vxYeirs+GR+13Hz3hHwAuhEmjpMZO1ITA8UR+8XABi12Es94qk8nWTRcYx5y4UjDgjJLx8ni8Rrlcfj/WFq6iIJ/5RVf3qNZsmX1iFwkAPj8KhMLYmzAA0I4Zzckvdffx/juo7+y1O1yHxiag94aGJ+46epy+p2cgyYz6JnJS2HgZqCRnQH8lzvv8hlQRbhGjUqm87e23326Lrlj4xPzmw+Ott976YWVl5ZtY5rLZ5XKW797nbR0ZI7M8L8YiGQqY8T9DqFjEHUzjMrJjLUc8c3Vy6sk/FJTIAABYRaw+tVr9QGlp6b4YiIZL3Dh5L+T2229/V61W78Ba4zOZrFc3/Aglksg1bxiP/0ZNNApsSOUwyCmNs8Cj0lofzS0U4SgXoFar98ebcgHxrGAmWb9+/VOTnx3W2iXibP4rG344BgHIE33JEoiJcQj441sPF6VxbBAESL8aDkIaTb97QSmFQ6Fk4hxyfOPGjbgR2FgSdz6Yc7FYLF4AwEm5XH4P1vqyzAzuhNNl/k6ri7knM25BEAhAEAKSkuJym8RlUIfyhJygs33nE1skBe2reQK8Ma8jcrn80kOHDsVHduUFxLUFA850wjukVqs3Tu4xsdaVV1ewl2ZmjEdfsgRiZBgCnvg09NJ5ZER6Fvw/Ts+uvyFVtARnHVGpVPfV19fHpXIBiaBgJiktLd0/ucfEWktmsZgH77+HlZHEtURfsgRh0ooxTsSdLwaGIKuIyyAd9Tgs5/JPbBLnXgFwZkir1eq3KisrMSd2xAsJoWDAmXG0k3vME1hrXDqdvfuHN05aOGQnPDzGxgBA40vHZPAYVgiCCI0zmauk0ei9v88vSp/lN9q5bdu2h6MsVtAkjIJpbGycmB5Hi1n4eMuihSl/vf4aXfQlSxA8bgiMj8VVFj45BhYbCIDxvxYvMmfQGXiZuma5XL5WpVIFNHgvliSMggFn2m1OqFSq+/FqW359xeX5isWy+Kj0i0f0QwD4Y549PkUal9HJolPw5vXMZ5CHcwoGilmcZXgHqFSqzfX19UHNJo8VCaVgwJnWDu/W1dVtw1vf88ObWEI2m3T6YuHzwWDCGHMrBgLAUZjGIX0vGFzGT/78R2kZeE7dSf5WWVn5RhRFIkTCKRhwZhztk1qt9j9YawIWk/PNfXdTRRxOXNRixB3jsffFpPOYRhiCyDGwF7CEy2v7c9GiS/HSR7Ra7ScymezX0ZcsdBJSwWg0GrSysvJuAMAhrHWpKI3/5h0b3DAEOaMvXZzjdMBgbDSWVowrW8AknS8XkMNkdTxZUMKHAcCbBtFcWVn5Y41GE99ZkxeQkAoGnHH6WuVy+XWTih1rfW1Bfsq/br9tONBeJPOKoUE0Vtm92QLWAINKEcbkzeMUBgwPvVhSiqbS6HiZusNyuXxdY2NjwjVdi+tM3ovR39/v5fF46vLy8juwlGVpukgwZLHom4f0SbGRME5BURjQaH7A4UT1AUODIfOC9CQmDEFkWcD/4X08r6i/lJskw1lHVCrVT5599tmTUZYrLCSsBXOWhx9++LO6uroteOsv3nxDyiJR2lB0pUoAxsaiXjqQlsR0UGCItF7O4Za0jAPXpKQtxVuvq6v7XWVl5fvRlSp8JLyCAWfabb6o1Wpfx1qjUyjMT+/+CSuHz0848zKiuJwwMEY1ouRJ5zHIToTncBk/ueV/cgrW4a1rtdq3qqurn4muVOFlTigYcKby+pcAAMxEOwmfn7zvtpvJcbQXotOi0YooZfCYfSyyW933UADU/0hOweTWHa9Qd3j9+vUPaDSaKEsWXhLaB3Muo6OjbgDAh3K5fAMAYIbPpTAlhc+mUTu+6OrhzaW/mxAIAgMGEwEsVkS3SxQYsi5KT6LBMER2IZy8OSnU0d0LFxtzmKxinENGlErlVW+//TZmACORmFM/tOmq0iG5XH4b1vr/Z+/cY5vIrj9+Zvy2Y8exYycmHhIT5+UbFtj9/bZh2WLz0MarLoiXYyo1iFKkPuSqgnYl1G5F/uhDLaWvVdltRaS2Yllqt6W7qLTsrpSkXZEAKktK7PAOyZgCedIEEtuZeCoTR03ZGW8S7LEzMx8JCelYo+PJ9XfOPXPuOWtKlxp7Rh70dd69JzY3mmGKioOxMKORbJFOOWzUKMS6lyR7lxBXXAVG1rxLIBD4is/n+4BbrzIDrwQmwc2bN4P19fVqs9m8hsm+mrBK3u68/Ggslv3xqjlBLIaBVhsHuSJTIjNlN+VFZBJcjF4en5DWdR8os9tTjHn9eWNj46HR0dHcOpm6QHKyCVE6oGn6NAC8zGT7Q1fo5o7j/nLuvcpRlEoKqh3STIw4MeUprlWY88Qh9tP0n0Crxgilim3tvY9h2Esc+5RReJPkfZKGhgZfYrvEZNte67B9e73zstjTN0kkIoXR0bS/UcIx7FGpQS2eOQIAOY4Pv1G1/E4KcbmXHKHMK3i3RZohFAqNAMCZZLvNJxslY+uW2You3b13/erAoPhmAx7PUYqDwZDWB45Zqxw0aRVs1amC4vMW6xW30bSKxRxtampyHjlypJtjtzIObwUGppO+AwihMYQQ41bpxdKl2DvdV4ZHJiLiUzYWA8jXx0EmS5fIxO0mzbhcigu+odRqnb79G6Xl1ThgjP1BA4HAqz6fL6c70y0U3uZgZkiOow0AwA4m++2RBz3VP3ldG6WmxEgmT0tBRSXjWIz5YtDIr1YXaavSca3FjE2p6j6GVhGJu8vykT8ihLYv9noXNnibg5kh8YdDCDWSJNnOZC8r0Nt+tXXzsJiPAYCHY1J49PCpczEYBuNlBrHfiwSw/tfKKqRs4pJYkwihz/FVXEAIAgPTIhNpbm7+AlvP3l2rVlTufm7V37j3LAcZfPpBbYV5igdKGS703Ev0cIWju1qTx1ZMN5lYk6FQiNctRXidg5lNW1vboMPhuIgQ2spUg7DFUV18jgz33BgaFvZhvGgUwGCkQSJZ8Pa5vFAzppBKBH2CvcFs6dxmLl7NYp7w+/3bfD4fY1TNJwQRwczg9Xr/HAwGD7OYVW9ueUUlxfFF0es0Y8TjONy9s+Btkl4lu6ZVygTda9ehzjv/NcLGWvsTDAZ/5PV6T3PrVXbgfZL3SaxWq5okyQ4AYJyUd/Ffd7vXH/216d+RqJCTvnGodgCoVPN6AGEAkZVW/ZBKLhHsEHuLXHH7aM0zUr1UxjYRoJMgiBfC4fA4x65lBcFskWZIjqO96HK59jLZLVqtCQP86gc3bwk5h4ABhk2BLn9eAmPUyPuL85WCFRcAmPxxheNOikOMdFNT0+ZTp071cuxX1hCcwMB0PuaOx+PpMZvNm5i2iWvKlub3jIyc67x7f2l2PMwBYlEaCk044HPXmGWFmlGlTCLUt0cT+5YuO+/SG59nsU/6/f5dPp/vDMd+ZRVB5WBmU1tb+9tAIHCAyYYBqH+zY2tdw3L0Efee5QgUJYG+3jkPtDZq5LfyVTLBRn1fKikN7TAVf5rNHggEXvV6vce59Sr7CC4HM5tkEd67ALCJyT4Wjd6xHfrZyND4eC333uUI1TUUqNSfVHwX+VSZYViCY4JM7j6rzW99vRKtBgC2Sf6/Rwh5+FzvwoZgIxj4bxHeTpIkzzPZtQpFyd+/uEdi0WqFO5J2Dr17i7SKIaGKS7lKff2wvcbBJi4kSZ5FCDUKUVxA6AID0yIz3tzcvJetkrfGVFjz/fqNfdx7liMMD9EQT/3WukinFOo6enjQVknJcdzMYp8ppotw7FfOIMgk75O0tbX1OxyOywihLQwnr2GlpbgoRlHvfdjbZxOcKNM0DvF4FHT5jNukArWst0SvsgjtvmAAo98trwo+q81nOyE94ff7t/p8vg6OXcspBLUoUuH1ek8Gg8Gfspjl36vfWP9Shf1Djt3KDQb6ZRCLMUV4k3bT42M2gntQ7bJYb7j0xjo2ezAY/KHX6/0Lt17lHqLAzMLtdn8nEdCwmPFjDdsqd65Y3gIAc367whNwGPr4GSVTnqJfJsFLs+NS9ngmT9uyq7gk1fc+43a7f8ChSzmLKDCzCIfDD10u18sAcJvJbtKol7zt3e56bd3a9xObB+49zCKDgx8bcVKky1gf35zFrtK890bV8pVKnHX87TWXy7U5HA7z+hDjXBFcaPtJ9Pb2Ujqdris5jpbp/mDry222/ytZcqmjLxx7EImwDSvnF/G4BFRqCpTTCd18pZQkCtRmAa2hh26D+Z1v2uw1GgnrUYjI/v37t584cYLxASVEBF0Hk4qWlpYvu1yuI6k+Q8Xjg9vf8l96t/vKekFEgzrdJJTapCCVxp8j9L0KmWRZtl3iiN4DpeUnNxUWfTWVoLa2tu5ct27d77h1LbcRytNn3ly4cOEfZrM5ghDawCbEOIapP7ui1vqZqoqgWi4fuDE0NDQxSRl5K9zRKIBMRhnMhv5inZL3uRcFjl/0mCwt3yqzTzyv07NFtI9pb28/tHbtWraXBIKFnz+ENNLS0rLb5XIdnaMYT5y+ev3sW5f+SR/vvFwFAAQHLnKLQkE5NrwwoOffsQAaAEgACK43FJ6zKTQTe5aUvAIArOX/s2hFCG0MhUJiV8QnEAVmDvj9/i0ej+eXAMBWUMXEwOV79+/fGB7Jo6amaP4khbF4gaXwI4kE70827lrka+jxMChMplLhLyrViegzEZlVppgZ/T+QJHnC7XbvDoVC0cz7uvhY5IuDO5xOp6G1tfWvAPD/2fYly0zO6gg4lfxHpziHw2eOIYR2i5ELO/xPTKaJtra2YYIgXIFA4OsAcC/b/uQIiW2jPCkucQCgkjVCU8n/85WRQCCwB8OwRlFcRNKOx+Mx0DT9Jk3TFC08YvP4bCR5j6IZ9Idr/uR0OguyvQZFBMC+ffscZ8+e/QVN0wPZXvUcMh+Bmc2M2FBPcY1s8aivr+/4wYMHN1itVjGtIMItTqcT9/v9m2iaPknT9ES2fw0ZJl3iMCM0kTRdLxOQXV1dB5xOp+CnUy4UUY3TTF1dnYogiOq6ujoHQRAEAFgAgE/VvlMZqJ+iEtd0OBwShBDBcX1W4vuMB4PBR8l55j0kSd7q6Ojoam9v7w6Hw089iE7I/CcAAP//LazR1LfsgEMAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - hco.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - v2v.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - machineremediation.kubevirt.io
+          resources:
+          - machineremediationoperators
+          - machineremediationoperators/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - daemonsets
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - '*'
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consoleclidownloads
+          - consolequickstarts
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+        serviceAccountName: hyperconverged-cluster-operator
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networkaddonsoperator.network.kubevirt.io
+          resources:
+          - networkaddonsconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          - endpoints
+          - pods/exec
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - patch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - kubevirt-handler
+          - kubevirt-controller
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - put
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - delete
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines/status
+          verbs:
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancemigrations
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstancepresets
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - limitranges
+          verbs:
+          - watch
+          - list
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinerestores
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - update
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/addvolume
+          - virtualmachineinstances/removevolume
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachineinstances
+          verbs:
+          - update
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - version
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          - virtualmachineinstances/addvolume
+          - virtualmachineinstances/removevolume
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/pause
+          - virtualmachineinstances/unpause
+          - virtualmachineinstances/addvolume
+          - virtualmachineinstances/removevolume
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          verbs:
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancepresets
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes/source
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirtcommontemplatesbundles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirtmetricsaggregations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirtnodelabellerbundles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirttemplatevalidators
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - ssps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - ssps/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - ssps/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - templates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: ssp-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - cdi.kubevirt.io
+          - upload.cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - '*'
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - datavolumes
+          verbs:
+          - list
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis
+          verbs:
+          - get
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims/finalizers
+          - pods/finalizers
+          - volumesnapshots/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - events
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+          - create
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - nodemaintenance.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: node-maintenance-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - list
+          - watch
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - clusterrolebindings
+          verbs:
+          - update
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - clusterroles
+          verbs:
+          - update
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - hostpath-provisioner-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - hostpathprovisioner.kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - delete
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+        serviceAccountName: hostpath-provisioner-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - v2v.kubevirt.io
+          resources:
+          - vmimportconfigs
+          - vmimportconfigs/finalizers
+          - vmimportconfigs/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - '*'
+        serviceAccountName: vm-import-operator
+      deployments:
+      - label:
+          app.kubernetes.io/component: deployment
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+          name: hyperconverged-cluster-operator
+        name: hco-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-operator
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: deployment
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
+                name: hyperconverged-cluster-operator
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-operator
+                env:
+                - name: WEBHOOK_MODE
+                  value: "false"
+                - name: APP
+                  value: OPERATOR
+                - name: KVM_EMULATION
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:ca0ad2865a5d70abc8d1f5670c4191502eda2e8b68849e0b9f78f72e41cf7cc5
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-operator
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                - name: CONVERSION_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-v2v-conversion@sha256:c620233c71b805004c2cd38927c421b69d99b27cb40af521967e655882b2f815
+                - name: VMWARE_CONTAINER
+                  value: quay.io/kubevirt/kubevirt-vmware@sha256:ae5ccd98a49ab9e154ce482d2fa73f044b00211f273210a9cd371b40746d3c92
+                - name: SMBIOS
+                  value: |-
+                    Family: KubeVirt
+                    Manufacturer: KubeVirt
+                    Product: None
+                - name: MACHINETYPE
+                - name: HCO_KV_IO_VERSION
+                  value: 1.4.0
+                - name: KUBEVIRT_VERSION
+                  value: v0.38.1
+                - name: CDI_VERSION
+                  value: v1.30.0
+                - name: NETWORK_ADDONS_VERSION
+                  value: v0.47.0
+                - name: SSP_VERSION
+                  value: v0.1.3
+                - name: NMO_VERSION
+                  value: v0.7.0
+                - name: HPPO_VERSION
+                  value: v0.7.2
+                - name: VM_IMPORT_VERSION
+                  value: v0.3.0
+                image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:ca0ad2865a5d70abc8d1f5670c4191502eda2e8b68849e0b9f78f72e41cf7cc5
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /livez
+                    port: 6060
+                    scheme: HTTP
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                name: hyperconverged-cluster-operator
+                readinessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /readyz
+                    port: 6060
+                    scheme: HTTP
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - label:
+          app.kubernetes.io/component: deployment
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+          name: hyperconverged-cluster-webhook
+        name: hco-webhook
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hyperconverged-cluster-webhook
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: deployment
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
+                name: hyperconverged-cluster-webhook
+            spec:
+              containers:
+              - command:
+                - hyperconverged-cluster-webhook
+                env:
+                - name: WEBHOOK_MODE
+                  value: "true"
+                - name: APP
+                  value: WEBHOOK
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:af4a7e5219898364fd04ec5f9c6fa225637c69770327ee42d510680e27ccaf1e
+                - name: OPERATOR_NAME
+                  value: hyperconverged-cluster-webhook
+                - name: OPERATOR_NAMESPACE
+                  value: kubevirt-hyperconverged
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:af4a7e5219898364fd04ec5f9c6fa225637c69770327ee42d510680e27ccaf1e
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /livez
+                    port: 6060
+                    scheme: HTTP
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                name: hyperconverged-cluster-webhook
+                readinessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /readyz
+                    port: 6060
+                    scheme: HTTP
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                resources: {}
+              serviceAccountName: hyperconverged-cluster-operator
+      - label:
+          app.kubernetes.io/component: network
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: cluster-network-addons-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cluster-network-addons-operator
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: network
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
+                name: cluster-network-addons-operator
+            spec:
+              containers:
+              - env:
+                - name: MULTUS_IMAGE
+                  value: quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de
+                - name: LINUX_BRIDGE_IMAGE
+                  value: quay.io/kubevirt/cni-default-plugins@sha256:a90902cf3e5154424148bf3ba3c1bf90316cc77a54042cf6584fe8aedbe6daec
+                - name: LINUX_BRIDGE_MARKER_IMAGE
+                  value: quay.io/kubevirt/bridge-marker@sha256:799459f8509a06ea643aa2f6ac02826721a641333aacab07e53166139a5a66c3
+                - name: NMSTATE_HANDLER_IMAGE
+                  value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:3e9748a805d723fef24bc08e0830acec9718f2c7920d7aef6b6eee2e01630e48
+                - name: OVS_CNI_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-plugin@sha256:931cf8e546fd54544a4545fb9299baf373a17864dc1612198901ed1f4de5b9ca
+                - name: OVS_MARKER_IMAGE
+                  value: quay.io/kubevirt/ovs-cni-marker@sha256:f4d47dd43e70a79eedae6d25513a44e40795601d15f35e525da43cda6b1f4299
+                - name: KUBEMACPOOL_IMAGE
+                  value: quay.io/kubevirt/kubemacpool@sha256:3efeba40b46b41c8361bf0f247cf98471e70e0dae36fc43eb15d5dbd2e61946e
+                - name: MACVTAP_CNI_IMAGE
+                  value: quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/cluster-network-addons-operator@sha256:77f351df53d420a94d4b5074bc6bd57203b3af920e3b9867825687adfc2d675e
+                - name: OPERATOR_NAME
+                  value: cluster-network-addons-operator
+                - name: OPERATOR_VERSION
+                  value: v0.47.0
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERAND_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                image: quay.io/kubevirt/cluster-network-addons-operator@sha256:77f351df53d420a94d4b5074bc6bd57203b3af920e3b9867825687adfc2d675e
+                imagePullPolicy: IfNotPresent
+                name: cluster-network-addons-operator
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cluster-network-addons-operator
+      - label:
+          app.kubernetes.io/component: compute
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: virt-operator
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              kubevirt.io: virt-operator
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              annotations:
+                scheduler.alpha.kubernetes.io/critical-pod: ""
+              labels:
+                app.kubernetes.io/component: compute
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
+                kubevirt.io: virt-operator
+                prometheus.kubevirt.io: ""
+              name: virt-operator
+            spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: kubevirt.io
+                          operator: In
+                          values:
+                          - virt-operator
+                      topologyKey: kubernetes.io/hostname
+                    weight: 1
+              containers:
+              - command:
+                - virt-operator
+                - --port
+                - "8443"
+                - -v
+                - "2"
+                env:
+                - name: OPERATOR_IMAGE
+                  value: quay.io/kubevirt/virt-operator@sha256:3a4401be0dd4ba55e4277030cd46f9fcf7c626b262e6514a38f43e348f8902bb
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: KUBEVIRT_VERSION
+                  value: v0.38.1
+                - name: VIRT_API_SHASUM
+                  value: sha256:5d56548370fac393f085547e81bdb104025ad3e1b1478a296dd7d8ba16d7d394
+                - name: VIRT_CONTROLLER_SHASUM
+                  value: sha256:4fb8ecebfd50b06c24fa7c3aa33640c7b2c6bc877a16c3cc3bd960ffa9aa4518
+                - name: VIRT_HANDLER_SHASUM
+                  value: sha256:8068403bbaf1090c953aa4510cd8dd91279212093ac169baca6d8b5437301878
+                - name: VIRT_LAUNCHER_SHASUM
+                  value: sha256:84123d7271da7da8c5099a329ca55c38f228cc9e1d9c572a97c9d96badeccda2
+                image: quay.io/kubevirt/virt-operator@sha256:3a4401be0dd4ba55e4277030cd46f9fcf7c626b262e6514a38f43e348f8902bb
+                imagePullPolicy: IfNotPresent
+                name: virt-operator
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8444
+                  name: webhooks
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /metrics
+                    port: 8443
+                    scheme: HTTPS
+                  initialDelaySeconds: 5
+                  timeoutSeconds: 10
+                resources: {}
+                volumeMounts:
+                - mountPath: /etc/virt-operator/certificates
+                  name: kubevirt-operator-certs
+                  readOnly: true
+              priorityClassName: kubevirt-cluster-critical
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: kubevirt-operator
+              tolerations:
+              - key: CriticalAddonsOnly
+                operator: Exists
+              volumes:
+              - name: kubevirt-operator-certs
+                secret:
+                  optional: true
+                  secretName: kubevirt-operator-certs
+      - label:
+          app.kubernetes.io/component: schedule
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: ssp-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: ssp-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: schedule
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
+                control-plane: ssp-operator
+            spec:
+              containers:
+              - args:
+                - --enable-leader-election
+                command:
+                - /manager
+                env:
+                - name: KVM_INFO_IMAGE
+                - name: VALIDATOR_IMAGE
+                - name: VIRT_LAUNCHER_IMAGE
+                - name: NODE_LABELLER_IMAGE
+                - name: CPU_PLUGIN_IMAGE
+                - name: OPERATOR_VERSION
+                  value: v0.1.3
+                image: quay.io/kubevirt/ssp-operator@sha256:efe94ed877c7c6f7dc9486ac3929d217d21f3601f7d139bf7bf177e1607b58c8
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                resources: {}
+              serviceAccountName: ssp-operator
+              terminationGracePeriodSeconds: 10
+      - label:
+          app.kubernetes.io/component: storage
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: cdi-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cdi-operator
+              operator.cdi.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: storage
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
+                name: cdi-operator
+                operator.cdi.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                  value: v1.30.0
+                - name: CONTROLLER_IMAGE
+                  value: quay.io/kubevirt/cdi-controller@sha256:cafb1d269c63e897a6a3c257966fe832490078489099df188f0eb64c18676f0f
+                - name: IMPORTER_IMAGE
+                  value: quay.io/kubevirt/cdi-importer@sha256:60018f82d93368d8bb2fee6dbfa861e1b9fe14267d87436977596495462ac150
+                - name: CLONER_IMAGE
+                  value: quay.io/kubevirt/cdi-cloner@sha256:90554df9c23a53a4ccdd1c22ff3901b138061081828fcbd7de0cbe4f6cf32023
+                - name: APISERVER_IMAGE
+                  value: quay.io/kubevirt/cdi-apiserver@sha256:b82c0f6c388fd7f2fdc0f54f76c52ad373d6c3bb20a588fdc08f76baa364a5c6
+                - name: UPLOAD_SERVER_IMAGE
+                  value: quay.io/kubevirt/cdi-uploadserver@sha256:5b46790f0db7536f8734d764ffba46d00b69d50422baddf9b5e204eabca90ced
+                - name: UPLOAD_PROXY_IMAGE
+                  value: quay.io/kubevirt/cdi-uploadproxy@sha256:a342eb335a24fbdf372c38abe356c4efc05d022695e50231e232a3090a8f57ab
+                - name: VERBOSITY
+                  value: "1"
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: quay.io/kubevirt/cdi-operator@sha256:caf1fdce1d04eb7a8d86cef8207358e2b6e5d9f2e7cd23b08cb87904df1efd4a
+                imagePullPolicy: IfNotPresent
+                name: cdi-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                  protocol: TCP
+                resources: {}
+              nodeSelector:
+                kubernetes.io/os: linux
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cdi-operator
+              tolerations:
+              - key: CriticalAddonsOnly
+                operator: Exists
+      - label:
+          app.kubernetes.io/component: network
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: node-maintenance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: node-maintenance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: network
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
+                name: node-maintenance-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: node-maintenance-operator
+                image: quay.io/kubevirt/node-maintenance-operator@sha256:71bb8de714dc0de0616050d66405ccb58841930fc1562a61399e1b964a0b678a
+                imagePullPolicy: Always
+                name: node-maintenance-operator
+                resources: {}
+              serviceAccountName: node-maintenance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+      - label:
+          app.kubernetes.io/component: storage
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: hostpath-provisioner-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: hostpath-provisioner-operator
+              operator.hostpath-provisioner.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: storage
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
+                name: hostpath-provisioner-operator
+                operator.hostpath-provisioner.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: hostpath-provisioner-operator
+                - name: PROVISIONER_IMAGE
+                  value: quay.io/kubevirt/hostpath-provisioner@sha256:93085fb9d68e5e58b5886f4efc779307d345257165da958e4df8ee0c8994a765
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:74d53f8cd3906587a83dec04e747285c81c09b78515eb0bc5cf5c26ddcec9437
+                imagePullPolicy: IfNotPresent
+                name: hostpath-provisioner-operator
+                resources: {}
+              serviceAccountName: hostpath-provisioner-operator
+      - label:
+          app.kubernetes.io/component: import
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/part-of: hyperconverged-cluster
+          app.kubernetes.io/version: 1.4.0
+        name: vm-import-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: vm-import-operator
+              operator.v2v.kubevirt.io: ""
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: import
+                app.kubernetes.io/managed-by: olm
+                app.kubernetes.io/part-of: hyperconverged-cluster
+                app.kubernetes.io/version: 1.4.0
+                name: vm-import-operator
+                operator.v2v.kubevirt.io: ""
+            spec:
+              containers:
+              - env:
+                - name: DEPLOY_CLUSTER_RESOURCES
+                  value: "true"
+                - name: OPERATOR_VERSION
+                  value: v0.3.0
+                - name: CONTROLLER_IMAGE
+                  value: quay.io/kubevirt/vm-import-controller@sha256:ea074a875cc405b10a390638319a5f050d5a050f9846dc4d17dc53a42f625e39
+                - name: PULL_POLICY
+                  value: IfNotPresent
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: MONITORING_NAMESPACE
+                  value: openshift-monitoring
+                - name: VIRTV2V_IMAGE
+                  value: quay.io/kubevirt/vm-import-virtv2v@sha256:0474930bc8157e4082f705e69af2c7bd83658a6acd2a473443c6aef65ed6e3f2
+                image: quay.io/kubevirt/vm-import-operator@sha256:86b6097f7b5069b9c63ab7ede03c659621b7ca2d47e2952bb9d65e43f43ef444
+                imagePullPolicy: IfNotPresent
+                name: vm-import-operator
+                resources: {}
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: vm-import-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        serviceAccountName: cluster-network-addons-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        serviceAccountName: kubevirt-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: ssp-operator
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - events
+          - secrets
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        serviceAccountName: cdi-operator
+      - rules:
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - hostpath-provisioner
+          resources:
+          - daemonsets
+          verbs:
+          - delete
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - ""
+          resourceNames:
+          - hostpath-provisioner-admin
+          resources:
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+        serviceAccountName: hostpath-provisioner-operator
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  - VM
+  labels:
+    alm-owner-kubevirt: kubevirt-hyperconverged
+    operated-by: kubevirt-hyperconverged
+  links:
+  - name: KubeVirt project
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/hyperconverged-cluster-operator
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  relatedImages:
+  - image: quay.io/kubevirt/bridge-marker@sha256:799459f8509a06ea643aa2f6ac02826721a641333aacab07e53166139a5a66c3
+    name: bridge-marker
+  - image: quay.io/kubevirt/cdi-apiserver@sha256:b82c0f6c388fd7f2fdc0f54f76c52ad373d6c3bb20a588fdc08f76baa364a5c6
+    name: cdi-apiserver
+  - image: quay.io/kubevirt/cdi-cloner@sha256:90554df9c23a53a4ccdd1c22ff3901b138061081828fcbd7de0cbe4f6cf32023
+    name: cdi-cloner
+  - image: quay.io/kubevirt/cdi-controller@sha256:cafb1d269c63e897a6a3c257966fe832490078489099df188f0eb64c18676f0f
+    name: cdi-controller
+  - image: quay.io/kubevirt/cdi-importer@sha256:60018f82d93368d8bb2fee6dbfa861e1b9fe14267d87436977596495462ac150
+    name: cdi-importer
+  - image: quay.io/kubevirt/cdi-operator@sha256:caf1fdce1d04eb7a8d86cef8207358e2b6e5d9f2e7cd23b08cb87904df1efd4a
+    name: cdi-operator
+  - image: quay.io/kubevirt/cdi-uploadproxy@sha256:a342eb335a24fbdf372c38abe356c4efc05d022695e50231e232a3090a8f57ab
+    name: cdi-uploadproxy
+  - image: quay.io/kubevirt/cdi-uploadserver@sha256:5b46790f0db7536f8734d764ffba46d00b69d50422baddf9b5e204eabca90ced
+    name: cdi-uploadserver
+  - image: quay.io/kubevirt/cluster-network-addon-multus@sha256:32867c73cda4d605651b898dc85fea67d93191c47f27e1ad9e9f2b9041c518de
+    name: cluster-network-addon-multus
+  - image: quay.io/kubevirt/cluster-network-addons-operator@sha256:77f351df53d420a94d4b5074bc6bd57203b3af920e3b9867825687adfc2d675e
+    name: cluster-network-addons-operator
+  - image: quay.io/kubevirt/cni-default-plugins@sha256:a90902cf3e5154424148bf3ba3c1bf90316cc77a54042cf6584fe8aedbe6daec
+    name: cni-default-plugins
+  - image: quay.io/kubevirt/hostpath-provisioner@sha256:93085fb9d68e5e58b5886f4efc779307d345257165da958e4df8ee0c8994a765
+    name: hostpath-provisioner
+  - image: quay.io/kubevirt/hostpath-provisioner-operator@sha256:74d53f8cd3906587a83dec04e747285c81c09b78515eb0bc5cf5c26ddcec9437
+    name: hostpath-provisioner-operator
+  - image: quay.io/kubevirt/hyperconverged-cluster-operator@sha256:ca0ad2865a5d70abc8d1f5670c4191502eda2e8b68849e0b9f78f72e41cf7cc5
+    name: hyperconverged-cluster-operator
+  - image: quay.io/kubevirt/hyperconverged-cluster-webhook@sha256:af4a7e5219898364fd04ec5f9c6fa225637c69770327ee42d510680e27ccaf1e
+    name: hyperconverged-cluster-webhook
+  - image: quay.io/kubevirt/kubemacpool@sha256:3efeba40b46b41c8361bf0f247cf98471e70e0dae36fc43eb15d5dbd2e61946e
+    name: kubemacpool
+  - image: quay.io/nmstate/kubernetes-nmstate-handler@sha256:3e9748a805d723fef24bc08e0830acec9718f2c7920d7aef6b6eee2e01630e48
+    name: kubernetes-nmstate-handler
+  - image: quay.io/kubevirt/kubevirt-v2v-conversion@sha256:c620233c71b805004c2cd38927c421b69d99b27cb40af521967e655882b2f815
+    name: kubevirt-v2v-conversion
+  - image: quay.io/kubevirt/kubevirt-vmware@sha256:ae5ccd98a49ab9e154ce482d2fa73f044b00211f273210a9cd371b40746d3c92
+    name: kubevirt-vmware
+  - image: quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266
+    name: macvtap-cni
+  - image: quay.io/kubevirt/node-maintenance-operator@sha256:71bb8de714dc0de0616050d66405ccb58841930fc1562a61399e1b964a0b678a
+    name: node-maintenance-operator
+  - image: quay.io/kubevirt/ovs-cni-marker@sha256:f4d47dd43e70a79eedae6d25513a44e40795601d15f35e525da43cda6b1f4299
+    name: ovs-cni-marker
+  - image: quay.io/kubevirt/ovs-cni-plugin@sha256:931cf8e546fd54544a4545fb9299baf373a17864dc1612198901ed1f4de5b9ca
+    name: ovs-cni-plugin
+  - image: quay.io/kubevirt/ssp-operator@sha256:efe94ed877c7c6f7dc9486ac3929d217d21f3601f7d139bf7bf177e1607b58c8
+    name: ssp-operator
+  - image: quay.io/kubevirt/virt-api@sha256:5d56548370fac393f085547e81bdb104025ad3e1b1478a296dd7d8ba16d7d394
+    name: virt-api
+  - image: quay.io/kubevirt/virt-controller@sha256:4fb8ecebfd50b06c24fa7c3aa33640c7b2c6bc877a16c3cc3bd960ffa9aa4518
+    name: virt-controller
+  - image: quay.io/kubevirt/virt-handler@sha256:8068403bbaf1090c953aa4510cd8dd91279212093ac169baca6d8b5437301878
+    name: virt-handler
+  - image: quay.io/kubevirt/virt-launcher@sha256:84123d7271da7da8c5099a329ca55c38f228cc9e1d9c572a97c9d96badeccda2
+    name: virt-launcher
+  - image: quay.io/kubevirt/virt-operator@sha256:3a4401be0dd4ba55e4277030cd46f9fcf7c626b262e6514a38f43e348f8902bb
+    name: virt-operator
+  - image: quay.io/kubevirt/vm-import-controller@sha256:ea074a875cc405b10a390638319a5f050d5a050f9846dc4d17dc53a42f625e39
+    name: vm-import-controller
+  - image: quay.io/kubevirt/vm-import-operator@sha256:86b6097f7b5069b9c63ab7ede03c659621b7ca2d47e2952bb9d65e43f43ef444
+    name: vm-import-operator
+  - image: quay.io/kubevirt/vm-import-virtv2v@sha256:0474930bc8157e4082f705e69af2c7bd83658a6acd2a473443c6aef65ed6e3f2
+    name: vm-import-virtv2v
+  replaces: kubevirt-hyperconverged-operator.v1.3.0
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-hyperconverged
+      operated-by: kubevirt-hyperconverged
+  version: 1.4.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1beta1
+    - v1
+    containerPort: 4343
+    deploymentName: hco-webhook
+    failurePolicy: Fail
+    generateName: validate-hco.kubevirt.io
+    rules:
+    - apiGroups:
+      - hco.kubevirt.io
+      apiVersions:
+      - v1alpha1
+      - v1beta1
+      operations:
+      - CREATE
+      - DELETE
+      - UPDATE
+      resources:
+      - hyperconvergeds
+    sideEffects: None
+    timeoutSeconds: 30
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-hco-kubevirt-io-v1beta1-hyperconverged
+  - admissionReviewVersions:
+    - v1beta1
+    - v1
+    containerPort: 4343
+    deploymentName: hco-webhook
+    failurePolicy: Fail
+    generateName: mutate-ns-hco.kubevirt.io
+    objectSelector:
+      matchLabels:
+        name: kubevirt-hyperconverged
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - DELETE
+      resources:
+      - namespaces
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 30
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-ns-hco-kubevirt-io
+  - admissionReviewVersions:
+    - v1beta1
+    containerPort: 9443
+    deploymentName: ssp-operator
+    failurePolicy: Fail
+    generateName: vssp.kb.io
+    rules:
+    - apiGroups:
+      - ssp.kubevirt.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - ssps
+    sideEffects: None
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-ssp-kubevirt-io-v1beta1-ssp
+  - admissionReviewVersions:
+    - v1beta1
+    containerPort: 8443
+    deploymentName: node-maintenance-operator
+    failurePolicy: Fail
+    generateName: nodemaintenance-validation.kubevirt.io
+    rules:
+    - apiGroups:
+      - nodemaintenance.kubevirt.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - nodemaintenances
+      scope: Cluster
+    sideEffects: None
+    timeoutSeconds: 15
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/kubevirt00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/kubevirt00.crd.yaml
@@ -1,0 +1,1072 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    categories:
+    - all
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KubeVirt represents the object deploying all KubeVirt resources
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            certificateRotateStrategy:
+              properties:
+                selfSigned:
+                  properties:
+                    caOverlapInterval:
+                      type: string
+                    caRotateInterval:
+                      type: string
+                    certRotateInterval:
+                      type: string
+                  type: object
+              type: object
+            configuration:
+              description: holds kubevirt configurations. same as the virt-configMap
+              properties:
+                cpuModel:
+                  type: string
+                cpuRequest:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                developerConfiguration:
+                  description: DeveloperConfiguration holds developer options
+                  properties:
+                    cpuAllocationRatio:
+                      type: integer
+                    featureGates:
+                      items:
+                        type: string
+                      type: array
+                    logVerbosity:
+                      description: LogVerbosity sets log verbosity level of  various components
+                      properties:
+                        nodeVerbosity:
+                          additionalProperties:
+                            type: integer
+                          description: NodeVerbosity represents a map of nodes with a specific verbosity level
+                          type: object
+                        virtAPI:
+                          type: integer
+                        virtController:
+                          type: integer
+                        virtHandler:
+                          type: integer
+                        virtLauncher:
+                          type: integer
+                        virtOperator:
+                          type: integer
+                      type: object
+                    memoryOvercommit:
+                      type: integer
+                    nodeSelectors:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    pvcTolerateLessSpaceUpToPercent:
+                      type: integer
+                    useEmulation:
+                      type: boolean
+                  type: object
+                emulatedMachines:
+                  items:
+                    type: string
+                  type: array
+                imagePullPolicy:
+                  description: PullPolicy describes a policy for if/when to pull a container image
+                  type: string
+                machineType:
+                  type: string
+                memBalloonStatsPeriod:
+                  format: int32
+                  type: integer
+                migrations:
+                  description: MigrationConfiguration holds migration options
+                  properties:
+                    allowAutoConverge:
+                      type: boolean
+                    allowPostCopy:
+                      type: boolean
+                    bandwidthPerMigration:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    completionTimeoutPerGiB:
+                      format: int64
+                      type: integer
+                    nodeDrainTaintKey:
+                      type: string
+                    parallelMigrationsPerCluster:
+                      format: int32
+                      type: integer
+                    parallelOutboundMigrationsPerNode:
+                      format: int32
+                      type: integer
+                    progressTimeout:
+                      format: int64
+                      type: integer
+                    unsafeMigrationOverride:
+                      type: boolean
+                  type: object
+                network:
+                  description: NetworkConfiguration holds network options
+                  properties:
+                    defaultNetworkInterface:
+                      type: string
+                    permitBridgeInterfaceOnPodNetwork:
+                      type: boolean
+                    permitSlirpInterface:
+                      type: boolean
+                  type: object
+                ovmfPath:
+                  type: string
+                permittedHostDevices:
+                  description: PermittedHostDevices holds inforamtion about devices allowed for passthrough
+                  properties:
+                    mediatedDevices:
+                      items:
+                        description: MediatedHostDevice represents a host mediated device allowed for passthrough
+                        properties:
+                          externalResourceProvider:
+                            type: boolean
+                          mdevNameSelector:
+                            type: string
+                          resourceName:
+                            type: string
+                        required:
+                        - mdevNameSelector
+                        - resourceName
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    pciHostDevices:
+                      items:
+                        description: PciHostDevice represents a host PCI device allowed for passthrough
+                        properties:
+                          externalResourceProvider:
+                            type: boolean
+                          pciVendorSelector:
+                            type: string
+                          resourceName:
+                            type: string
+                        required:
+                        - pciVendorSelector
+                        - resourceName
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                selinuxLauncherType:
+                  type: string
+                smbios:
+                  properties:
+                    family:
+                      type: string
+                    manufacturer:
+                      type: string
+                    product:
+                      type: string
+                    sku:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                supportedGuestAgentVersions:
+                  items:
+                    type: string
+                  type: array
+              type: object
+            customizeComponents:
+              properties:
+                patches:
+                  items:
+                    properties:
+                      patch:
+                        type: string
+                      resourceName:
+                        type: string
+                      resourceType:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+            imagePullPolicy:
+              description: The ImagePullPolicy to use.
+              type: string
+            imageRegistry:
+              description: The image registry to pull the container images from Defaults to the same registry the operator's container image is pulled from.
+              type: string
+            imageTag:
+              description: The image tag to use for the continer images installed. Defaults to the same tag as the operator's container image.
+              type: string
+            infra:
+              description: selectors and tolerations that should apply to KubeVirt infrastructure components
+              properties:
+                nodePlacement:
+                  description: nodePlacement decsribes scheduling confiuguration for specific KubeVirt components
+                  properties:
+                    affinity:
+                      description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms. The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources, in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources, in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                      type: object
+                    tolerations:
+                      description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                      items:
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            monitorAccount:
+              description: The name of the Prometheus service account that needs read-access to KubeVirt endpoints Defaults to prometheus-k8s
+              type: string
+            monitorNamespace:
+              description: The namespace Prometheus is deployed in Defaults to openshift-monitor
+              type: string
+            productName:
+              description: Designate the apps.kubevirt.io/part-of label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductName is not specified, the part-of label will be omitted.
+              type: string
+            productVersion:
+              description: Designate the apps.kubevirt.io/version label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductVersion is not specified, KubeVirt's version will be used.
+              type: string
+            uninstallStrategy:
+              description: Specifies if kubevirt can be deleted if workloads are still present. This is mainly a precaution to avoid accidental data loss
+              type: string
+            workloads:
+              description: selectors and tolerations that should apply to KubeVirt workloads
+              properties:
+                nodePlacement:
+                  description: nodePlacement decsribes scheduling confiuguration for specific KubeVirt components
+                  properties:
+                    affinity:
+                      description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms. The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources, in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources, in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                      type: object
+                    tolerations:
+                      description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                      items:
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          type: object
+        status:
+          description: KubeVirtStatus represents information pertaining to a KubeVirt deployment.
+          properties:
+            conditions:
+              items:
+                description: KubeVirtCondition represents a condition of a KubeVirt deployment
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    nullable: true
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            observedDeploymentConfig:
+              type: string
+            observedDeploymentID:
+              type: string
+            observedKubeVirtRegistry:
+              type: string
+            observedKubeVirtVersion:
+              type: string
+            operatorVersion:
+              type: string
+            phase:
+              description: KubeVirtPhase is a label for the phase of a KubeVirt deployment at the current time.
+              type: string
+            targetDeploymentConfig:
+              type: string
+            targetDeploymentID:
+              type: string
+            targetKubeVirtRegistry:
+              type: string
+            targetKubeVirtVersion:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: false
+  - name: v1alpha3
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/node-maintenance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/node-maintenance00.crd.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nodemaintenances.nodemaintenance.kubevirt.io
+spec:
+  group: nodemaintenance.kubevirt.io
+  names:
+    kind: NodeMaintenance
+    listKind: NodeMaintenanceList
+    plural: nodemaintenances
+    singular: nodemaintenance
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: NodeMaintenance is the Schema for the nodemaintenances API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: NodeMaintenanceSpec defines the desired state of NodeMaintenance
+          properties:
+            nodeName:
+              description: Node name to apply maintanance on/off
+              type: string
+            reason:
+              description: Reason for maintanance
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          description: NodeMaintenanceStatus defines the observed state of NodeMaintenance
+          properties:
+            errorOnLeaseCount:
+              description: Consecutive number of errors upon obtaining a lease
+              type: integer
+            evictionPods:
+              description: EvictionPods is the total number of pods up for eviction
+                from the start
+              type: integer
+            lastError:
+              description: LastError represents the latest error if any in the latest
+                reconciliation
+              type: string
+            pendingPods:
+              description: PendingPods is a list of pending pods for eviction
+              items:
+                type: string
+              type: array
+            phase:
+              description: Phase is the represtation of the maintenance progress (Running,Succeeded,Failed)
+              type: string
+            totalpods:
+              description: TotalPods is the total number of all pods on the node from
+                the start
+              type: integer
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/scheduling-scale-performance00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/scheduling-scale-performance00.crd.yaml
@@ -1,0 +1,855 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  name: ssps.ssp.kubevirt.io
+spec:
+  group: ssp.kubevirt.io
+  names:
+    kind: SSP
+    listKind: SSPList
+    plural: ssps
+    singular: ssp
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: SSP is the Schema for the ssps API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SSPSpec defines the desired state of SSP
+            properties:
+              commonTemplates:
+                description: CommonTemplates is the configuration of the common templates operand
+                properties:
+                  namespace:
+                    description: Namespace is the k8s namespace where CommonTemplates should be installed
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - namespace
+                type: object
+              nodeLabeller:
+                description: NodeLabeller is configuration of the node-labeller operand
+                properties:
+                  placement:
+                    description: Placement describes the node scheduling configuration
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              templateValidator:
+                description: TemplateValidator is configuration of the template validator operand
+                properties:
+                  placement:
+                    description: Placement describes the node scheduling configuration
+                    properties:
+                      affinity:
+                        description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                        type: object
+                      tolerations:
+                        description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  replicas:
+                    default: 2
+                    description: Replicas is the number of replicas of the template validator pod
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+            required:
+            - commonTemplates
+            type: object
+          status:
+            description: SSPStatus defines the observed state of SSP
+            properties:
+              conditions:
+                description: A list of current conditions of the resource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the resource
+                type: string
+              operatorVersion:
+                description: The version of the resource as defined by the operator
+                type: string
+              paused:
+                description: Paused is true when the operator notices paused annotation.
+                type: boolean
+              phase:
+                description: Phase is the current phase of the deployment
+                type: string
+              targetVersion:
+                description: The desired version of the resource
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/vm-import-operator00.crd.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/manifests/vm-import-operator00.crd.yaml
@@ -1,0 +1,903 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.v2v.kubevirt.io: ""
+  name: vmimportconfigs.v2v.kubevirt.io
+spec:
+  group: v2v.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: VMImportConfig
+    listKind: VMImportConfigList
+    plural: vmimportconfigs
+    singular: vmimportconfig
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VMImportConfig is the Schema for the vmimportconfigs API
+        properties:
+          apiVersion:
+            description: APIVersion defines the versioned schema of this representation of an object
+            type: string
+          kind:
+            description: Kind is a string value representing the REST resource this object represents
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VMImportConfigSpec defines the desired state of VMImportConfig
+            properties:
+              imagePullPolicy:
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes vm import infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: VMImportConfigStatus defines the observed state of VMImportConfig
+            properties:
+              conditions:
+                description: A list of current conditions of the VMImportConfig resource
+                items:
+                  properties:
+                    lastHeartbeatTime:
+                      description: Last time the state of the condition was checked
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the state of the condition changed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message related to the last condition change
+                      type: string
+                    reason:
+                      description: Reason the last condition changed
+                      type: string
+                    status:
+                      description: Current status of the condition, True, False, Unknown
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the VMImportConfig resource
+                type: string
+              operatorVersion:
+                description: The version of the VMImportConfig resource as defined by the operator
+                type: string
+              phase:
+                description: VMImportPhase is the current phase of the VMImport deployment
+                type: string
+              targetVersion:
+                description: The desired version of the VMImportConfig resource
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VMImportConfig is the Schema for the vmimportconfigs API
+        properties:
+          apiVersion:
+            description: APIVersion defines the versioned schema of this representation of an object
+            type: string
+          kind:
+            description: Kind is a string value representing the REST resource this object represents
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VMImportConfigSpec defines the desired state of VMImportConfig
+            properties:
+              imagePullPolicy:
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              infra:
+                description: Rules on which nodes vm import infrastructure pods will be scheduled
+                properties:
+                  affinity:
+                    description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
+                    type: object
+                  tolerations:
+                    description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: ' defines the status of the installation'
+            properties:
+              conditions:
+                description: A list of current conditions of the resource
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedVersion:
+                description: The observed version of the resource
+                type: string
+              operatorVersion:
+                description: The version of the resource as defined by the operator
+                type: string
+              phase:
+                description: Phase is the current phase of the deployment
+                type: string
+              targetVersion:
+                description: The desired version of the resource
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/community-operators/community-kubevirt-hyperconverged/1.4.0/metadata/annotations.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/1.4.0/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: community-kubevirt-hyperconverged
+  com.redhat.openshift.versions: "=v4.8"

--- a/community-operators/community-kubevirt-hyperconverged/ci.yaml
+++ b/community-operators/community-kubevirt-hyperconverged/ci.yaml
@@ -1,0 +1,3 @@
+---
+# Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
+updateGraph: replaces-mode


### PR DESCRIPTION
HCO operator repository is:
https://github.com/kubevirt/hyperconverged-cluster-operator

Signed-off-by: orenc1 <ocohen@redhat.com>

Thanks submitting your Operator. Please check below list before you create your Pull Request.

### New Submissions

* [x] Does your operator have [nested directory structure](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#create-a-bundle)?
* [ ] Have you selected the Project *Community Operator Submissions* in your PR on the right-hand menu bar?
* [x] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md)?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
* [x] Have you tested your Operator with all Custom Resource Definitions?
* [x] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
* [x] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
* [x] Have you considered whether you want use [semantic versioning order](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#updating-your-existing-operator)?
* [x] Is operator [icon](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#operator-icon) set?

### Updates to existing Operators

* [ ] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#updating-your-existing-operator)?
* [ ] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
* [ ] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` or `annotations.yaml` ?
* [ ] Have you tested an update to your Operator when deployed via OLM?
* [ ] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-required-fields.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo

Remember that you can preview your CSV [here](https://operatorhub.io/preview).

--

<sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file an issue against this repo and explain your need

<sup>2</sup> For more information see [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.svg)
