### PR TITLE
community-operators [R] community-windows-machine-config-operator (0.0.1 0.1.0 1.0.0 2.0.0 2.0.1)

### DIFF
--- a/community-operators/community-windows-machine-config-operator/0.0.1/metadata/annotations.yaml
+++ b/community-operators/community-windows-machine-config-operator/0.0.1/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: community-windows-machine-config-operator
+  com.redhat.openshift.versions: "=v4.6"

--- a/community-operators/community-windows-machine-config-operator/0.1.0/metadata/annotations.yaml
+++ b/community-operators/community-windows-machine-config-operator/0.1.0/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: community-windows-machine-config-operator
+  com.redhat.openshift.versions: "=v4.6"

--- a/community-operators/community-windows-machine-config-operator/1.0.0/metadata/annotations.yaml
+++ b/community-operators/community-windows-machine-config-operator/1.0.0/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: community-windows-machine-config-operator
+  com.redhat.openshift.versions: "=v4.6"

--- a/community-operators/community-windows-machine-config-operator/2.0.0/metadata/annotations.yaml
+++ b/community-operators/community-windows-machine-config-operator/2.0.0/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: community-windows-machine-config-operator
+  com.redhat.openshift.versions: "=v4.7"

--- a/community-operators/community-windows-machine-config-operator/2.0.1/metadata/annotations.yaml
+++ b/community-operators/community-windows-machine-config-operator/2.0.1/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: community-windows-machine-config-operator
+  com.redhat.openshift.versions: "=v4.7"


### PR DESCRIPTION
@sebsoto, @aravindhp We updated your `annotations.yaml` files as Dockerfile is no longer used for build in our pipeline. You can  have a Dockerfile, but we will just ignore it for security reasons. Please approve the change:)

Signed-off-by: j0zi <jbreza@redhat.com>
