### PR TITLE
installation validated will be removed on push while hold

### DIFF
--- a/.github/workflows/operator_ci.yaml
+++ b/.github/workflows/operator_ci.yaml
@@ -150,7 +150,7 @@ jobs:
 
       - name: "Remove installation-validated"
         uses: actions/github-script@v4
-        if: (!contains(github.event.pull_request.labels.*.name, 'do-not-merge/hold')) && (github.event.action != 'unlabeled')
+        if: (github.event.action != 'unlabeled')
         continue-on-error: true
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Signed-off-by: J0zi <jbreza@redhat.com>
handle `installation-validated` during hold