### PR TITLE
upstream-community-operators [N] poison-pill-operator (0.0.1)

### DIFF
--- a/upstream-community-operators/poison-pill-operator/0.0.1/manifests/external_remediation_clusterrole.yaml
+++ b/upstream-community-operators/poison-pill-operator/0.0.1/manifests/external_remediation_clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
       - poisonpillremediations
     verbs:
       - get
+      - list
       - create
       - delete
 


### PR DESCRIPTION
we need that list permission in the RBAC role that is being used by NHC
