### PR TITLE
upstream-community-operators infinispan (2.1.4)

### DIFF
--- a/upstream-community-operators/infinispan/2.1.4/infinispan-operator.v2.1.4.clusterserviceversion.yaml
+++ b/upstream-community-operators/infinispan/2.1.4/infinispan-operator.v2.1.4.clusterserviceversion.yaml
@@ -1,0 +1,529 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "infinispan.org/v1",
+          "kind": "Infinispan",
+          "metadata": {
+            "name": "example-infinispan"
+          },
+          "spec": {
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "infinispan.org/v2alpha1",
+          "kind": "Backup",
+          "metadata": {
+            "name": "example-backup"
+          },
+          "spec": {
+            "cluster": "example-infinispan",
+            "container": {
+              "cpu": "1000m",
+              "extraJvmOpts": "-Djava.property=me",
+              "memory": "1Gi"
+            }
+          }
+        },
+        {
+          "apiVersion": "infinispan.org/v2alpha1",
+          "kind": "Cache",
+          "metadata": {
+            "name": "example-cache"
+          },
+          "spec": {
+            "adminAuth": {
+              "secretName": "basic-auth"
+            },
+            "clusterName": "example-infinispan",
+            "name": "mycache"
+          }
+        },
+        {
+          "apiVersion": "infinispan.org/v2alpha1",
+          "kind": "Restore",
+          "metadata": {
+            "name": "example-restore"
+          },
+          "spec": {
+            "cluster": "example-infinispan",
+            "container": {
+              "cpu": "1000m",
+              "extraJvmOpts": "-Djava.property=me",
+              "memory": "1Gi"
+            }
+          }
+        },
+        {
+          "apiVersion": "infinispan.org/v2alpha1",
+          "kind": "Batch",
+          "metadata": {
+            "name": "example-batch"
+          },
+          "spec": {
+            "cluster": "example-infinispan",
+            "config": "create cache --template=org.infinispan.DIST_SYNC batch-cache"
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: Database
+    repository: https://github.com/infinispan/infinispan-operator
+    description: Create and manage Infinispan clusters.
+    containerImage: quay.io/infinispan/operator:2.1.3.Final
+    createdAt: 2021-01-26T09:00:00Z
+    support: Infinispan
+    certified: "false"
+  name: infinispan-operator.v2.1.4
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: Backup is the Schema for the backups API
+        kind: Backup
+        name: backups.infinispan.org
+        version: v2alpha1
+        displayName: Backup
+        specDescriptors:
+          - displayName: Cluster name
+            description: Names your Infinispan cluster.
+            path: cluster
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:infinispan.org:v1:Infinispan'
+          - displayName: Storage class name
+            description: Names the storage class object for persistent volume claims.
+            path: volume.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:StorageClass'
+      - description: Restore API schema.
+        kind: Restore
+        name: restores.infinispan.org
+        version: v2alpha1
+        displayName: Restore
+        specDescriptors:
+          - displayName: Cluster name
+            description: Infinispan cluster name
+            path: cluster
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:infinispan.org:v1:Infinispan'
+          - displayName: Backup name
+            description: Specifies an Infinispan backup to restore.
+            path: backup
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:infinispan.org:v2alpha1:Backup'
+      - description: Cache is the Schema for the caches API
+        kind: Cache
+        name: caches.infinispan.org
+        version: v2alpha1
+        displayName: Cache
+        specDescriptors:
+          - displayName: Cluster name
+            description: Infinispan cluster name
+            path: clusterName
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:infinispan.org:v1:Infinispan'
+          - displayName: Authentication secret
+            description: Names the secret that contains user credentials.
+            path: adminAuth.secretName
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:Secret'
+      - description: Batch is the Schema for the batches API
+        kind: Batch
+        name: batches.infinispan.org
+        version: v2alpha1
+        displayName: Batch
+        specDescriptors:
+          - displayName: Cluster name
+            description: Infinispan cluster name
+            path: cluster
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:infinispan.org:v1:Infinispan'
+          - displayName: Config command
+            description: List of commands to be executed
+            path: config
+          - displayName: ConfigMap name
+            description: Name if the ConfigMap containing th List of commands to be executed
+            path: configMap
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+        statusDescriptors:
+          - description: Current state of the batch operation
+            displayName: Batch Status
+            path: phase
+          - description: The reason for any batch related failures
+            displayName: Batch reason
+            path: reason
+      - description: Infinispan is the Schema for the infinispans API
+        kind: Infinispan
+        name: infinispans.infinispan.org
+        version: v1
+        displayName: Infinispan Cluster
+        specDescriptors:
+          - description: Controls the number of nodes in your Infinispan cluster.
+            displayName: Replicas
+            path: replicas
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+          - description: Enable or disable user authentication.
+            displayName: Toggle authentication
+            path: security.endpointAuthentication
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+          - displayName: Configure encryption
+            description: Disable or modify endpoint encryption.
+            path: security.endpointEncryption.type
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:select:Service'
+              - 'urn:alm:descriptor:com.tectonic.ui:select:Secret'
+              - 'urn:alm:descriptor:com.tectonic.ui:select:None'
+          - displayName: Encryption secret
+            description: Names the secret that contains TLS certificates.
+            path: security.endpointEncryption.certSecretName
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:Secret'
+              - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:security.endpointEncryption.type:Secret'
+          - displayName: Encryption service
+            description: Names the service that encrypts client traffic.
+            path: security.endpointEncryption.certServiceName
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:text'
+              - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:security.endpointEncryption.type:Service'
+          - displayName: Authentication secret
+            description: Names the secret that contains user credentials.
+            path: security.endpointSecretName
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:Secret'
+              - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:security.endpointAuthentication:true'
+          - displayName: Service type
+            description: Configures the service type.
+            path: service.type
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:select:Cache'
+              - 'urn:alm:descriptor:com.tectonic.ui:select:DataGrid'
+          - displayName: Backup location secret
+            description: Names the access secret that allows backups to a remote site.
+            path: service.sites.locations[].secretName
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:Secret'
+          - displayName: Node port
+            description: Specifies the node port that accepts traffic from a load balancer service.
+            path: service.sites.local.expose.nodePort
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:number'
+              - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:service.sites.local.expose.type:NodePort'
+          - displayName: Number of owners
+            description: Controls cache replication factor, or number of copies for each entry.
+            path: service.replicationFactor
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:number'
+          - description: Enable/disable container ephemeral storage
+            displayName: Container ephemeral storage
+            path: service.container.ephemeralStorage
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+          - displayName: Storage size
+            description: Sets the amount of storage for the persistent volume claim.
+            path: service.container.storage
+            x-descriptors:
+              - 'urn:alm:descriptor:text'
+          - displayName: Storage class name
+            description: Names the storage class object for persistent volume claims.
+            path: service.container.storageClassName
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:StorageClass'
+              - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:service.container.ephemeralStorage:false'
+          - displayName: Route hostname
+            description: Defines the network hostname for your Infinispan cluster.
+            path: expose.host
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:text'
+              - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:expose.type:Route'
+          - displayName: Persistent volume claim (PVC) name
+            description: Names the PVC that holds custom libraries.
+            path: dependencies.volumeClaimName
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:PersistentVolumeClaim'
+        statusDescriptors:
+          - description: The current pods
+            displayName: Pod Status
+            path: podStatus
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+          - displayName: Infinispan Console URL
+            description: Infinispan Console location
+            path: consoleUrl
+            x-descriptors:
+              - 'urn:alm:descriptor:org.w3:link'
+  description: |
+    Infinispan is an in-memory data store and open-source project.
+
+    ### Infinispan
+    * **Schemaless structure:** Store objects in key/value pairs.
+    * **Grid storage:** Distribute and replicate data across clusters.
+    * **Elasticity:** Scale to meet workload demands without service disruption.
+    * **Polyglot access:** Read, write, and query from multiple client languages with different endpoints.
+    * **Continuous availability:** Create a fault-tolerant caching service that guarantees business continuity.
+
+    ### Operator capabilities
+    * Built-in intelligence to automate Infinispan cluster deployment.
+    * Infinispan CR for service configuration.
+    * Cache CR for fully configurable caches.
+    * Batch CR for scripting bulk resource creation.
+    * REST and Hot Rod endpoints available at port `11222`.
+    * Default application user: `developer`. Infinispan Operator generates credentials in an authentication secret at startup.
+    * Infinispan pods request `0.25` (limit `0.50`) CPUs, 512MiB of memory and 1Gi of ReadWriteOnce persistent storage. Infinispan Operator lets you adjust resource allocation to suit your requirements.
+  displayName: Infinispan Operator
+  install:
+    spec:
+      deployments:
+        - name: infinispan-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: infinispan-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: infinispan-operator
+              spec:
+                containers:
+                  - command:
+                      - infinispan-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: infinispan-operator
+                      - name: RELATED_IMAGE_OPENJDK
+                        value: quay.io/infinispan/server:12.1.3.Final
+                    image: quay.io/infinispan/operator:2.1.3.Final
+                    imagePullPolicy: Always
+                    name: infinispan-operator
+                    ports:
+                      - containerPort: 60000
+                        name: metrics
+                    resources: {}
+                serviceAccountName: infinispan-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - persistentvolumeclaims
+                - services
+                - services/finalizers
+                - endpoints
+                - configmaps
+                - pods
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - pods/log
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - pods/exec
+              verbs:
+                - create
+            - apiGroups:
+                - apps
+              resources:
+                - replicasets
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - apps
+              resources:
+                - statefulsets
+                - deployments/finalizers
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+                - routes/custom-host
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - infinispan.org
+              resources:
+                - infinispans
+                - infinispans/status
+                - infinispans/finalizers
+                - caches
+                - caches/status
+                - caches/finalizers
+                - backups
+                - backups/status
+                - backups/finalizers
+                - restores
+                - restores/status
+                - restores/finalizers
+                - batches
+                - batches/status
+                - batches/finalizers
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+            - apiGroups:
+                - integreatly.org
+              resources:
+                - grafanadashboards
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+          serviceAccountName: infinispan-operator
+      clusterPermissions:
+        - serviceAccountName: infinispan-operator
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+                - customresourcedefinitions/status
+              verbs:
+                - get
+                - list
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - storageclasses
+              verbs:
+                - get
+                - watch
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  maturity: alpha
+  provider: {name: Infinispan}
+  replaces: infinispan-operator.v2.1.3
+  version: 2.1.4
+  keywords:
+    - infinispan
+    - key value
+    - database
+    - datagrid
+    - open source
+  minKubeVersion: 1.11.0
+  maintainers:
+    - name: Infinispan Community
+      email: infinispan-dev@lists.jboss.org
+  relatedImages:
+    - name: infinispan-server
+      image: quay.io/infinispan/server:12.1.3.Final
+  labels:
+    operated-by: infinispan-operator
+  selector:
+    matchLabels:
+      operated-by: infinispan-operator
+  links:
+    - name: Blog
+      url: https://blog.infinispan.org/
+    - name: Documentation
+      url: https://infinispan.org/
+    - name: Chat
+      url: https://infinispan.zulipchat.com/#narrow/stream/185835-infinispan-cloud
+    - name: Quickstart
+      url: https://github.com/infinispan/infinispan-simple-tutorials/tree/master/operator
+    - name: Operator Source Code
+      url: https://github.com/infinispan/infinispan-operator
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAACxAAAAsQHGLUmNAAAEOklEQVR4nO1bTUhUURQ+ZSioGAyNTFAmNBCjUEHSShRaTRs3tWlR61q3KciVC1e1rV3QOjduciUo0iIUpqARYQI1QVGZSHRASYrv8e7wmnz33vfmnjPPZj54zCjv3nfvd8/fO+fMmQdvP/6mJsbZZt480CIgAWtoKFoEJGANDYU1AVdSXTSQ6aHO9nOJ3QzWhjVirbaw3s2j2/2Uy/RU/97dP6S18gEVt/a8C98loQ5EbfhCd0f16ctbezQx89VqNbGPEw/EdasvVSVkrrRD86Vt2tk/ZKEi3d1BI9leGs2m/9pwPXAmz1jQvZuXvGu+tENThe/OiEh7c1+mkWzayXxBsCg0FoprqrBBH4qbVDn6FWse6PTdgYseqVxgtWhYOMT15exKZBsBvX5655ozUQ8DuxvEBibHrkcSX9yLMdybB8TigMfDWc+TmIB7cK8UYr0NKteDT+UFbAED+WahFEpSVEO3tF6uumF8RkUsG6B8PwwcDBX0HMbKRmSxQSwWY2v/b7t5uFyMh9uNa2AVnOYD4KpARGd7m/HeV7MrtLhe9r5Dkl7kB41jKkfH3sbhYl3BqQ3Awp5Pf7ay+BB3FVaDOBMwJ+Z2uXnAuRFE8DMxU/R0XQdIyZPhq94dpk1hLszJEWGyeAHoJQydiQQYUIg/7MlyiAFTRrNeXQ8DqxvEwsM2pqBc3klSgLFhHsMV2OMARIEwXmGA5xjqS/0jBRiDsdxgJ0Cpgw7wHMBcabt6F6fYByESCcLd6VQBeQa88S2u//BOHvcqF8kNsVDYZOmhBjjx5a2fzl2dDmIEmLJGQ35I/b6wESukjQvRpKjOLap0m3RqTZQAk15HSWa6gigBiOR0LrHL4h3CNcTrAjoRz2XOi64FECeAK2McFy0CErCGhiJRBKQFkqC1aBEg/UCdF/jv4wAyGEFkiaSlIFESQIF3AimIEqBEXPdqzFEA1UGMAOT+7vtFTt07gSq4SEGMAKS+VahreimySZO7gggB0Ouc117T5ok4DKEpQyRlC9gJQPEjWOwczfZ6n7WlsVoECyecYCcANf5gqSzn9/VADXYNLhFjTzUBOMXcCQZN6bgpW4yx3KVyFgKU2Ie5NCUFyP0tGQwi5uBUB+cEIJIbzw8Y/bmSgtcL37RZIvJJwJwcUaJTArCpybEbVjG9Sn3bFE7Ijw8wt2sXWXd/QNQGCfJ1vzZDjPEPLVpoKAkNEk3ZIjOeHzzRokfBTHGT3n1aDR2h6oF5v1ZoAxxA7SFEaZUVC4WxOd3mFXAPd0k8CPZQC/oatVESarJWrog0SrISUE+rLAh7Nv3ldLbKumqWBnGYBx3oiW+W5myXx3ywCyAjMe3yjfjBBIgACbh0P5iIAus4AA9B8XK1XBFpXYkDBGX9qU46ODq2PhBrCZCu28cBDiZqMNQqjSVgDQ1Fi4AErKGhaG4CiOgPK6Ej+g5fAyMAAAAASUVORK5CYII=
+      mediatype: image/png

--- a/upstream-community-operators/infinispan/2.1.4/infinispan.org_backups_crd.yaml
+++ b/upstream-community-operators/infinispan/2.1.4/infinispan.org_backups_crd.yaml
@@ -1,0 +1,107 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.infinispan.org
+  labels:
+    name: infinispan-operator
+spec:
+  group: infinispan.org
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    singular: backup
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Backup is the Schema for the backups API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BackupSpec defines the desired state of Backup
+          properties:
+            cluster:
+              type: string
+            container:
+              description: InfinispanContainerSpec specify resource requirements per container
+              properties:
+                cpu:
+                  type: string
+                extraJvmOpts:
+                  type: string
+                memory:
+                  type: string
+              type: object
+            resources:
+              properties:
+                cacheConfigs:
+                  description: Deprecated and to be removed on subsequent release. Use .Templates instead.
+                  items:
+                    type: string
+                  type: array
+                caches:
+                  items:
+                    type: string
+                  type: array
+                counters:
+                  items:
+                    type: string
+                  type: array
+                protoSchemas:
+                  items:
+                    type: string
+                  type: array
+                scripts:
+                  description: Deprecated and to be removed on subsequent release. Use .Tasks instead.
+                  items:
+                    type: string
+                  type: array
+                tasks:
+                  items:
+                    type: string
+                  type: array
+                templates:
+                  items:
+                    type: string
+                  type: array
+              type: object
+            volume:
+              properties:
+                storage:
+                  type: string
+                storageClassName:
+                  type: string
+              type: object
+          required:
+            - cluster
+          type: object
+        status:
+          description: BackupStatus defines the observed state of Backup
+          properties:
+            phase:
+              description: State indicates the current state of the backup operation
+              type: string
+            pvc:
+              description: The name of the created PersistentVolumeClaim used to store the backup
+              type: string
+            reason:
+              description: Reason indicates the reason for any backup related failures.
+              type: string
+          required:
+            - phase
+          type: object
+      type: object
+  version: v2alpha1
+  versions:
+    - name: v2alpha1
+      served: true
+      storage: true

--- a/upstream-community-operators/infinispan/2.1.4/infinispan.org_batches_crd.yaml
+++ b/upstream-community-operators/infinispan/2.1.4/infinispan.org_batches_crd.yaml
@@ -1,0 +1,61 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: batches.infinispan.org
+  labels:
+    name: infinispan-operator
+spec:
+  group: infinispan.org
+  names:
+    kind: Batch
+    listKind: BatchList
+    plural: batches
+    singular: batch
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Batch is the Schema for the batches API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BatchSpec defines the desired state of Batch
+          properties:
+            cluster:
+              type: string
+            config:
+              type: string
+            configMap:
+              type: string
+          required:
+            - cluster
+          type: object
+        status:
+          description: BatchStatus defines the observed state of Batch
+          properties:
+            clusterUID:
+              description: The UUID of the Infinispan instance that the Batch is associated with
+              type: string
+            phase:
+              description: State indicates the current state of the batch operation
+              type: string
+            reason:
+              description: Reason indicates the reason for any batch related failures.
+              type: string
+          required:
+            - phase
+          type: object
+      type: object
+  version: v2alpha1
+  versions:
+    - name: v2alpha1
+      served: true
+      storage: true

--- a/upstream-community-operators/infinispan/2.1.4/infinispan.org_caches_crd.yaml
+++ b/upstream-community-operators/infinispan/2.1.4/infinispan.org_caches_crd.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: caches.infinispan.org
+  labels:
+    name: infinispan-operator
+spec:
+  group: infinispan.org
+  names:
+    kind: Cache
+    listKind: CacheList
+    plural: caches
+    singular: cache
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Cache is the Schema for the caches API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CacheSpec defines the desired state of Cache
+          properties:
+            adminAuth:
+              description: Deprecated. This no longer has any effect. The operator's admin credentials are now used to perform cache operations
+              properties:
+                password:
+                  description: Secret and key containing the admin password for authentication.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                    optional:
+                      description: Specify whether the Secret or its key must be defined
+                      type: boolean
+                  required:
+                    - key
+                  type: object
+                secretName:
+                  description: name of the secret containing both admin username and password
+                  type: string
+                username:
+                  description: Secret and key containing the admin username for authentication.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                    optional:
+                      description: Specify whether the Secret or its key must be defined
+                      type: boolean
+                  required:
+                    - key
+                  type: object
+              type: object
+            clusterName:
+              description: Name of the cluster where to create the cache
+              type: string
+            name:
+              description: Name of the cache to be created. If empty ObjectMeta.Name will be used
+              type: string
+            template:
+              description: Cache template in XML format
+              type: string
+            templateName:
+              description: Name of the template to be used to create this cache
+              type: string
+          required:
+            - clusterName
+          type: object
+        status:
+          description: CacheStatus defines the observed state of Cache
+          properties:
+            conditions:
+              description: Conditions list for this cache
+              items:
+                description: CacheCondition define a condition of the cluster
+                properties:
+                  message:
+                    description: Human-readable message indicating details about last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                required:
+                  - status
+                  - type
+                type: object
+              type: array
+            serviceName:
+              description: Service name that exposes the cache inside the cluster
+              type: string
+          type: object
+      type: object
+  version: v2alpha1
+  versions:
+    - name: v2alpha1
+      served: true
+      storage: true

--- a/upstream-community-operators/infinispan/2.1.4/infinispan.org_infinispans_crd.yaml
+++ b/upstream-community-operators/infinispan/2.1.4/infinispan.org_infinispans_crd.yaml
@@ -1,0 +1,652 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: infinispans.infinispan.org
+  labels:
+    name: infinispan-operator
+spec:
+  group: infinispan.org
+  names:
+    kind: Infinispan
+    listKind: InfinispanList
+    plural: infinispans
+    singular: infinispan
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Infinispan is the Schema for the infinispans API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: InfinispanSpec defines the desired state of Infinispan
+          properties:
+            affinity:
+              description: Affinity is a group of affinity scheduling rules.
+              properties:
+                nodeAffinity:
+                  description: Describes node affinity scheduling rules for the pod.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                        properties:
+                          preference:
+                            description: A node selector term, associated with the corresponding weight.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                          - preference
+                          - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                        - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources, in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                          - podAffinityTerm
+                          - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                            type: string
+                        required:
+                          - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources, in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                          - podAffinityTerm
+                          - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                            type: string
+                        required:
+                          - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            autoscale:
+              description: Autoscale describe autoscaling configuration for the cluster
+              properties:
+                disabled:
+                  type: boolean
+                maxMemUsagePercent:
+                  type: integer
+                maxReplicas:
+                  format: int32
+                  type: integer
+                minMemUsagePercent:
+                  type: integer
+                minReplicas:
+                  format: int32
+                  type: integer
+              required:
+                - maxMemUsagePercent
+                - maxReplicas
+                - minMemUsagePercent
+                - minReplicas
+              type: object
+            cloudEvents:
+              description: InfinispanCloudEvents describes how Infinispan is connected with Cloud Event, see Kafka docs for more info
+              properties:
+                acks:
+                  description: Acks configuration for the producer ack-value
+                  type: string
+                bootstrapServers:
+                  description: BootstrapServers is comma separated list of boostrap server:port addresses
+                  type: string
+                cacheEntriesTopic:
+                  description: CacheEntriesTopic is the name of the topic on which events will be published
+                  type: string
+              required:
+                - bootstrapServers
+              type: object
+            container:
+              description: InfinispanContainerSpec specify resource requirements per container
+              properties:
+                cpu:
+                  type: string
+                extraJvmOpts:
+                  type: string
+                memory:
+                  type: string
+              type: object
+            dependencies:
+              description: External dependencies needed by the Infinispan cluster
+              properties:
+                volumeClaimName:
+                  description: Name of the persistent volume claim with custom libraries
+                  type: string
+              type: object
+            expose:
+              description: ExposeSpec describe how Infinispan will be exposed externally
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                host:
+                  type: string
+                nodePort:
+                  format: int32
+                  type: integer
+                type:
+                  description: Type specifies different exposition methods for data grid
+                  enum:
+                    - NodePort
+                    - LoadBalancer
+                    - Route
+                  type: string
+              required:
+                - type
+              type: object
+            image:
+              type: string
+            logging:
+              properties:
+                categories:
+                  additionalProperties:
+                    description: LoggingLevelType describe the logging level for selected category
+                    enum:
+                      - trace
+                      - debug
+                      - info
+                      - warn
+                      - error
+                    type: string
+                  type: object
+              type: object
+            replicas:
+              format: int32
+              type: integer
+            security:
+              description: InfinispanSecurity info for the user application connection
+              properties:
+                endpointAuthentication:
+                  type: boolean
+                endpointEncryption:
+                  description: EndpointEncryption configuration
+                  properties:
+                    certSecretName:
+                      type: string
+                    certServiceName:
+                      type: string
+                    type:
+                      description: CertificateSourceType specifies all the possible sources for the encryption certificate
+                      enum:
+                        - Service
+                        - service
+                        - Secret
+                        - secret
+                        - None
+                      type: string
+                  type: object
+                endpointSecretName:
+                  type: string
+              type: object
+            service:
+              description: InfinispanServiceSpec specify configuration for specific service
+              properties:
+                container:
+                  description: InfinispanServiceContainerSpec resource requirements specific for service
+                  properties:
+                    ephemeralStorage:
+                      type: boolean
+                    storage:
+                      type: string
+                    storageClassName:
+                      type: string
+                  type: object
+                replicationFactor:
+                  format: int32
+                  type: integer
+                sites:
+                  properties:
+                    local:
+                      properties:
+                        expose:
+                          description: CrossSiteExposeSpec describe how Infinispan Cross-Site service will be exposed externally
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            nodePort:
+                              format: int32
+                              type: integer
+                            type:
+                              description: Type specifies different exposition methods for data grid
+                              enum:
+                                - NodePort
+                                - LoadBalancer
+                                - ClusterIP
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        name:
+                          type: string
+                      required:
+                        - expose
+                        - name
+                      type: object
+                    locations:
+                      items:
+                        properties:
+                          clusterName:
+                            type: string
+                          host:
+                            description: Deprecated and to be removed on subsequent release. Use .URL with infinispan+xsite schema instead.
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          port:
+                            description: Deprecated and to be removed on subsequent release. Use .URL with infinispan+xsite schema instead.
+                            format: int32
+                            type: integer
+                          secretName:
+                            type: string
+                          url:
+                            pattern: (^(kubernetes|minikube|openshift):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])*(:[0-9]+)+$)|(^(infinispan\+xsite):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])*(:[0-9]+)*$)
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                  required:
+                    - local
+                  type: object
+                type:
+                  enum:
+                    - DataGrid
+                    - Cache
+                  type: string
+              type: object
+          required:
+            - replicas
+          type: object
+        status:
+          description: InfinispanStatus defines the observed state of Infinispan
+          properties:
+            conditions:
+              items:
+                description: InfinispanCondition define a condition of the cluster
+                properties:
+                  message:
+                    description: Human-readable message indicating details about last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                required:
+                  - status
+                  - type
+                type: object
+              type: array
+            consoleUrl:
+              type: string
+            podStatus:
+              properties:
+                ready:
+                  description: Deployments are ready to serve requests
+                  items:
+                    type: string
+                  type: array
+                starting:
+                  description: Deployments are starting, may or may not succeed
+                  items:
+                    type: string
+                  type: array
+                stopped:
+                  description: Deployments are not starting, unclear what next step will be
+                  items:
+                    type: string
+                  type: array
+              type: object
+            replicasWantedAtRestart:
+              format: int32
+              type: integer
+            security:
+              description: InfinispanSecurity info for the user application connection
+              properties:
+                endpointAuthentication:
+                  type: boolean
+                endpointEncryption:
+                  description: EndpointEncryption configuration
+                  properties:
+                    certSecretName:
+                      type: string
+                    certServiceName:
+                      type: string
+                    type:
+                      description: CertificateSourceType specifies all the possible sources for the encryption certificate
+                      enum:
+                        - Service
+                        - service
+                        - Secret
+                        - secret
+                        - None
+                      type: string
+                  type: object
+                endpointSecretName:
+                  type: string
+              type: object
+            statefulSetName:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/upstream-community-operators/infinispan/2.1.4/infinispan.org_restores_crd.yaml
+++ b/upstream-community-operators/infinispan/2.1.4/infinispan.org_restores_crd.yaml
@@ -1,0 +1,100 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.infinispan.org
+  labels:
+    name: infinispan-operator
+spec:
+  group: infinispan.org
+  names:
+    kind: Restore
+    listKind: RestoreList
+    plural: restores
+    singular: restore
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Restore is the Schema for the restores API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BackupSpec defines the desired state of Backup
+          properties:
+            backup:
+              type: string
+            cluster:
+              type: string
+            container:
+              description: InfinispanContainerSpec specify resource requirements per container
+              properties:
+                cpu:
+                  type: string
+                extraJvmOpts:
+                  type: string
+                memory:
+                  type: string
+              type: object
+            resources:
+              properties:
+                cacheConfigs:
+                  description: Deprecated and to be removed on subsequent release. Use .Templates instead.
+                  items:
+                    type: string
+                  type: array
+                caches:
+                  items:
+                    type: string
+                  type: array
+                counters:
+                  items:
+                    type: string
+                  type: array
+                protoSchemas:
+                  items:
+                    type: string
+                  type: array
+                scripts:
+                  description: Deprecated and to be removed on subsequent release. Use .Tasks instead.
+                  items:
+                    type: string
+                  type: array
+                tasks:
+                  items:
+                    type: string
+                  type: array
+                templates:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          required:
+            - backup
+            - cluster
+          type: object
+        status:
+          description: RestoreStatus defines the observed state of Restore
+          properties:
+            phase:
+              description: State indicates the current state of the restore operation
+              type: string
+            reason:
+              description: Reason indicates the reason for any Restore related failures.
+              type: string
+          required:
+            - phase
+          type: object
+      type: object
+  version: v2alpha1
+  versions:
+    - name: v2alpha1
+      served: true
+      storage: true

--- a/upstream-community-operators/infinispan/infinispan.package.yaml
+++ b/upstream-community-operators/infinispan/infinispan.package.yaml
@@ -7,7 +7,7 @@ channels:
   name: 1.1.x
 - currentCSV: infinispan-operator.v2.0.6
   name: 2.0.x
-- currentCSV: infinispan-operator.v2.1.3
+- currentCSV: infinispan-operator.v2.1.4
   name: 2.1.x
 defaultChannel: 2.1.x
 packageName: infinispan


### PR DESCRIPTION
Thanks submitting your Operator. Please check below list before you create your Pull Request.

### New Submissions

* [x] Does your operator have [nested directory structure](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#create-a-bundle)?
* [x] Have you selected the Project *Community Operator Submissions* in your PR on the right-hand menu bar?
* [x] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md)?
* [x] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
* [x] Have you tested your Operator with all Custom Resource Definitions?
* [x] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
* [x] Have you considered whether you want use [semantic versioning order](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#updating-your-existing-operator)?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
* [x] Is operator [icon](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#operator-icon) set?

### Updates to existing Operators

* [x] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#updating-your-existing-operator)?
* [x] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` or `annotations.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-required-fields.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo

Remember that you can preview your CSV [here](https://operatorhub.io/preview).

--

<sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file an issue against this repo and explain your need

<sup>2</sup> For more information see [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.svg)
