### PR TITLE
community-operators flux (0.7.7)

### DIFF
--- a/community-operators/flux/0.7.7/metadata/annotations.yaml
+++ b/community-operators/flux/0.7.7/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1


### PR DESCRIPTION
We will update the stable channel with newer releases, but without this change users will not see them unless they know they need to select the stable channel on the OperatorHub landing page.

(Reviewer question: is it OK to change metadata in an existing release? I followed some issue reports from the original contributor and I think I understand the problem. I do not know when we will publish a new release in the alpha channel, the Flux operator is in prerelease and some APIs remain in alpha, but we don't want to call the whole thing alpha since many core packages have reached beta, and the "stable" Flux release is not really something you could characterize as an operator.)

When the 0.7.7 release was published, there was no stable channel. As feature parity was declared around that time and users are recommended to upgrade from Flux v1 to the new "operator" driven flux v2, the messaging has changed and releases will likely all be going into the stable channel for the foreseeable future, at least until a GA release is declared.

So, I hypothesized that something like this change was needed in #3711, will this likely fix our problem of the Operator Hub landing page advertising the alpha channel above the stable channel to people that land there by searching normally?