### PR TITLE
Update WildFly Operator 0.5.2

### DIFF
--- a/upstream-community-operators/wildfly/0.5.2/bundle.Dockerfile
+++ b/upstream-community-operators/wildfly/0.5.2/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=wildfly
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/upstream-community-operators/wildfly/0.5.2/manifests/wildfly-operator.v0.5.2.clusterserviceversion.yaml
+++ b/upstream-community-operators/wildfly/0.5.2/manifests/wildfly-operator.v0.5.2.clusterserviceversion.yaml
@@ -1,0 +1,405 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: "[\n  {\n    \"apiVersion\": \"wildfly.org/v1alpha1\",\n    \"kind\"\
+      : \"WildFlyServer\",\n    \"metadata\": {\n      \"name\": \"quickstart\"\n\
+      \    },\n    \"spec\": {\n      \"applicationImage\": \"quay.io/wildfly-quickstarts/wildfly-operator-quickstart:18.0\"\
+      ,\n      \"replicas\": 1\n    }\n  }\n]\n"
+    capabilities: Seamless Upgrades
+    categories: Application Runtime
+    certified: 'false'
+    containerImage: quay.io/wildfly/wildfly-operator:0.5.2
+    createdAt: '2021-07-20T08:00:00Z'
+    description: Operator that deploys and manages Java applications running on WildFly.
+    repository: https://github.com/wildfly/wildfly-operator
+    support: WildFlyServer
+  name: wildfly-operator.v0.5.2
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: An application running on WildFly application runtime.
+      displayName: WildFlyServer
+      kind: WildFlyServer
+      name: wildflyservers.wildfly.org
+      resources:
+      - kind: Service
+        version: v1
+      - kind: Pod
+        version: v1
+      - kind: StatefulSet
+        version: v1beta2
+      specDescriptors:
+      - description: Number of instances for a WildFlyServer resource.
+        displayName: Replicas
+        path: replicas
+      - description: Name of the application image to be deployed.
+        displayName: Application Image
+        path: applicationImage
+      - description: Specifies whether the application image is using S2I Builder/Runtime images or Bootable Jar
+        displayName: Bootable Jar
+        path: bootableJar
+      - description: spec to specify how standalone configuration can be read from
+          a ConfigMap.
+        displayName: Standalone ConfigMap
+        path: standaloneConfigMap
+      - description: Storage spec to specify how storage should be used.
+        displayName: Storage
+        path: storage
+      version: v1alpha1
+  description: >
+    WildFly is a flexible, lightweight, managed application runtime that helps you build amazing applications. Fly Fast, and Free!
+    
+    ## Save Time With Faster Development
+
+    WildFly supports the latest standards for REST based data access, including JAX-RS 2, and JSON-P. Building on Jakarta EE provides rich enterprise capabilities in easy to consume frameworks that eliminate boilerplate and reduce technical burden.
+
+    The quick boot of WildFly combined with the easy-to-use Arquillian framework allows for test driven development using the real environment your code will be running in. Your test code is separate and simply deployed along side your application where it has full access to server resources.
+
+    ## Save Resources With Efficient Management
+
+    WildFly takes an aggressive approach to memory management and is based on pluggable subsystems that can be added or removed as needed.
+
+
+    The quick boot of WildFly combined with the easy-to-use Arquillian framework allows for test driven development using the real environment your code will be running in. Your test code is separate and simply deployed along side your application where it has full access to server resources.
+
+    Configuration in WildFly is centralized, simple and user-focused. The configuration file is organized by subsystems that you can easily comprehend and no internal server wiring is exposed. Subsystems use intelligent defaults, but can still be customized to best fit your needs. If you are running in domain mode, the configuration for all servers participating in the domain is specified in a well-organized manner within the same file.
+
+    ## Save Money With Open Source
+
+    WildFly is an open source community project sponsored by Red Hat(TM) and is available for use and distribution under the LGPL v2.1 license meaning that it is available for you to download and use at no cost. This allows organizations like yours to develop amazing new technologies and federates the tech world to allow successful startups to come from anywhere.
+
+    ## Basic Install (Phase I)
+
+    The features and capabilities of Basic Install (Phase I) deals with the provisioning, installation and configuration of a Java application managed by the WildFly Operator.
+
+    ### Specify the Docker Application Image
+
+    The `applicationImage` specifies the Docker application image that contains the Java application. The image must have been built [WildFly S2I](https://github.com/wildfly/wildfly-s2i).
+
+        spec:
+           applicationImage: "quay.io/wildfly-quickstarts/wildfly-operator-quickstart:18.0"
+
+    The `applicationImage` accepts different references to Docker image:
+
+      * the name of the image: `quay.io/wildfly-quickstarts/wildfly-operator-quickstart`
+      * a tag: `quay.io/wildfly-quickstarts/wildfly-operator-quickstart:18.0`
+      * a digest: `quay.io/wildfly-quickstarts/wildfly-operator-quickstart@sha256:0af38bc38be93116b6a1d86a9c78bd14cd527121970899d719baf78e5dc7bfd2`
+      * an image stream tag: `my-app:latest`
+
+    ### Specify that the application image uses aBootable JAR
+    
+    The bootableJar specifies whether the application image is a Bootable JAR server. If this configuration is unspecified, the WildFly Operator assumes that the application image is an S2I image.
+
+    Example of Bootable JAR configuration
+
+        spec:
+          bootableJar: true
+    
+    ### Specify the Size of the Application
+
+    The `replicas` specifies the size of the application, i.e. the number of pods that runs the application image.
+
+        spec:
+          replicas:2
+
+    ### Specify the Storage Requirements for the Server Data Directory
+
+    The `storage` defines the storage requirements for the application data. The application may require persistent storage for some data (e.g. transaction or messaging logs) that must persist across Pod restarts.
+
+    If the `storage` spec is empty, an `EmptyDir` volume will be used by each pod of the application (but this volume will not persist after its corresponding pod is stopped).
+
+        spec:
+          storage:
+            volumeClaimTemplate:
+              spec:
+                resources:
+                  requests:
+                    storage: 3Gi
+
+    The persistent volume that meets this storage requirement is mounted on the `/wildfly/standalone/data` directory (corresponding to WildFly's `jboss.server.data.dir` path).
+
+    ### Configure the Application Environment
+
+    Environment can be configured using the `env` spec. Environment variables can come directly from values (such as the `POSTGRESQL_SERVICE_HOST` example below) or from secrets (e.g. the `POSTGRESQL_USER` example below).
+
+        spec:
+          env:
+          - name: POSTGRESQL_SERVICE_HOST
+            value: postgresql
+          - name: POSTGRESQL_SERVICE_PORT
+            value: '5432'
+          - name: POSTGRESQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: postgresql
+          - name: POSTGRESQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: postgresql
+          - name: POSTGRESQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: postgresql
+
+    ### Configure Secrets
+
+    Secrets can be mounted as volumes to be accessed from the application.
+
+    The secrets must be created *before* the WildFly Operator deploys the application. For example we can create a secret named `my-secret` with a command such as:
+
+        $ kubectl create secret generic my-secret --from-literal=my-key=devuser --from-literal=my-password='my-very-secure-pasword'
+
+    Once the secret has been created, we can specify its name in the WildFlyServer Spec to have it mounted as a volume in the pods running the application:
+
+    Once the secret has been created, we can specify its name in the WildFlyServer Spec to have it mounted as a volume in the pods running the application:
+
+        spec:
+          secrets:
+            - my-secret
+
+    The secrets will then be mounted under `/etc/secrets/<secret name>` and each key/value will be stored in a file (whose name is the key and the content is the value).
+
+        $ ls /etc/secrets/my-secret/
+        my-key  my-password
+        $ cat /etc/secrets/my-secret/my-key
+        devuser
+        $ cat /etc/secrets/my-secret/my-password
+        my-very-secure-pasword
+
+    ### Configure ConfigMaps
+
+    ConfigMaps can be mounted as volumes to be accessed from the application.
+
+    The config maps must be created *before* the WildFly Operator deploys the application. For example we can create a config map named `my-config` with a command such as:
+
+        $ kubectl create configmap my-config --from-literal=key1=value1 --from-literal=key2=value2
+        configmap/my-config created
+
+    Once the config map has been created, we can specify its name in the WildFlyServer Spec to have it mounted as a volume in the pods running the application:
+
+        spec:
+          configMaps:
+          - my-config
+
+    The config maps will then be mounted under `/etc/configmaps/<config map name>` and each key/value will be stored in a file (whose name is the key and the content is the value).
+
+        $ ls /etc/configmaps/my-config/
+        key1 key2
+        $ cat /etc/configmaps/my-config/key1
+        value1
+        $ cat /etc/configmaps/my-config/key2
+        value2
+
+    ### Bring Your Own Standalone XML Configuation
+
+    It is possible to directly provide WildFly standalone configuration instead of the one in the application image (that comes from WildFly S2I).
+
+    The standalone XML file must be put in a ConfigMap that is accessible by the operator. The `standaloneConfigMap` must provide the name of this ConfigMap as well as the key corresponding to the name of standalone XML file.
+
+        spec:
+          standaloneConfigMap:
+            name: clusterbench-config-map
+            key: standalone-openshift.xml
+
+    In this example, the `clusterbench-config-map` must be created before the WildFly Operator deploys the application.
+
+        $ kubectl create configmap clusterbench-config-map --from-file examples/clustering/config/standalone-openshift.xml
+        configmap/clusterbench-config-map created
+
+    ## OpenShift Features
+
+    Some Operator features are only available when running on OpenShift if Kubernetes does not provide the required resources to activate these features.
+
+    ### Seamless Upgrades (Phase II)
+
+    When the `applicationImage` corresponds to an ImageStream Tag of an ImageStream in the same namespace, the WildFly operator will detect any changes to the application image and triggers a new deployment of the application.
+
+    ### Creation of an HTTP Route
+
+    By default, when the Operator runs on OpenShift, it creates an external route to the HTTP port of the Java application.
+
+    This route creation can be disabled by setting `disableHTTPRoute` to `true` if you do not wish to create an external route to the Java application.
+
+        spec:
+          disableHTTPRoute: true
+
+    ## Full Lifecycle (Phase III)
+   
+    ### Transaction recovery during scaledown
+
+    As the application deployed in the WildFly application server
+    may use JTA transactions there and the question emerges: what does happen when the cluster is scaled down?
+    When the number of active WildFly replicas is decreased, still there may be some in-doubt transactions in the transaction log.
+    When the pod is removed then all the in-progress transactions are stopped and rolled back.
+    A more troublesome situation occurs when XA transactions are used.
+    When the XA transaction declares it's prepared it's a promise to finish the transaction successfully.
+    But the transaction manager which made this promise is running inside the WildFly server.
+    Then simply shutting down such pod may lead to data inconsistencies or data locks.  
+
+
+    It must be ensured that all transactions are finished before the number of replicas is really decreased.
+    For that purpose, the WildFly Operator provides scale down functionality which verifies if all transactions were finished
+    and only then marks the pod as clean for termination.  
+
+
+    Full documentation of transaction recovery can be found at [WildFly Operator User Guide](https://github.com/wildfly/wildfly-operator/blob/master/doc/user-guide.adoc#scaledown-transaction-recovery).
+  displayName: WildFly
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAMfpJREFUeNrsnQtcW1W2/3feAQKEQiFtaUlb2lL7IH2CrVrQjq3jjG2v/7GO9Y74dxyd8c61/mccdfTa1hn/6ni9tTNjvR0fpXPVsb4K9V+dvgT6pi8ehZZaHqEvwjtAQt7Jf6/DOfQQEgglQBLW9/M5n5N3Tk7O+u211l57b0IQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQJNgRcDdmLl6uobvNdCtgH9KyW/GFkwf0eKoQJIQFgBWBGrpTe3gdCEAxKw7FrCho8fQhSGgJQBbdbYfbCxfOO3H9uk7V1NSsslqtcg/vBQHIZ0UhHwUBQYJcAFgRKKI7ze23Ly148cVnwcBJQ0Oj/MyZItXZsyXqqqrqpOvX6zx5CcWsIORSMcjHU4sgwSkAGXSXB7dffvmFbUuWpOk8vfHbb/epQRDOn78wo7m5ReUhZMhhxSAHTzOCBIkAsCIAycD1CoVCv3Xr5m3x8WPNfX0IeAi7d+9JuXDhYtKlS1UpHkIGEIEdKAYIEhwCoGS9AM2UKZMrqAjsHMiH7tz5RcrJk2dmeBAD9AwQJNAFgBUB6BaEfABZufIHe9evf+rEQD+c8wxoqDCjuromxe1pLSsGWzCBiCAjg8jbE03XqnVjJ0xpA/uvrKxOpp7AxYkTEw0D+fCIiAj7/Pka3b33rixfsGBeSWenydLS0qpkvQLwMtIh1KDfk0E3Af3OYvxLECQAPACeJwChQIav+QBfgATigQN5qeXlFzRuT0GIkI1eAYIEjgCo2VBAOX78OO2HH767w19ffuHCReVXX+3WFBWVpBoMBqXb0/mkK3GYjX8TgoyQALAisJrudsHtWbNmFr/11mu5/j6Q99/P1hw7VpjqocYAPAEQnbexJBlBhikH4JYPqKAxOhOzNzY2qWiLrVyxYvlFfx4I5ApWrfpRCeQampqaxfA97FPwvRl0e5Ieg4puF+nxoBAgyHB5ADxPALyA1UPpCfDDA+oVLPNSVwBhwSbMEyDIMHgAHLT13Ut3K+mmGipPoPu7xsaZ4bPvuivjTFNTi0Onq1c5HA4x+zQkD6H3QE23EvQIEGQYPADWC+guEhoOT4ADagreey87vbDwVBp6BAgyAh4Amw8w01Z3J98TOHasULVo0YIq6PcfqgOFz77jjqVa9AgQZAQ9AG+eQGzsGN3mzW/s8EedgK8ewZ//vHXZ6dNF6R6efpv1CFAIEMSfHoA3T8BkMikOHTqaPG6c6tpAKwZv1iO4886MKqgwvHr1mpzXawCAKECvgYUe5wn8mxHEzwLgTQSOHz85OylpUtVwiADAJQupB1J75cpVZUdHd0ER5AlW0uPLYsMCzA8giD8FwJMIQFw+3CIATJs2VQ91BGazua2yslrNyw+AIIAIaOhWiPkBBPGjAHgTgYKCIwvBGKHAZzh/EHwfJAqpNyC+fl2XyHsqhRWCMHq8+fjXI4ifBIATAbptg0w8YROD589XpIyECHD5AQgLKiurmNCEFxbAyMPVbEUhhgUICoA/oUaVGwgiwIUF99+/6kxt7RWBW7ehivUGlGxYYMZLAUEBCEERAKB+QKOZW37uXLmKlyQEoLfgQXqstTDeAS8HBAUgREUAegsgSdjU1Gy5fPlqoluS8EE2SbgXvQEEBcC/IsDN/DPiIsA0+emLr4I3cOlSlbK1VR/HewqShE+yuQH0BhAUAD+JwF5wsQk7ijAQRAC8AZimTCIR19PjSeZ5A3L0BhAUAP+LQLG7CFRUXJTfeWdG1Uj++Nmzb2mCLsOSkrI49AYQFIBhFAHoox/K4cS+Al2G/XgD2FOAhCyC4f5CduUhmFiEycYP13BiX4ABRs8///JaL9OSrblw8gDOWoygBzBIT0DLTizyILSywzWc2FdvoI+egifZqcvz8bJB0AMYvCegZj2BERlO3B8wJdkf//jGWg/rHoIAPIqTjyDoAQzOE9Cz4wcg4ZYC5br79+fNTkycUDucg4i8AT0FXBXh5ctX+CEB3M7CBCGCAjB4EYDxAzvBtaZ3M2CqLxhJKBQKmiFDHwgnCKoIYUxBefkFNW8qMkwQIigAfhSCfGpIBfTmahp3K4qLS2dDywvGFwjHB2MKMjJuL/HQXQgFTivZmgEcZoygAAxCBCA5uI01KjW43d99V6CePn1aLbjjI318XHchJAhhrUTeUyoMCRAUAP+FBDvYRUnTOzoMqry8Q5r6+gYHlPAGwjHCccDiJWfOFCd7CAmwlwAJKgSBemBsL8FmwhYOwbqEzz67PnfmzBkB4Wr3UTMAS54/ihOSIn1c29DzpfTwFDym8fI2Lbu5UzyYa00QBCdrI909Qrqy7+T225cWvPjiswHTyr766psZhw8fXeb+p7AiUDyQiwILjYLeoNXcdUrhXxPeDN7fcCIBglDC3afXVX4wC0AN76QywFLljz32s9x77rlbGwjHuHPnFykff/zZKrcFS+BPWNPXyXcXOvrajWhOAW3kataYk3jGrvbn94CnO5DXe/BAvVHMbiAM+VxjEwwCkEV32z09t3DhvBP//u+/KgiE4iGoZnznnW2rPBQOPerLEuf0d66nr3sbTS0grrkM1tBTWQPPuJnPgeI2mUxmlsvl5gkTxtfDYwkJY/X0NuOyR0dHm5csSfPbqFgoXtNqa5Xt7e3yysoaVUtLS3Rrq17pQSSy6bX2aLAIALhO4AUooeWnxq67evVad598IHkDkBfYuPH/rqqurklxewqWNn+mn9+5ub/XIENyfXEGnsruNQNtsWNilPoxY8a0JSdP1kVFRZkXLJinC5SKVuD997M1X3yRs8rd+INCALjWkXQlBMnTT/9qBxg7uN0nT56ZUV5+QRNo3sBLL21a4WHFoh4n3stvzMc8wLAZ/DJ275MLDa25SpWgA0OfPz9VG2hG7o3f/OaFVZyNeLoGBUH0x8EyZBlSqdT8xht/2Mb1BvAXDYXnAsUbcFPdbhGg2zOesrbshbmhL5FAhsfg4TpKTJygBbcdjD1Qck2DDEk9hqKCIPsjiyAU8DRwiC8EaWmLCgOhp+Dbb/ep3333/bVuyUFo4TO9iEAewYFG/rhWVvMMXuOrwU+fnly7ePFCrT/j8pHArWcKriWvQ9kFQfjH7uJcMk+jBzkhqKqqTgqEugFQ4tdff+sRX0SATT49TR9fg2Y84MaBM/rVo83gOSAJ+Oabb6/iJf36rUkRBOGfnUXYXoG+hhBzqwfHxcW1rV//1IguEArH8swzzz3i1kPgTQTAC9hCH89B0+7zOoCW/RFfW3lI1k2dOqU2WF36/nj77XfSv/uuYBnb0OjZUDO7v/cJgvTP7yECTz31RK43FQc3/OjR4zNGOkHoqwjwZkyaHMzVhPA7fK2BGKAHuMqXWB56h5KSJmoXL15wMTNzmTYYEnY3G2Z+9NGnK3jX1YCK0ARBfIF1iwC4dOvWPZC7du3/quhLIceNS9D39ZrhwC0ry/xh9M+a5/bboMcDKgMzg/j/8UthE8/oYa/sr5WfO3f2xVBy6/sy/M8/37XMrY8f6kg2DaThEATzSWBFYDN3YfRXJgwxEvO+Ec4LeBCBHt0zbO0DJDxzgrE2YLBdmqx7/3R/Rs/F8tStv3jfffdWhGor74PhF7Mu/4A9LkGwnxD2YsnjLhQICV566bmdgTJoaBAikMH+Lp8qCQMtNh+ocLGJvCzCG/fhzeinTZtaAa79SHtzwwl0K+flHUpzCyH1bIt/0xWkglA4OWyLuYuNDZmL5M47lxWMdPLPDyIALvQG0tWNkxNE/8MaX91Q1sV/hPSRvR+tRg8e61df7dZA17aHcSZbSFeF6aAaOkEonTCewXTHhD//edbeQI4HPRQMuYsAeAEgEpmBXCXItvybWVe02AehWN9faz9lyuQKcO/pfziqqiOh6/jLL3PS3BoHvxp+SAoA70LcTnhdQ4FUJuyjCHSPHeDlA5SBKgJsuLKd9LN2AlftyLr6HoEQLjPzjsLREtPzgfL2vXsPpnkYvON3ww9ZAXDzBp7mcgPgRt533w/3Bmpr4kEEumN/Xp6DBJoI8M6z1+NiBWID8TKqDv6buXNnFa9b92BhoOduhuq//+c/DywzGAzuCU8ta/jZQ9UlLAjlE8u2ONv5Fx60MA8//ODeQCwG8VA6zBcBrgpSHwgiwPO0OFHSD9TwIUSj4VnJaHPxfTB8OB9bhiP5KxgNJ5o1ns38eBMuvp/8ZE1BoAmBW+lwD2Pn1T6MmAiwIckGNob3OMy5L8PnEnrU6AtGY2vfj+Hnk66sfv5wHYtgNJ1497AAgLUJA+1i9CAC3VWB9DdsZ2NoPesh5Azj+ctihZR4+m73eRz5QGXebbfdWvjQQw8Uj7bYHuDGqBQVlaR6MPwctsXPH+7jEoy2P4KXgd7AfzzQhMBNBHpUC/JEoEeYMMSGv4H1oHoNMOkruTfa3Xz+KFW3rjwgm23xR8wLFZBRireLNpCEwE0Eerjb9Ph38VraIREBN8OHi/QZfqvPiulmb4YfiCHWcAF9+NTVX3bpUlWKhz78nJE2/FEvAMEiBG4ikMm5iazxcTUCfhMBnofED5U2EV4XlJfXdJ+3++9fXRjqtfje6KMrD4x9SDP6KAD9X9wZfTyt5rV2ASUEcFFt3/7RWvYimudmiHwRmDeI+ns1a9BZPKPOYVt9Le91vRKqo70bD1r7jz/+NK2i4lKKl/h+R6BWcgpCxKj5CypwM6H0tcjCgJk6dTJUppHk5KndxiAWi8xRUZHMbK8SidQMXYxwe9q0qX537Xh1Au6hAFcopCY30TvgxQPKJ27ZaE9dqpDYmzcvteTxx7NOjLbEHnhmJ0+eVp86dSbVw0zQXGufE+izOwXLpKCcMXNzsnO3+xweyk3LfMOIp9QO5HtNpk5ZaWm5hh/DxcTEkJkzp5PExETa8kn6fH9kZKSWEwn6Pl10dJR+4sTEm3aNeWMHJru1yvwBUT6JgBfD17KhRL7ba7mkqZIz/JUrlxeMpsQetPJHjx5X031Sbe0VtZe++1zW6IPmvAgC0NjVPANf5s3Qwe2Mi4vVcVMyc/Otq9VJenBDRUJBjEAgYCxUJhJG09tO7r1CgUAuEQnEvhxPa2ub/MMdnyTvzzs8vrmlNZz/XGrqnKa7776r5Y7bl3Q2NTUr4LGGxiaBzWYTG41GmdFokre3tyvsdrvYXRjGjFHWqlQq7UC9hXXr/vcTtMX5p/vkob6KgJfEnZZt8bM9/Bfdrf5oMnww+L17D6R8/31lEn8aerdzBkIJq1rnB+s8joJgMHbIKI8fr9LB9F4zZkzTwZTMqoR4kVAoiJAIhQpq7AIpY+TEQe/D3kmfs4kEAps/j/eL3G9UBwuOqQqOFk7kPx4RHu5MS1tgmJc6x5SZcTu0+E6Xy0U3YnfCnhDblavXIpuaW6TUeEVtbe2K9vYOBV8QEhLiL06YME7bn4cArucrr7z2hLsXwAuHuJJh9yIiT4k7rzXmbKwPxq8cDYYP3XV5eQVqmGreSwvPN/ycUFnDQTDMBq8hN6Zo1rgn3LhWHVx1WGRh7tw5OmjNxSJhPBi6WCiQSsVCGRg5GDi9bxmJk9bcopfk7NmnKjhyQnW6+Jx7/EfSFs033LY03XBX5h0GEAPucSoIQhdxiZxOl91ktpCGpibZ9es6WZ2uQdbS0sKNWdDTc1BBPYMSb2LArjuw09M4cLeVlMBg17CtvXvGfhPxMriEW4cB/g+YYTlUY3wuji8tLZsxgCW2CPFhoRcUgBstUoa31p1r2anbXr906a1avrHLxMJIERi8SEhvCs3QqgfqSeQ8g7IL38e6hwmcGKxZdW+7p/eyoiA2mczOK9fqwmovX1Xo6hskJpNJHh4eBuemcMaM6RUREeE9pkD/2c8eT/M2ZVhfy6mRfopPuCKjQFuN2V9Aj8q5c+VJVHhV3JJd7uGju2fwxhv/taKvxTVQAHq69Pw52ZX81p2bihnceCgQgThdKhLFSETCMBqThweDsffHqbOlUd8eyB93rPCM6vLV61HuYcIdS281LF40v5PvGbj/JzRskDQ0NkkvXqqKrqrWhjscTsvkyeqC9PRF3ROcrF//u7Rdf996zwAEIJ/0U2cOxk//pweDYTKVgSbvDAYjE8NzIaQvHg0Mzvrgg7+v4oUD2aG2cIvAD0bPTc+8mu/Sc7OyUkWthdb9lltSOqnLHi8XixScGy8SCSz+jtMDiUpqvF//86Bq78FDE/li4ItncMNDcInPV1yKOltyTklvN61Y8YMd4A0UFZWYV9+19HUPHtd24nmSjV6Tj7qLBjX+d59//jc7QqWIB1x82A/093BVfG4TcjwTiou3Cvxp9DCDC7fYwtKl6S08g4+E1p229J1klAJiUHD0ZOzpotLYmtor0ZwggGew6r57Wh/+6U9a+/AKiNliER7MP6JyOF1ltIXeSx+qSBqj+JRn+D1G30UoIsgTT/ycHNj/HSktPUf6asHAcxs7Nu7bt956LXc0DtThC4aHmXgGNM12SAsA61pyizH0mKsN5l4fPy4hihr8WOrHh492g/clkZh3+Fhs4ZmS2HPlFXH0vuLJX2Q1ePMI2to7JMUlZc1NrfoPVqxYDm68duXK1bAK8WZ3w1+9+j6yes19JCIighiNRvLsb54jWu1lryKwIOPH7/72t+sFo7F8F2L83bv3pHiZcPOZYJqQdUgFgD8CjT9XGzXyxDCJOFouESplIpElEON3B42pnU6XZKDvG858BHgIn3yxe+KEiROjQATY5GDnubILwq92fa0uLjn3t+aW1j9A1t7b+IXly+8kT/zyccbw+bS3tZHnn3vRqwh8nX9i49y5s3u858qVqyqz2SK3WCzy1tbWXj0dUMPAvz8U1Y9DnRc4e7Zkhoel3OF37CBDMP1WKHgAjAjA/Ptc15BbIk9M7ytoXC8YrPHYHM5w1nhd1O01DOS9QoEgmr6/jW6dFrqHx+wOZ8OABUAkjOff5wqKxPAbhQL4njB622tB0UA9IBCqNpMtnh53Xfbf/xG1/0DexOvX67Rc8s6b4aelLSRPPPkLohqn6p1DcDqJxWQkujodefa5/6AeQWevmLa2xbAR9mVl51OqqmrSqNGruSrH6OhoM1Qzwu3W1jal0+no/myr1UY3a4/vE4lE5vDwcJ1cLtOHh4e1gVBAsVZcXOyIGRPXxw/Z/5qaWrWH0l0AvKodod7iDzoHwC8L5WJ+T5lVMB764VKZWCTjinS8G7sLCmbM1NaFnMFSo9d/883e8XD74sVLKnrhym/mB0I9wVBPJS1g6pAESui+lIqF0RAC+eoN0R8uszqcFrPNYbmqa2jJ3vFJ0pEjx9MMBgM353u2t9F3s2ffQtY9/FOSqkn1lkAkJkM7IwJM00Y9gI2vvMYXAWYEIRUATW3tlazCEyd/ffvS9GZVwlhTRES4x/8Lahhg56I/22A0iu12h5j+d46GhqZIm81mamtvDzObzWKDwajo7OyE7s0ewgAVkFAWPXmyWsvv2vQnkL2Ha4Z6MQk6Xb3Ki8Fz8T209jmjdUXmm00CKtkEILdOW/dFCf3HsIdiHviDQRw89a+CG6bV1jLvo64Yk0iEFX1hzyvK0LIb/FFt7N69JVGyhsHEwdD7kJIyrWLOnFm1YPjgodCWOgKEiP3BEuiFuGEkRGRlRaefE9XjfcxFzXo7A2ntwbUH74Z+p8Fkc+gtdkf9kaMnIiH5xI4dB6NgqvPYt/Qy/MlT1OQXv3jMq+HzW3+TsaPrR0okRCyRkWNHj5HXXvtP/ss4EZBrq6r/PGP61LskYrH9Zq4L6L6EU0VFwgIVkCazRUQ3oa6+XtLaqo+ACsi2tjY5JwpQ50DDFd3YsXG1kyZN1A7USwBDv3bturK+vlEJ1057e4eyjwo+Lq6Hlh5q9vNxGXY/1QGwrilsXLFPEnvflxF5Wt5Wyxq51tesKztvfgZ/Agpq7Ek0HlFSg1VQw7SPZFcjGLzd6ZRDK2+xOzvNdkcjhCNcrTnb2iv5sac3w09IiGda/OU/uKv/EMpiIXabhaqWnDF+VqeInbrsH/3Px+Szz3f1EgEQ9ofXrd33yMNr48PkMn9VWUJdgxg8BxriWE1ms8hg7BRev64Lb2xsVFJhUFBvoVsQlEolLORZy3kIYOTt7e3yysoaVUtLSzR9vbKpqVnloTbfWwsPWwkZxFJlKAD+E4gbHoCf5j+jn+2CUGTr1s07oaWPlEtuVcjEHSNl9ODSU4MXWu1OA5eD4PIP3ErFbnFoj9jTbRaeARu+w26nm5WIxFK6iT0+b6ZewTtb3yP5BUf4LSMzbgC6eG9NX7zn/6z/pVEVHy/ghzG0hRVeqPhefr1OJ67T1Utu+qITCMQ0xHNZbbZOu93utFptVAhaFVQUunMK1NB75Rf6adk5Y2cakZGYXw8FYASgF2xNbOwYOX+qb8g/QMKOegJQf6AYioIjMHToWbA5nW30YiacsdPHjPTaNnIGD+ENuKceFnPsEXt6Mnzo0gPDh269/j0NF3FS46bW5dHwuddYzZ3E6XAQi9VGXnxpE6mp1noUgenTk7/9j5d+V5SUOH4yFVbhy6+8rrp+7TpzDjs7TRL3wqZhhPOUusPD0ZCtRwHwLgAQYoA/q4bx/4sWLShxXx6anwfgDwXmx/C9Wkpe7wM/T0ANHVxZE9/QASgiOX/+gkqrrU3wkGnWkhtDR3PcJtT0aPj8vvx+jZ/G+mDcQpHIu2dgszGvAXEQCIXMYx3t7eS53/2e3z3IF4GsSZMS333851lH71iarhRYO5vjxsT0Cgug+7Km9moY3KaiEH6tThfuy/9WWaWNMnR29vAipk5OaotURDD5B3qMsmkzZlTW1TcYaIyfRM9tyuXLV+WsV8Cdz9xgWDMRBWDoRQDiZDCkR7icAzf2AAZ7zJ+fqvW1/tuXxBM/JvWSZeYbvMdkk6ey3QEbPjVoL/rV7+sYL8BkpCLQwfQMeBOBmJiY7b/+9RO5d2febouSS6KGcwQmaJrF4ZCZbU692e5oKSktj8vLPzzFTQy4STZ3oNs/SgXAQ76BG5DUa8gx10vBTSTi7XNgNiAYMQa3oRimj64kLT/R1J9L6mXRDL1aPUm5acPvSWx8Qp8tOWfQYB1cSz5QwBuwQ55AJGE+A6oFX3j+JUI9F/5vmscWHTEisGrVvSd+tu6BM9Fh0lvCJCLDSPy3VATCQAxMNntbUUmZ4tChozM8eAbcHPtaNO9RKAB9JCDB4LjeiV5JSR8STFzs3t0dOZAWx5vhkxtdfrs+37kjQyyVEqk83GPLDq4+JPH4bvyAWlQv7wdBaa7XkZc3vsr3BIpZT0DPDhTa/sAD/1J8/7+sylPFRs+MkkkcI1X1yfcM+GJQVFSiuXLlKvGUXEVGqQAM0ED1/u4q6s/w+Sv+/OWvm7OmJk/12OJD952QGi106d2M4dusZo89AxAKmDsNzGugQOidd98jp06d9SgCELIsW3a77vHHs3YmjosfGy2XxsnEQstI/m8gBtQzEJtsjo4mfbvubFHJxP3789LOnStTsd2L3LnORq8ABWC4BcXd8OEC3OSpVQIDW/vA/dsfWreWiCXS7hYaDBSM82YMH1p7MHx4vzwispdXAaGA1WJiRAGKhCD0ALH5t6ee5vcO8EWAmSYsOXmKPCvr4dzFixZciZRLZnvyBqDYyWx3xkhEgha5WGQajnMOPTMmq93WaXM0VtbUWvbtO5h24sQpvleQTQJkQY5AQYSnwP+GP3bCFEjubeSFGXDBQe39o03Xqj16GPQ92qampid/+MMVcon0RsEhCEF/OQFPhm81GYnNYmaM2934QRDAo4DHpGHh9DWSHiHB4gUaUlxSSvR6JkUCuY+V9PhgCrJiut/b0tJ6W1FR6XKbzSYcP3FioUskkkEptFgo7K4gpPdtUpHQSFtmSbvZ3uFwuui3CaKEAoGd3nANxbmnn+2QiUWuCKlYMTY2Zsy8+ZprGZnL9sfFxVlhQBP1CBY6HI719DfAf1RL/wstCgAylIYPcShU2T3jzfA56PPmMKUqLCEhIWPq1Ck+Zff7MnzGuOXhdAvrmQOgrT74zZBrAGFhCofoY1xoAK8JC48gd96VSc6cOcsU5LAikEKPcSfddCAGZrNZVVxc+qNLlypnT0hMPB8WGX2Reg8JErFQImRnYAZDpwYJQhBlcTgtepO13Giz00baKXC6iMxJXGH0OAVC3ozNfnFr6fdKREJHuFQsUYTLJqTMmN5y98q7901KmtjY3t6hogKWQoUgC4UAQwB/GD70NGx2c/XB1dwy0HwCdGcmJIytefNPryrjElQDivHBlWcUXSTpleTjsv4gChJZGLOH0AKKgkAEuMfcgTqB56F34IZ99BhGzIUEMTExyuXLM4offPAne6OjFFFKuSQ5TCK2egoLDFZ7e6fVfoV6BK2spxBDPYcoKhTMPJDUcAVD0dXIfbfRYq86cvT4tK+//hZm/FGyvQecUI86IUAPYHAtPhj+2+TG4pmQbFpDLySmpRzoZ7JegMVqtaxMnTuLgKPsq/sPeQPY4PWcMTNDgTsNtJW3Md6AmA0t7FYLgcnKpTJ5V77Bi7chk8lIRsYd5NTJU1w4oKG/WU2PM5c93gp6fxv1BlLOn6/IKCsrXxihiGiIVY07ZXU4IzyFBWHUwiNkYpj4NZEegpjG7S12p7PFYnc0UmG4arTaW2nYAOMHZP4MGbjvptukSZMmmpdlLjvo5hFAaKCmWwn9XXoUAMQXVz+F3JhsE+L7fDDiwXw+ff+J1k5XxsyU6eoxMdHUW3cSoVDUd7efh0IfCAMstIWH5J6MuvTwfkjwgSiA0TNeQj9hBuQJnNRzOHr0BGlsbCpmQwF3ETBDaACGQ19z2/HjJ9Pr6xvU6imTz1LXopa29NG0RY8CA+TF6k6pWOikTX44bfWTRNQDcLhcYPRGF9NYu9rMdkc9bbFrqRgIHfSQ6ePhQiH9FYMMF7wJAT12Nd0W0peAECjpVjjY/xIFIHQNHyoPP2Vb+y39xfcDBYxJW3v5yR/9+N6umgBej4DdZmUy+9CK2+02xkvgd+2B0UK3Hhi3PFzR4zl4zJf6AfgeGEYM37Vnz16y/0AeeDng+q/0JAI8b2AHbUnllZXVK6lopJvNFsmESZOKbERYTw1cyU6k0mNMBngIcolITOP1WLlYNBEmc6GvtVOtYoyPikI75x3QrZN6DFBqPGgx4AvBhMTE9luX3JrHJQshyUlf8iT9PWEg6igAaPic4YObDwtq/JJ184fEVYTwQRIRKwgPD8uYPi25K7lHW3Nw5QVCARGLpQR6CmBjuu6YrL6FeQ0ogjwsgnH3byaRyAgF4y04yXffFZD33s/mJsXUQ/LPTQQEfANhvYG99PFco9GYUlxcetvZs0ULw8LDTeMTE890Wh3N3oQAjBkSd9QgxRAieBID2NPQopcYUBFx3WyYAMfBJQunT5/WuOS2pXvpb1c0N7eo6W+A/z6LTRRWhOL1jUlA74YPCa6n2fh+BxnmQhJICI4dG9e69a9vMRl7KSTq3Kr3uOQetNgw7h9ed7NGz/9cEJOcXbvJ9uyPumsA+MdFei5J/qi3ajtuoJNUKlXPmjVT/+Mf31OwZEl6MQzMokY+VSEVR/U3kQpMkwa9Bha7swOq/qjRN9Bj7DFOGOalpJ+lovGEaDCjPqGoiH6HlLocNdd1DaaPPvp01ZEjx9RsQREI3TOhNqcACoDnixYGFTFDdkfyD6fHsutvf/vL6sRJSV3GwI71hz0Yqpid5WegdQLegElE9C3N5K9b/wbVgNnsBe9p6bCBiED3dGZUCJTuQkBbX3W4VKT0tViIioHCbHe0Ga32ZpvDebVHOCESxkdKxZMUMpgA5ebLlEF0Omnc0W6xVVVcrIz+8MO/r+L1GLzN5nxCIlGIIUDPixUu1BP0z30DXNmbyeT7ORcwc7JanZE8fVrXhUlbfEgIgusP/fvuBTw3C5c3OHHsBNn4yut6rfYyhDibvCXB4HG3cGA16yYXe3othAnQW+BwOCw6Xf3K48dPppSWlmnCwuQdCePHn+u0OerNNgdci7BYjKiv2J4+aaUNvVAhlUTS/ST6kIJ6BTCVuuPY8ZNzaAt+Wa5QuJg8gUAgheKggZ4P+H4oKKLhyITYuDHkjsxl/xw3TtVJjz2Rlx+o93fuBwVghIEM/EgbvZsAkKSkiVmzZt3CJPNgY7r5/GD0fAwGA3nzzc3k8y9y8m022z2+DHIaiAi4CQEkCpXUmFKoEGhOnz6rsVisUtX4cRcdAmEtxPa0BY6kLXiESCB0eovt+cU+0JNAXxQRFa2sLjx5ZuGH2R9nni09bxFI5a1RMWP0DqdLAl2KIB43kyiEz09SJ7W65QdWs4VEJYF0zaAAhBCQaacuc5ZmnoYZCDQUQLHP73//MikvuwDu/i8HktjkiUAKu/UpAux79NB7wHkEjY1N6adOnaFiUHjb1avXlNHR0XpFdPRF6uJf4boAaaAa2VfFIPQkgBBEhMkmJU2ZXDZhwoTvCwoOp3/8yWdz9x3ISy0tryCddkdjWJSyTSASQ+Ab2Ze4ePr8MIlYRj8/cXbq3NL58zVnqQDEXbtWp6G/4clg7jZEAQgCAUiZPpXAfPxQvMMv9BlUso9dL+DZ374A8wCsudlhs7w6ADWbE+hXBPgeAd3egNe3t7fDVN6aw4ePagoLT2usVluYMibmskgquwJiAJ6Bxe4UQGsOrT21YpG7e08bays11LFjxoxxLVi0cP/163XJNNRQVFdrDfn5h785fuLkj0vKLoyhn1cXER3TzokBv1jJa7Ksy+MAoYlVKqOVi9PT8nn1A1xYcDHYegtQAIJAAG65JYUp3pHI5IPP8kPZsLmTGn8n+eyzr8jRY4WQ0PpvP4RPuW4iUOKrMYBY0G0bdB9Sw5dTg0oBryAv73B6UVFJCr0fJ5XKDFFKZQ0UCIEgQMWgwWo3Qw+B2e40U2GQ26hK0j2MPYgRisXiuZq5BfX1Dcm1tZcTIXF3fN+Xz3RYhOUFBUdmnD5TdHfFpWqpXBGpDYuMNggFZAwVgn69AvBC5GKRk6sfSLs1nQkL6urq1Waz+UH6GzSsN6BHAUD8IgCzqABAws/bZJ++Gj4ztBi6Dx12YugwkC1/+W9tyZFv1vgxhwIiAFn/dNI1gnBAiVR4LXwG6xWUUIMy19XpEouLS2cfPJiv+e67goySknPqK1euxgiEQpHJbLaEKRSXrQ4nlA/X0a0eNuotQAVis1QqsatUCc3ffrsPRKmEzfFo4TuEcuUH1ONoO3T42L9WVteoTXbH1TjVuAZq/pFikVDcX5FRV37gRlgwZ87s8zpdvbqlpVXDDjSywPcF+jWG3YABDBQhPfCTNXk/fegBIguL8NvnQpnwrq9ySfaOj4dkyWtu8hDCm19wkJ8HBpxBuqZ5gz2zVoJCEcHMnQgLioSHh+mpl0AmT07qntesvb0jGqYMq6xkYvN53uo44HhlMumGW26ZqYQuyjtuX3I9nIYSEVJmybt+F3yBbsMOs83eYbGf2737myVffLFrGfU84ClIpq4J5C5DFIDAFoD1VAA2Zz3Wc0Vvrqa/rKychgRCUlVdzTw+dcoUZmLRKVMm9/YA2AIfGzMQyMmsE6jVXo4ZqovT3yLg9tncgjPcQjSp5MYCKtxj3FRuYPQ+TQLiLgS3Lb31EhQsUXc/0pc6Bep9KNrMtktVNbWuDz/8n1VnzhTBAiZwHI8G6uzFKACBLQAbN254YcO8+fNJc0srY/ClpWWktKQUFrz0+j4QgVtvTSc/+MFdzPqB3FBhKCGGmYXqrl0njz32JExPvmaIjx+MMY+9mxksVXScECQnT1VmZNxRsvyujLPKKEVMhFSsCpOKSF/Vhn14A9nES2EVCgDiVQDu/eHdG2CizvLzPfNpc+fO6brgaDwvEt3IDRiMBlJdVdN9f9asmeThf32oxzqCObtyyd+2fTAk7r8XEeCmP88MplJarpQ5OXmK6rbblhQvX55ZmBAfJ6Cx/3jwCvqau4DvDWzd+t7aoqISJeuRPBpI5wAFIHAvPqbcdtYtKZo778wgEyYmEpgwFGJebp5AQOg2rJdZIYg+D8U95y9UkOPHCsnx4ycYb+ChdQ8SqVhIXn31T1DqO2+4LkRe6XDQiQBfCBIS4tVz5syqWLIk7WJq6tyKSEWECCY04S04Ey4VCWVCocAGXgK73LulsbW9+pN/fJaZm7tHw4YEawJlDQMUgMC+6Ja98spLWQsWLRpU9x/M+//VF7uY0OGpXz1O4/+X9afzcmNG4DeBJ7A6GEWAPf4M0jVOJGsiFeQZM6ZVqNWT6qkYaGGdCW51Y26WI+ohiGHkI9QvmGz24vz8w+nbtn24orWVmQzp0UCYshwFIMBDgD/+4eUN8xYuuDHLD9vCM5vT3h3Xe4Mr+IEBRI2NTWT7jo+h9R/y+L+P3wTjLTYEqwjwPBoQA27xmYyYmBgSGxtjTkhI0EFPhEYzVxcdHaWnQtGjG7Ss7HzKli1b17IzFQ9LGIYCEMQCAElAqAPoC6gOhFGBnoYDwwi/rnkCuoAVgd/Z+h63lFbOCP2uDDYvsCZUhteyuQ4NTxQ0XDellP4vKlW8trVVr+roMMjr6xu45cy2jPTvF6OZBR9g5BD7i9mFPvoaHOQ+hqC8/ALsYFKTEctGQ/xLDSYTRIDuQ2KMPfsbYMvmi4LBYGS6LGmLz++aDJgVjVEAgghw9SW0pfd1kZAbKwKJu0OHU6eL9IFgcGy/fCY1ks1gKKG4hBfvPOcH6jEK0awCmmWc4YdHKbvm+KO3ufn9waA9Gj41dqben25QQQgLg4QposjpM8WQEMwJMCN5ZiS9kdEOegDBANt6M3P/Mav6ipmBQZ4MH6r9oDYApgiTcot90MchEVhYeAru5gZgS5mDfzIKAOKFrqnAOhhXHlp0TzE/zOoD4gCGzxcH8BTAEwDxYN1/NDYEBSBYUCdNYvYwPXjBoSNMKXBDfQNT/280GElCQjwZOzaOqf9PnZfKlADzW31mKTAKVBIGmvuPoAAg/RAREU72fLOPfP5lDmPw7kCdOWxlZefJ7t17mHEAq1ffR9Y9/FOml4ATgFOnzgSk+4+MLFgHEMDMXLw8794f3p1hNHYyNf0TEhNJlFLJtPZQ3cfV/IM3ALfPlZ4j7MATMmXqZPLKppeITNKl8b/6t9+QQ3s+xf8bQQ8gmMh6ZB2zh2IfyORzJMREEdXCuaTd4iBz5s7u4REc2H+QGfDz0kubyMaXX2AqAOmG7j/SC+wGDGy4efeZJJ7QaSNjwiUkMVpO4iKkJDZCRibQ21GyGzoOOQEY9PPBh9uISqUib/7nFm4kYQGeTgQFILhgJrlQKsLJlHFxZFJsFGPsYmGXJ2+wOojeZKdegB3mqiPKMAlRRcpItFxCoqKjyaYNz5PYmGiY+Qdejh4AggRZDsBVVnPN1dRmcLV2GF3tRpOLA5bQrW01MVuryeZyOJ3M47Cvaze7jFZ792vp5xTh2UQwBxCk6FraGC9gQpyy+7GWThuJkoupRyBiWn/A6nAyHgGECVJRl3PX0WGAXT6eRQQFIFjjADfjtztdJC5C0m34nPED8Qops6eeABEJheTgoWNwdweeRQRzAEEIGLFqTFSPx2DqeqPJQmx2R7exQ4vPtfrc+4BPv/xaG2or2iLoAYwaIsPl3cZsttpIc3tXMRCIAve4yMtw4Irvq0hpeQW6/wgKQLDS0WkmWl0z08qDAMRGRVDjj/b6eniNXNo1XJh1/7H6D0EBCFbA8I1mC9PKQx4A8gH855xOF5GIbyzwxN2+3NBCsj/5Egf/ICgAoZAHUKtiu1t2rqV3UOOPkEt7CAK8FvbfFRzDwT9Iv2ASMMABo5+WGN/D+PWGzl7Gz4UL3P4kDv5BkOAGCoHsDkd3QY/VZnfV1je7TBaryx0oFIINqKlrci3MXNWKZxDBECDIudLQyrT0Juryd5qtvUIBLhxo0HeQ6YkJXfG/tgbdfwRDgBBACwlAMG6+8UOMz7n7YPzQSxAbpeh+07myC+j+IygAoSAAsC4glwuAuL+RigF4BeHUKwAhuNakZzL/SkVY95t2f7Mfs/8IhgChgLGza1EP8ASMOgsjBOAJAGD8UBfA7xrM2bOPXLlWl41nDkEBCDE444euPnD9J8WP6fWa7Z98ATus/UcwBAiFEKDT2NnL+AFP5b/FZRXkUmVNMdb+IygAoUGttrYrBwCuPgA1AFxpMB+4/8FHn8PNLXjaEAwBQgyI97mW31NX4JW6RnIw7xC36CSCoAcQAuSzi3n2Mn6j2dr9OAwLzv7Hl0zrHyiLTiLoASCDR8/1AgAT48cwxg9hQBddpcDf114je77ZCzez8ZQhSAjBzQvIlfnCHkp9ORpa210b3nwH5v3bjmcLwRAg9CjmioFgMhDIBYxVRt7IDdQ3ca3/JjxVCApAKApA7WXG8GFyUJgTgBsFCKFAztffEqOx820a+2vxVCEoAKFHAZcI5Ff9Qbdf+aUa8tnnu/TY+iMoAKFLzqnTZ9nJQW9MBaZraSevvv5fjOuPmX8ECWFmLl6+66/ZO10Gk6U7EfjbjX+CxN8uPDsIegChT25+/mFyramVqQL8+Mv/B0uGQ7nvo3hqkMEgwlMQ+DRdqy52SaNWO10u1dHjJ8nHn3yupQ//FBN/yGDB9eKDJwyAlYLzSNcyX49i3I8gCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgSEDz/wUYAMCLqahAoIY+AAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: wildfly-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: wildfly-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: wildfly-operator
+            spec:
+              containers:
+              - command:
+                - wildfly-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: wildfly-operator
+                image: quay.io/wildfly/wildfly-operator:0.5.2
+                imagePullPolicy: Always
+                name: wildfly-operator
+                resources: {}
+              serviceAccountName: wildfly-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - pods/exec
+          - pods/log
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          - deployments/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - wildfly.org
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: wildfly-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - wildfly
+  - java
+  - open source
+  - application runtime
+  labels:
+    operated-by: wildfly-operator
+  links:
+  - name: WildFly Homepage
+    url: https://wildfly.org/
+  - name: Blog
+    url: https://wildfly.org/news/
+  - name: Documentation
+    url: https://docs.wildfly.org
+  - name: Quickstart
+    url: https://github.com/wildfly/quickstart
+  maintainers:
+  - email: wildfly-dev@lists.jboss.org
+    name: WildFly Community
+  maturity: alpha
+  minKubeVersion: 1.11.0
+  provider:
+    name: WildFly
+  replaces: wildfly-operator.v0.5.0
+  selector:
+    matchLabels:
+      operated-by: wildfly-operator
+  version: 0.5.2

--- a/upstream-community-operators/wildfly/0.5.2/manifests/wildflyservers.wildfly.org.crd.yaml
+++ b/upstream-community-operators/wildfly/0.5.2/manifests/wildflyservers.wildfly.org.crd.yaml
@@ -1,0 +1,548 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: wildflyservers.wildfly.org
+spec:
+  group: wildfly.org
+  names:
+    kind: WildFlyServer
+    listKind: WildFlyServerList
+    plural: wildflyservers
+    shortNames:
+    - wfly
+    singular: wildflyserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      name: Replicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: WildFlyServer is the Schema for the wildflyservers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WildFlyServerSpec defines the desired state of WildFlyServer
+            properties:
+              applicationImage:
+                description: ApplicationImage is the name of the application image
+                  to be deployed
+                type: string
+              bootableJar:
+                description: BootableJar specifies whether the application image is
+                  using S2I Builder/Runtime images or Bootable Jar. If omitted, it
+                  defaults to false (application image is expected to use S2I Builder/Runtime
+                  images)
+                type: boolean
+              configMaps:
+                description: ConfigMaps is a list of ConfigMaps in the same namespace
+                  as the WildFlyServer object, which shall be mounted into the WildFlyServer
+                  Pods. The ConfigMaps are mounted into /etc/configmaps/<configmap-name>.
+                items:
+                  type: string
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: set
+              disableHTTPRoute:
+                description: DisableHTTPRoute disables the creation a route to the
+                  HTTP port of the application service (false if omitted)
+                type: boolean
+              env:
+                description: Env contains environment variables for the containers
+                  running the WildFlyServer application
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, metadata.labels, metadata.annotations,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              envFrom:
+                description: EnvFrom contains environment variables from a source
+                  such as a ConfigMap or a Secret
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              replicas:
+                description: Replicas is the desired number of replicas for the application
+                format: int32
+                minimum: 0
+                type: integer
+              secrets:
+                description: Secrets is a list of Secrets in the same namespace as
+                  the WildFlyServer object, which shall be mounted into the WildFlyServer
+                  Pods. The Secrets are mounted into /etc/secrets/<secret-name>.
+                items:
+                  type: string
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: set
+              serviceAccountName:
+                type: string
+              sessionAffinity:
+                description: SessionAffinity defines if connections from the same
+                  client ip are passed to the same WildFlyServer instance/pod each
+                  time (false if omitted)
+                type: boolean
+              standaloneConfigMap:
+                description: StandaloneConfigMapSpec defines the desired configMap
+                  configuration to obtain the standalone configuration for WildFlyServer
+                properties:
+                  key:
+                    description: Key of the config map whose value is the standalone
+                      XML configuration file ("standalone.xml" if omitted)
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              storage:
+                description: StorageSpec defines specific storage required for the
+                  server own data directory. If omitted, an EmptyDir is used (that
+                  will not persist data across pod restart).
+                properties:
+                  emptyDir:
+                    description: Represents an empty directory for a pod. Empty directory
+                      volumes support ownership management and SELinux relabeling.
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  volumeClaimTemplate:
+                    description: VolumeClaimTemplate defines the template to store
+                      WildFlyServer standalone data directory. The name of the template
+                      is derived from the WildFlyServer name.  The corresponding volume
+                      will be mounted in ReadWriteOnce access mode. This template
+                      should be used to specify specific Resources requirements in
+                      the template spec.
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      metadata:
+                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      spec:
+                        description: 'Spec defines the desired characteristics of
+                          a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        properties:
+                          accessModes:
+                            description: 'AccessModes contains the desired access
+                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            description: 'This field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                              - Beta) * An existing PVC (PersistentVolumeClaim) *
+                              An existing custom resource/object that implements data
+                              population (Alpha) In order to use VolumeSnapshot object
+                              types, the appropriate feature gate must be enabled
+                              (VolumeSnapshotDataSource or AnyVolumeDataSource) If
+                              the provisioner or an external controller can support
+                              the specified data source, it will create a new volume
+                              based on the contents of the specified data source.
+                              If the specified data source is not supported, the volume
+                              will not be created and the failure will be reported
+                              as an event. In the future, we plan to support more
+                              data source types and the behavior of the provisioner
+                              may change.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            description: 'Resources represents the minimum resources
+                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          selector:
+                            description: A label query over volumes to consider for
+                              binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          storageClassName:
+                            description: 'Name of the StorageClass required by the
+                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            type: string
+                          volumeMode:
+                            description: volumeMode defines what type of volume is
+                              required by the claim. Value of Filesystem is implied
+                              when not included in claim spec.
+                            type: string
+                          volumeName:
+                            description: VolumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                      status:
+                        description: 'Status represents the current information/status
+                          of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        properties:
+                          accessModes:
+                            description: 'AccessModes contains the actual access modes
+                              the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
+                              type: string
+                            type: array
+                          capacity:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: Represents the actual resources of the underlying
+                              volume.
+                            type: object
+                          conditions:
+                            description: Current Condition of persistent volume claim.
+                              If underlying persistent volume is being resized then
+                              the Condition will be set to 'ResizeStarted'.
+                            items:
+                              description: PersistentVolumeClaimCondition contails
+                                details about state of pvc
+                              properties:
+                                lastProbeTime:
+                                  description: Last time we probed the condition.
+                                  format: date-time
+                                  type: string
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned
+                                    from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Human-readable message indicating details
+                                    about last transition.
+                                  type: string
+                                reason:
+                                  description: Unique, this should be a short, machine
+                                    understandable string that gives the reason for
+                                    condition's last transition. If it reports "ResizeStarted"
+                                    that means the underlying persistent volume is
+                                    being resized.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: PersistentVolumeClaimConditionType
+                                    is a valid value of PersistentVolumeClaimCondition.Type
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          phase:
+                            description: Phase represents the current phase of PersistentVolumeClaim.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+            required:
+            - applicationImage
+            - replicas
+            type: object
+          status:
+            description: WildFlyServerStatus defines the observed state of WildFlyServer
+            properties:
+              hosts:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              pods:
+                items:
+                  description: PodStatus defines the observed state of pods running
+                    the WildFlyServer application
+                  properties:
+                    name:
+                      type: string
+                    podIP:
+                      type: string
+                    state:
+                      description: Represent the state of the Pod, it is used especially
+                        during scale down.
+                      enum:
+                      - ACTIVE
+                      - SCALING_DOWN_RECOVERY_INVESTIGATION
+                      - SCALING_DOWN_RECOVERY_DIRTY
+                      - SCALING_DOWN_CLEAN
+                      type: string
+                  required:
+                  - name
+                  - podIP
+                  - state
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              replicas:
+                description: Replicas is the actual number of replicas for the application
+                format: int32
+                type: integer
+              scalingdownPods:
+                description: "Represents the number of pods which are in scaledown
+                  process what particular pod is scaling down can be verified by PodStatus
+                  \n Read-only."
+                format: int32
+                type: integer
+            required:
+            - replicas
+            - scalingdownPods
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/upstream-community-operators/wildfly/0.5.2/metadata/annotations.yaml
+++ b/upstream-community-operators/wildfly/0.5.2/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: wildfly


### PR DESCRIPTION
This version uses the apiextensions.k8s.io/v1 CRD API instead of the
deprecated v1beta1

It replaces wildfly-operator 0.5.0

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

Thanks submitting your Operator. Please check below list before you create your Pull Request.


### Updates to existing Operators

* [x] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md)?
* [x] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#channels) defined in the `package.yaml` or `annotations.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?
