### PR TITLE
Add missing metadata to the assisted-installer operator CSV

### DIFF
--- a/community-operators/assisted-service-operator/0.0.1/adi.io.my.domain_agents.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/adi.io.my.domain_agents.yaml
@@ -1,0 +1,377 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: agents.adi.io.my.domain
+spec:
+  group: adi.io.my.domain
+  names:
+    kind: Agent
+    listKind: AgentList
+    plural: agents
+    singular: agent
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Agent is the Schema for the hosts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentSpec defines the desired state of Agent
+            properties:
+              approved:
+                type: boolean
+              clusterDeploymentName:
+                description: ClusterReference represents a Cluster Reference. It has enough information to retrieve cluster in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a cluster resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the cluster name must be unique.
+                    type: string
+                type: object
+              hostname:
+                type: string
+              installation_disk_path:
+                description: 'InstallationDiskPath defines the installation destination disk. e.g.: /dev/sda'
+                type: string
+              machineConfigPool:
+                type: string
+              role:
+                description: "HostRole host role \n swagger:model host-role"
+                type: string
+            required:
+            - approved
+            - clusterDeploymentName
+            - role
+            type: object
+          status:
+            description: AgentStatus defines the observed state of Agent
+            properties:
+              apiVIPConnectivity:
+                type: boolean
+              bootstrap:
+                type: boolean
+              checkedInTime:
+                description: 'Name in REST API: checked_in_at'
+                format: date-time
+                type: string
+              conditions:
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              connectivity:
+                items:
+                  properties:
+                    hostDeploymentName:
+                      description: AgentReference represents a Agent Reference. It has enough information to retrieve an agent in any namespace
+                      properties:
+                        name:
+                          description: Name is unique within a namespace to reference an agent resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the agent name must be unique.
+                          type: string
+                      type: object
+                    l2Connectivity:
+                      properties:
+                        outgoingIPAddress:
+                          type: string
+                        outgoingNIC:
+                          type: string
+                        remoteIPAddress:
+                          type: string
+                        remoteMAC:
+                          type: string
+                        successful:
+                          type: boolean
+                      type: object
+                    l3Connectivity:
+                      properties:
+                        outgoingNIC:
+                          type: string
+                        remoteIPAddress:
+                          type: string
+                        successful:
+                          type: boolean
+                      type: object
+                  required:
+                  - hostDeploymentName
+                  type: object
+                type: array
+              discoveryAgentVersion:
+                type: string
+              hostValidationInfo:
+                properties:
+                  hardware:
+                    properties:
+                      hasCPUCoresForRole:
+                        type: string
+                      hasInventory:
+                        type: string
+                      hasMemoryForRole:
+                        type: string
+                      hasMinCPUCores:
+                        type: string
+                      hasMinMemory:
+                        type: string
+                      hasMinValidDisks:
+                        type: string
+                      isHostnameUnique:
+                        type: string
+                      isHostnameValid:
+                        type: string
+                      isPlatformValid:
+                        type: string
+                    type: object
+                  network:
+                    properties:
+                      apiVIPConnected:
+                        type: string
+                      belongsToMachineCIDR:
+                        type: string
+                      belongsToMajorityGroup:
+                        type: string
+                      connected:
+                        type: string
+                      machineCIDRDefined:
+                        type: string
+                      ntpSynced:
+                        type: string
+                    type: object
+                type: object
+              hostname:
+                type: string
+              installerVersion:
+                type: string
+              inventory:
+                properties:
+                  bmcAddress:
+                    type: string
+                  bmcV6Address:
+                    type: string
+                  boot:
+                    properties:
+                      currentBootMode:
+                        type: string
+                      pxeInterface:
+                        type: string
+                    type: object
+                  cpu:
+                    properties:
+                      architecture:
+                        type: string
+                      clockMegahertz:
+                        description: 'Name in REST API: frequency'
+                        format: int64
+                        type: integer
+                      count:
+                        format: int64
+                        type: integer
+                      flags:
+                        items:
+                          type: string
+                        type: array
+                      modelName:
+                        type: string
+                    type: object
+                  disks:
+                    items:
+                      properties:
+                        bootable:
+                          type: boolean
+                        byPath:
+                          type: string
+                        driveType:
+                          type: string
+                        hctl:
+                          type: string
+                        installationEligibility:
+                          properties:
+                            eligible:
+                              type: boolean
+                            notEligibleReasons:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - notEligibleReasons
+                          type: object
+                        ioPerf:
+                          properties:
+                            syncDurationMilliseconds:
+                              description: 99th percentile of fsync duration in milliseconds
+                              format: int64
+                              type: integer
+                          type: object
+                        model:
+                          type: string
+                        name:
+                          type: string
+                        path:
+                          type: string
+                        serial:
+                          type: string
+                        sizeBytes:
+                          format: int64
+                          type: integer
+                        smart:
+                          type: string
+                        vendor:
+                          type: string
+                        wwn:
+                          type: string
+                      type: object
+                    type: array
+                  hostname:
+                    type: string
+                  interfaces:
+                    items:
+                      properties:
+                        biosDevName:
+                          type: string
+                        clientID:
+                          type: string
+                        flags:
+                          items:
+                            type: string
+                          type: array
+                        hasCarrier:
+                          type: boolean
+                        ipV4Addresses:
+                          items:
+                            type: string
+                          type: array
+                        ipV6Addresses:
+                          items:
+                            type: string
+                          type: array
+                        macAddress:
+                          type: string
+                        mtu:
+                          format: int64
+                          type: integer
+                        name:
+                          type: string
+                        product:
+                          type: string
+                        speedMbps:
+                          format: int64
+                          type: integer
+                        vendor:
+                          type: string
+                      required:
+                      - flags
+                      - ipV4Addresses
+                      - ipV6Addresses
+                      type: object
+                    type: array
+                  memory:
+                    properties:
+                      physicalBytes:
+                        format: int64
+                        type: integer
+                      usableBytes:
+                        format: int64
+                        type: integer
+                    type: object
+                  reportTime:
+                    description: 'Name in REST API: timestamp'
+                    format: date-time
+                    type: string
+                  systemVendor:
+                    properties:
+                      manufacturer:
+                        type: string
+                      productName:
+                        type: string
+                      serialNumber:
+                        type: string
+                      virtual:
+                        type: boolean
+                    type: object
+                type: object
+              logsCollectedTime:
+                description: 'Name in REST API: logs_collected_at'
+                format: date-time
+                type: string
+              ntpSources:
+                items:
+                  properties:
+                    sourceName:
+                      type: string
+                    sourceState:
+                      description: "SourceState source state \n swagger:model source_state"
+                      type: string
+                  type: object
+                type: array
+              progress:
+                properties:
+                  currentStage:
+                    description: "HostStage host stage \n swagger:model host-stage"
+                    type: string
+                  progressInfo:
+                    type: string
+                  stageStartTime:
+                    description: 'Name in REST API: stage_started_at'
+                    type: string
+                  stageUpdateTime:
+                    description: 'Name in REST API: stage_updated_at'
+                    type: string
+                type: object
+              state:
+                type: string
+              stateInfo:
+                type: string
+              stateUpdatedTime:
+                description: 'Name in REST API: status_updated_at'
+                format: date-time
+                type: string
+              updateTime:
+                description: 'Name in REST API: updated_at'
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/community-operators/assisted-service-operator/0.0.1/adi.io.my.domain_installenvs.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/adi.io.my.domain_installenvs.yaml
@@ -1,0 +1,185 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: installenvs.adi.io.my.domain
+spec:
+  group: adi.io.my.domain
+  names:
+    kind: InstallEnv
+    listKind: InstallEnvList
+    plural: installenvs
+    singular: installenv
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              additionalNTPSources:
+                description: AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster hosts. They are added to any NTP sources that were configured through other means.
+                items:
+                  type: string
+                type: array
+              agentLabelSelector:
+                description: AgentLabelSelector specifies a label that should be applied to Agents that boot from the installation media of this InstallEnv. This is how a user would identify which agents are associated with a particular InstallEnv.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              agentLabels:
+                additionalProperties:
+                  type: string
+                description: AgentLabels lists labels to apply to Agents that are associated with this InstallEnv upon the creation of the Agents.
+                type: object
+              clusterRef:
+                description: ClusterRef is the reference to the single ClusterDeployment that will be installed from this InstallEnv. Future versions will allow for multiple ClusterDeployments and this reference will be removed.
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a cluster resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the cluster name must be unique.
+                    type: string
+                type: object
+              ignitionConfigOverride:
+                description: Json formatted string containing the user overrides for the initial ignition config
+                type: string
+              nmStateConfigLabelSelector:
+                description: NmstateConfigLabelSelector associates NMStateConfigs for hosts that are considered part of this installation environment.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              proxy:
+                description: Proxy defines the proxy settings for agents and clusters that use the InstallEnv. If unset, the agents and clusters will not be configured to use a proxy.
+                properties:
+                  httpProxy:
+                    description: HTTPProxy is the URL of the proxy for HTTP requests.
+                    type: string
+                  httpsProxy:
+                    description: HTTPSProxy is the URL of the proxy for HTTPS requests.
+                    type: string
+                  noProxy:
+                    description: NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be used.
+                    type: string
+                type: object
+              pullSecretRef:
+                description: PullSecretRef is the reference to the secret to use when pulling images.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              sshAuthorizedKeys:
+                description: SSHAuthorizedKeys is a list of SSH public keys that will be added to all agents for use in debugging.
+                items:
+                  type: string
+                type: array
+            required:
+            - agentLabelSelector
+            - clusterRef
+            - ignitionConfigOverride
+            - pullSecretRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition represents the state of the operator's reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              isoDownloadURL:
+                description: ISODownloadURL specifies an HTTP/S URL that contains a discovery ISO containing the configuration from this InstallEnv.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/community-operators/assisted-service-operator/0.0.1/assisted-installer-public-s3_v1_secret.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/assisted-installer-public-s3_v1_secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: scality
+  name: assisted-installer-public-s3
+stringData:
+  aws_access_key_id: accessKey1
+  aws_region: us-east-1
+  aws_secret_access_key: verySecretKey1
+  bucket: pub-test
+  endpoint: http://cloudserver-front:8000
+  s3_data_path: /mnt/data
+  s3_metadata_path: /mnt/data
+type: Opaque

--- a/community-operators/assisted-service-operator/0.0.1/assisted-installer-s3_v1_secret.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/assisted-installer-s3_v1_secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: scality
+  name: assisted-installer-s3
+stringData:
+  aws_access_key_id: accessKey1
+  aws_region: us-east-1
+  aws_secret_access_key: verySecretKey1
+  bucket: test
+  endpoint: http://cloudserver-front:8000
+  s3_data_path: /mnt/data
+  s3_metadata_path: /mnt/data
+type: Opaque

--- a/community-operators/assisted-service-operator/0.0.1/assisted-installer-sso_v1_secret.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/assisted-installer-sso_v1_secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: assisted-service
+  name: assisted-installer-sso
+stringData:
+  ocm-service.clientId: ""
+  ocm-service.clientSecret: ""
+type: Opaque

--- a/community-operators/assisted-service-operator/0.0.1/assisted-service-config_v1_configmap.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/assisted-service-config_v1_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  ADMIN_USERS: ercohen,lgamliel,mfilanov,ygoldber
+  AGENT_DOCKER_IMAGE: quay.io/ocpmetal/assisted-installer-agent:latest
+  AUTH_TYPE: none
+  BASE_DNS_DOMAINS: ""
+  CHECK_CLUSTER_VERSION: "False"
+  CONTROLLER_IMAGE: quay.io/ocpmetal/assisted-installer-controller:latest
+  CREATE_S3_BUCKET: "true"
+  ENABLE_KUBE_API: "true"
+  ENABLE_SINGLE_NODE_DNSMASQ: "True"
+  INSTALLER_IMAGE: quay.io/ocpmetal/assisted-installer:latest
+  IPV6_SUPPORT: "False"
+  JWKS_URL: https://api.openshift.com/.well-known/jwks.json
+  NAMESPACE: assisted-installer
+  OCM_BASE_URL: https://api-integration.6943.hive-integration.openshiftapps.com
+  OPENSHIFT_VERSIONS: ' {"4.6":{"display_name":"4.6.16","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.2","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.2-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}'
+  PUBLIC_CONTAINER_REGISTRIES: quay.io,registry.svc.ci.openshift.org
+  SELF_VERSION: quay.io/ocpmetal/assisted-service:latest
+  SERVICE_BASE_URL: REPLACE_BASE_URL
+  SKIP_CERT_VERIFICATION: "true"
+  WITH_AMS_SUBSCRIPTIONS: "False"
+kind: ConfigMap
+metadata:
+  labels:
+    app: assisted-service
+  name: assisted-service-config

--- a/community-operators/assisted-service-operator/0.0.1/assisted-service-operator.clusterserviceversion.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/assisted-service-operator.clusterserviceversion.yaml
@@ -1,0 +1,516 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+    categories: OpenShift Optional
+    description: Assisted Service is used to orchestrate baremetal OpenShift installations.
+    operatorframework.io/suggested-namespace: assisted-installer
+    operators.operatorframework.io/builder: operator-sdk-v1.4.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/openshift/assisted-service
+    support: https://github.com/openshift/assisted-service/issues/new
+  name: assisted-service-operator.v0.0.1
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    required:
+    - kind: ClusterDeployment
+      name: clusterdeployments.hive.openshift.io
+      version: v1
+    - kind: BareMetalHost
+      name: baremetalhosts.metal3.io
+      version: v1alpha1
+    owned:
+    - kind: Agent
+      name: agents.adi.io.my.domain
+      version: v1alpha1
+    - kind: InstallEnv
+      name: installenvs.adi.io.my.domain
+      version: v1alpha1
+  description: |-
+    Assisted Service is used to orchestrate baremetal OpenShift installations.
+
+    # Prerequisites
+
+    The ClusterDeployment CRD from Hive is required. Install the Hive operator
+    if it hasn't already been installed.
+
+    A PersistentVolumeClaim named postgres-pv-claim is required.
+
+    ````
+    cat <<EOF | oc create -f -
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels: {app: postgres}
+      name: postgres-pv-claim
+      namespace: assisted-installer
+    spec:
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests: {storage: 10Gi}
+    EOF
+    ````
+
+    A PersistentVolumeClaim named bucket-pv-claim is required for the filesystem storage.
+
+    ````
+    cat <<EOF | oc create -f -
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels: {app: assisted-service}
+      name: bucket-pv-claim
+      namespace: assisted-installer
+    spec:
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests: {storage: 10Gi}
+    EOF
+    ````
+  displayName: Assisted Service Operator
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          - pods
+          - endpoints
+          - services
+          - secrets
+          verbs:
+          - get
+          - watch
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - watch
+          - list
+          - create
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - watch
+          - list
+          - delete
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resourceNames:
+          - assisted-service-leader-election-helper
+          - assisted-service-migration-helper
+          - assisted-service-baseiso-helper
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - update
+          - delete
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - adi.io.my.domain
+          resources:
+          - agents
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - adi.io.my.domain
+          resources:
+          - agents/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - adi.io.my.domain
+          resources:
+          - installenvs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - adi.io.my.domain
+          resources:
+          - installenvs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterdeployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterdeployments/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: default
+      deployments:
+      - name: assisted-service
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: assisted-service
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: assisted-service
+            spec:
+              containers:
+              - env:
+                - name: ISO_IMAGE_TYPE
+                  value: minimal-iso
+                - name: DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: db.host
+                      name: assisted-installer-rds
+                - name: DB_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      key: db.name
+                      name: assisted-installer-rds
+                - name: DB_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      key: db.password
+                      name: assisted-installer-rds
+                - name: DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: db.port
+                      name: assisted-installer-rds
+                - name: DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      key: db.user
+                      name: assisted-installer-rds
+                - name: OCM_SERVICE_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: ocm-service.clientId
+                      name: assisted-installer-sso
+                - name: OCM_SERVICE_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      key: ocm-service.clientSecret
+                      name: assisted-installer-sso
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_secret_access_key
+                      name: assisted-installer-s3
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_access_key_id
+                      name: assisted-installer-s3
+                - name: S3_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_region
+                      name: assisted-installer-s3
+                - name: S3_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      key: bucket
+                      name: assisted-installer-s3
+                - name: S3_ENDPOINT_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: endpoint
+                      name: assisted-installer-s3
+                - name: AWS_SECRET_ACCESS_KEY_PUBLIC
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_secret_access_key
+                      name: assisted-installer-public-s3
+                - name: AWS_ACCESS_KEY_ID_PUBLIC
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_access_key_id
+                      name: assisted-installer-public-s3
+                - name: S3_REGION_PUBLIC
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_region
+                      name: assisted-installer-public-s3
+                - name: S3_BUCKET_PUBLIC
+                  valueFrom:
+                    secretKeyRef:
+                      key: bucket
+                      name: assisted-installer-public-s3
+                - name: S3_ENDPOINT_URL_PUBLIC
+                  valueFrom:
+                    secretKeyRef:
+                      key: endpoint
+                      name: assisted-installer-public-s3
+                - name: S3_USE_SSL
+                  value: "false"
+                - name: LOG_LEVEL
+                  value: info
+                - name: LOG_FORMAT
+                  value: text
+                - name: INSTALL_RH_CA
+                  value: "false"
+                - name: REGISTRY_CREDS
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: AWS_SHARED_CREDENTIALS_FILE
+                  value: /etc/.aws/credentials
+                - name: DEPLOY_TARGET
+                  value: ocp
+                - name: STORAGE
+                  value: filesystem
+                - name: ISO_WORKSPACE_BASE_DIR
+                  value: /data
+                - name: ISO_CACHE_DIR
+                  value: /data/cache
+                envFrom:
+                - configMapRef:
+                    name: assisted-service-config
+                image: quay.io/ocpmetal/assisted-service@sha256:a4fee3365a842bdf57070723d7f5980e34bf8ca0ae46089d8aa9449406ab8c5d
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /health
+                    port: 8090
+                  initialDelaySeconds: 30
+                name: assisted-service
+                ports:
+                - containerPort: 8090
+                readinessProbe:
+                  httpGet:
+                    path: /ready
+                    port: 8090
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 2000Mi
+                  requests:
+                    cpu: 300m
+                    memory: 400Mi
+                volumeMounts:
+                - mountPath: /data
+                  name: bucket-filesystem
+                - mountPath: /etc/.aws
+                  name: route53-creds
+                  readOnly: true
+              initContainers:
+              - command:
+                - sh
+                - -c
+                - until getent hosts assisted-service.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for assisted-service; sleep 2; done
+                image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+                name: init-wait-for-service
+                resources: {}
+              - command:
+                - sh
+                - -c
+                - 'export NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) && export HAS_ROUTE=$(oc get routes -n $NAMESPACE assisted-service) && if [ "$HAS_ROUTE" == "" ] ; then oc expose service -n $NAMESPACE assisted-service ; fi && export ROUTE_URL=$(oc get routes -n $NAMESPACE assisted-service -o jsonpath={.spec.host}) && oc get configmap -n $NAMESPACE assisted-service-config -o yaml | sed -e "s|REPLACE_BASE_URL|http\:\/\/$ROUTE_URL|" | oc apply -f - '
+                image: quay.io/openshift/origin-cli@sha256:3a931dd86a2cbbec8c96740bfe3d5b8da78f50d66597579a1d6d2e4916adecad
+                name: init-add-route-and-update-config-map
+                resources: {}
+              volumes:
+              - name: bucket-filesystem
+                persistentVolumeClaim:
+                  claimName: bucket-pv-claim
+              - name: route53-creds
+                secret:
+                  optional: true
+                  secretName: route53-creds
+      - name: postgres
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: postgres
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: postgres
+            spec:
+              containers:
+              - env:
+                - name: POSTGRESQL_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: db.name
+                      name: assisted-installer-rds
+                - name: POSTGRESQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      key: db.user
+                      name: assisted-installer-rds
+                - name: POSTGRESQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: db.password
+                      name: assisted-installer-rds
+                image: quay.io/ocpmetal/postgresql-12-centos7@sha256:e3ca49b057eb57490e2c6a8c95933b2345575193444dce197fb443af68825ab4
+                imagePullPolicy: IfNotPresent
+                name: postgres
+                ports:
+                - containerPort: 5432
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 500Mi
+                  requests:
+                    cpu: 100m
+                    memory: 400Mi
+                volumeMounts:
+                - mountPath: /var/lib/pgsql/data
+                  name: postgredb
+              initContainers:
+              - command:
+                - sh
+                - -c
+                - export NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) && export HAS_PG_SECRET=$(oc get secrets -n $NAMESPACE assisted-installer-rds) && if [ "$HAS_PG_SECRET" == "" ] ; then export PASSWORD=$(cat /dev/urandom | tr -dc "a-zA-Z0-9" | head -c 20) && oc create secret generic assisted-installer-rds --from-literal=db.host=postgres --from-literal=db.name=installer --from-literal=db.port=5432 --from-literal=db.user=admin --type=opaque --from-literal=db.password=$PASSWORD -n $NAMESPACE; fi
+                image: quay.io/openshift/origin-cli@sha256:3a931dd86a2cbbec8c96740bfe3d5b8da78f50d66597579a1d6d2e4916adecad
+                name: init-add-postgres-secret-if-missing
+                resources: {}
+              volumes:
+              - name: postgredb
+                persistentVolumeClaim:
+                  claimName: postgres-pv-claim
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: default
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - assisted-service
+  - assisted-installer
+  - OpenShift
+  links:
+  - name: Assisted Service
+    url: https://github.com/openshift/assisted-service
+  maintainers:
+  - email: support@redhat.com
+    name: Support
+  maturity: alpha
+  provider:
+    name: Red Hat
+  version: 0.0.1

--- a/community-operators/assisted-service-operator/0.0.1/assisted-service-operator.clusterserviceversion.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/assisted-service-operator.clusterserviceversion.yaml
@@ -11,6 +11,8 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/assisted-service
     support: https://github.com/openshift/assisted-service/issues/new
+    createdAt: '2021-03-19T09:49:00Z'
+    containerImage: quay.io/ocpmetal/assisted-service-operator-bundle:73440529c68424ea318362ded9874042a9d2de8e
   name: assisted-service-operator.v0.0.1
 spec:
   apiservicedefinitions: {}
@@ -25,9 +27,11 @@ spec:
     owned:
     - kind: Agent
       name: agents.adi.io.my.domain
+      displayName: Agent
       version: v1alpha1
     - kind: InstallEnv
       name: installenvs.adi.io.my.domain
+      displayName: InstallEnv
       version: v1alpha1
   description: |-
     Assisted Service is used to orchestrate baremetal OpenShift installations.

--- a/community-operators/assisted-service-operator/0.0.1/assisted-service_v1_service.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/assisted-service_v1_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: assisted-service
+  name: assisted-service
+spec:
+  ports:
+  - name: assisted-service
+    port: 8090
+    protocol: TCP
+    targetPort: 8090
+  selector:
+    app: assisted-service
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/community-operators/assisted-service-operator/0.0.1/controller-manager-metrics-service_v1_service.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/community-operators/assisted-service-operator/0.0.1/default_v1_serviceaccount.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/default_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: default

--- a/community-operators/assisted-service-operator/0.0.1/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/community-operators/assisted-service-operator/0.0.1/ocp-metal-ui_v1_configmap.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/ocp-metal-ui_v1_configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+  nginx.conf: |
+    server {
+      listen 8080;
+      server_name _;
+
+      root /app;
+      index index.html;
+
+      location /api {
+          proxy_pass http://assisted-service.assisted-installer.svc.cluster.local:8090;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection 'upgrade';
+          proxy_set_header Host $host;
+          proxy_cache_bypass $http_upgrade;
+          proxy_connect_timeout 120;
+          proxy_send_timeout 120;
+          proxy_read_timeout 120;
+          send_timeout 120;
+      }
+
+      location / {
+         try_files $uri /index.html;
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: ocp-metal-ui

--- a/community-operators/assisted-service-operator/0.0.1/ocp-metal-ui_v1_service.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/ocp-metal-ui_v1_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: ocp-metal-ui
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ocp-metal-ui
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/community-operators/assisted-service-operator/0.0.1/postgres_v1_service.yaml
+++ b/community-operators/assisted-service-operator/0.0.1/postgres_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: postgres
+  name: postgres
+spec:
+  ports:
+  - port: 5432
+    targetPort: 0
+  selector:
+    app: postgres
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/community-operators/assisted-service-operator/assisted-service.package.yaml
+++ b/community-operators/assisted-service-operator/assisted-service.package.yaml
@@ -1,0 +1,7 @@
+channels:
+- currentCSV: assisted-service-operator.v0.0.1
+  name: alpha
+- currentCSV: assisted-service-operator.v0.0.1
+  name: ocm-2.3
+defaultChannel: alpha
+packageName: assisted-service-operator

--- a/community-operators/assisted-service-operator/ci.yaml
+++ b/community-operators/assisted-service-operator/ci.yaml
@@ -1,0 +1,3 @@
+---
+# Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
+updateGraph: replaces-mode


### PR DESCRIPTION
This PR adds the missing metadata to the `assisted-service` operator added in #3329


![DeepinScreenshot_select-area_20210319104509](https://user-images.githubusercontent.com/13816/111768821-50ff8500-88a0-11eb-974e-d1f28579046b.png)
