### PR TITLE
chore : python : use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/Dockerfile.mkdoc
+++ b/Dockerfile.mkdoc
@@ -1,4 +1,4 @@
 FROM fedora:33
 RUN dnf install python3-pip git mkdocs-material -y
-RUN pip install mkpdfs-mkdocs mkdocs-mermaid2-plugin
+RUN pip install --no-cache-dir mkpdfs-mkdocs mkdocs-mermaid2-plugin
 CMD ["/bin/bash"]

--- a/scripts/utils/Makefile
+++ b/scripts/utils/Makefile
@@ -45,7 +45,7 @@ dependencies.install.jq: ## Install jq
 	@echo "Installed"
 
 dependencies.install.operator-courier: ## Install operator-courier
-	@python3 -m pip install operator-courier==${COURIER_VER}
+	@python3 -m pip install --no-cache-dir operator-courier==${COURIER_VER}
 	@echo "Installed"
 
 dependencies.install.operator-sdk: ## Install operator-sdk


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>