### PR TITLE
Add High Availability Category

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -7,6 +7,7 @@
       "Developer Tools",
       "Database",
       "Drivers and plugins",
+      "High Availability",
       "Integration & Delivery",
       "Logging & Tracing",
       "Modernization & Migration",


### PR DESCRIPTION
The high availability category can be used for any operators that enhance the high availability of the cluster or the apps that runs on the cluster.

In [medik8s](https://www.medik8s.io/), we have several operators that should fit this category. 
This includes node-healthcehck-controller which detects health issues of nodes and ask for remediation, poison pill operator which remediates nodes by rebooting them, etc.