### PR TITLE
Fixing replaces for cockroachdb

### DIFF
--- a/upstream-community-operators/cockroachdb/5.0.4/manifests/cockroachdb.clusterserviceversion.yaml
+++ b/upstream-community-operators/cockroachdb/5.0.4/manifests/cockroachdb.clusterserviceversion.yaml
@@ -837,3 +837,4 @@ spec:
     name: Helm Community
     url: https://artifacthub.io/packages/helm/cockroachdb/cockroachdb
   version: 5.0.4
+  replaces: cockroachdb.v5.0.3


### PR DESCRIPTION
Signed-off-by: Martin Vala <mavala@redhat.com>

@dmesser I am fixing replaces in `5.0.4` version since it is in same channel as `5.0.3`. Do you agree?